### PR TITLE
The docs learn to count to seven, and the status note catches up with the release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ dates it, ranks it, and shows its work.
 Seven tools — `remember`, `recall`, `context`, `forget`, `inspect`,
 `consolidate`, `reflect` — and two rituals that ask for them.
 
-> Status: Phase 2 complete, and `consolidate` and `reflect` (Phase 3) have
-> landed. The loop, the session-start block, removal, startup pruning, the
-> shared daemon, the rituals, candidate surfacing and cited insights all work
-> end to end from Claude Code. The entity graph and the memory-quality eval
-> are what is left of Phase 3.
+> Status: v0.1.1, backlog empty — Phases 0–4 all landed. The loop, the
+> session-start block, removal, startup pruning, the shared daemon, the
+> rituals, candidate surfacing, cited insights, `ws://` sharing and the
+> offline quality eval all work end to end from Claude Code. The entity
+> graph stayed unbuilt on purpose: `recall` takes the multi-hop itself,
+> seeded from its top hits' entities (#27).
 
 ## Install
 
@@ -119,15 +120,15 @@ claude mcp add agmem --scope project -e AGMEM_SPACE=myproject -- agmem
 This repo checks in no `.mcp.json` of its own: the global registration
 covers it, and the space derives to `agmem` from the folder.
 
-**Cursor** — `.cursor/mcp.json` for one project, `~/.cursor/mcp.json` for all of
-them. Identical shape:
+**Cursor** — `~/.cursor/mcp.json` covers every project, and wants no env:
+the space derives per project there exactly as above.
 
 ```json
-{ "mcpServers": { "agmem": {
-    "command": "agmem",
-    "env": { "AGMEM_SPACE": "myproject" }
-} } }
+{ "mcpServers": { "agmem": { "command": "agmem" } } }
 ```
+
+A project that needs a different name pins `AGMEM_SPACE` in its own
+`.cursor/mcp.json` — identical shape plus the `env` block.
 
 **Claude Desktop** — `claude_desktop_config.json`, reachable from Settings →
 Developer → Edit Config, at
@@ -180,10 +181,7 @@ Point every agmem at a SurrealDB server rather than an embedded file:
 ```json
 { "mcpServers": { "agmem": {
     "command": "agmem",
-    "env": {
-      "AGMEM_SPACE": "myproject",
-      "AGMEM_DB": "ws://memory.internal:8000"
-    }
+    "env": { "AGMEM_DB": "ws://memory.internal:8000" }
 } } }
 ```
 
@@ -550,7 +548,7 @@ rebuild:
 
 The override is the whole description, not an addition, so what the agent reads
 is exactly what you wrote. A variable naming something that is not one of the
-five tools stops the server with a message rather than being ignored — a typo
+seven tools stops the server with a message rather than being ignored — a typo
 here is invisible otherwise. `agmem --doctor` and the startup log both report
 which tools a run is rewording, and each project keeps its own wording even
 when several share one daemon.

--- a/crates/agmem-server/src/config.rs
+++ b/crates/agmem-server/src/config.rs
@@ -174,7 +174,7 @@ impl ToolDescriptions {
             let tool = suffix.to_ascii_lowercase();
             if !crate::tools::NAMES.contains(&tool.as_str()) {
                 bail!(
-                    "{key} names no agmem tool. The five are: {}.",
+                    "{key} names no agmem tool. The seven are: {}.",
                     crate::tools::NAMES.join(", ")
                 );
             }
@@ -549,7 +549,7 @@ mod tests {
             ("AGMEM_SPACE", "unrelated"),
             ("PATH", "/usr/bin"),
         ])
-        .expect("all five names are known");
+        .expect("every name is a known tool");
 
         assert_eq!(overrides.get("recall"), Some("Search what you were told."));
         assert_eq!(overrides.get("remember"), Some("Write it down."));

--- a/crates/agmem-server/src/doctor.rs
+++ b/crates/agmem-server/src/doctor.rs
@@ -28,7 +28,7 @@ pub async fn run(cfg: &Config) -> anyhow::Result<()> {
 
     // Not a check — nothing here can fail, `Config` refused an unknown tool
     // long before this. It is on the report because an override is invisible
-    // from the outside: the surface still lists five tools, and the only way
+    // from the outside: the surface still lists seven tools, and the only way
     // to see which words an agent is being handed is to ask.
     if cfg.tool_desc.is_empty() {
         eprintln!("  ok    tool descriptions    agmem's own wording");

--- a/docs/tool-descriptions.md
+++ b/docs/tool-descriptions.md
@@ -413,7 +413,7 @@ an agent can check itself against.
   started the daemon would have chosen the wording for all of them.
 
 `agmem --doctor` prints which tools a run is rewording — an override is
-invisible from the outside otherwise, since the surface still lists five tools.
+invisible from the outside otherwise, since the surface still lists seven tools.
 
 ## Re-running this
 


### PR DESCRIPTION
A consistency pass over the README found five-tool fossils from before `consolidate` and `reflect` landed, plus two sections the last week outran:

- **"Five tools" → seven**, everywhere it survived: the server's unknown-override refusal (`config.rs` — it said "The five are:" then printed seven names), the README's rewording section, a `doctor.rs` comment, `docs/tool-descriptions.md`, and a test expect message.
- **Status blockquote** — said Phase 3 was half done; now says what's true: backlog empty, Phases 0–4 landed, v0.1.1 released, the entity graph deliberately traded for `recall`'s hop arm (#27).
- **Cursor global example** — pinned `AGMEM_SPACE=myproject` in `~/.cursor/mcp.json`, which under derivation (#44) would fold every project on the machine into one space. Now env-free, with the pin shown as the per-project exception.
- **ws:// example** — dropped the now-optional `AGMEM_SPACE` pin so the mode's example matches the derivation story.

No behavior changes; the only compiled edits are two string literals and a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011xwwpzAf888q3AMphCCs6m