### PR TITLE
v0.1.2 carries the shell-answering context block to the tap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "blake3",
  "jiff",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-embed"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "fastembed",
  "model2vec-rs",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "agmem-core",
  "agmem-embed",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-store"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "agmem-core",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ dates it, ranks it, and shows its work.
 Seven tools — `remember`, `recall`, `context`, `forget`, `inspect`,
 `consolidate`, `reflect` — and two rituals that ask for them.
 
-> Status: v0.1.1, backlog empty — Phases 0–4 all landed. The loop, the
+> Status: v0.1.2, backlog empty — Phases 0–4 all landed. The loop, the
 > session-start block, removal, startup pruning, the shared daemon, the
 > rituals, candidate surfacing, cited insights, `ws://` sharing and the
 > offline quality eval all work end to end from Claude Code. The entity


### PR DESCRIPTION
Version bump to 0.1.2 for release: ships the shell-facing `agmem context` one-shot surface and pushing hooks (#47) plus the doc catch-up (#45). Tag `v0.1.2` follows once this merges; cargo-dist takes it from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JCZPnR9yyniDzhprg9pMu