### PR TITLE
Episode chunks learn when they happened, and as_of stops reading the future

### DIFF
--- a/crates/agmem-server/src/tools/recall.rs
+++ b/crates/agmem-server/src/tools/recall.rs
@@ -60,7 +60,8 @@ pub struct RecallParams {
 
     /// What was believed at this instant, RFC3339 — corrections are dated, so
     /// this returns the claim that was live then rather than the one that
-    /// replaced it.
+    /// replaced it. Verbatim text is dated too: an episode recorded after
+    /// the instant stays out of the answer.
     #[serde(default)]
     pub as_of: Option<String>,
 

--- a/crates/agmem-server/tests/eval/metrics.rs
+++ b/crates/agmem-server/tests/eval/metrics.rs
@@ -143,14 +143,20 @@ pub async fn timeline(scenario: &Scenario, embedder: Arc<dyn Embedder>) -> Ratio
         }
         let answer = seeded.agmem.recall(arguments).await;
 
-        // `expect_top` is judged on the first *claim*: an episode slice
-        // outranking it is a ranking fact, and ranking has its own column.
-        // Whether the claim layer answers correctly over time is this one's.
-        let top = hits(&answer)
-            .iter()
-            .find(|hit| hit["kind"].as_str() != Some("episode"))
-            .cloned()
-            .unwrap_or(Value::Null);
+        // For a live check, `expect_top` is judged on the first *claim*: an
+        // episode slice outranking it is a ranking fact, and ranking has its
+        // own column. An as-of check judges the raw top instead — chunks are
+        // dated since schema v4, and a chunk surfacing for an instant before
+        // its episode happened is exactly the failure this metric watches.
+        let top = if check.as_of.is_some() {
+            hits(&answer).first().cloned().unwrap_or(Value::Null)
+        } else {
+            hits(&answer)
+                .iter()
+                .find(|hit| hit["kind"].as_str() != Some("episode"))
+                .cloned()
+                .unwrap_or(Value::Null)
+        };
         let mut ok = top["id"].as_str() == Some(seeded.id(check.expect_top.as_str()));
         if let Some(successor) = &check.superseded_by {
             ok = ok

--- a/crates/agmem-server/tests/protocol.rs
+++ b/crates/agmem-server/tests/protocol.rs
@@ -1080,6 +1080,42 @@ async fn as_of_returns_the_claim_that_was_live_then() {
 }
 
 #[tokio::test]
+async fn as_of_reads_only_episodes_that_had_already_happened() {
+    // Episodes have no supersession, so before schema v4 they sat outside
+    // as-of entirely: a chunk stored today came back — ranked first — for an
+    // instant years before its episode occurred.
+    let agmem = Harness::start(Arc::new(NoopEmbedder)).await;
+    agmem
+        .remember(json!({
+            "memories": [],
+            "episode": {
+                "content": "the deploy ran from a laptop",
+                "occurred_at": "2026-01-01T00:00:00Z"
+            }
+        }))
+        .await;
+    agmem
+        .remember(json!({
+            "memories": [],
+            "episode": {
+                "content": "the deploy runs from CI now",
+                "occurred_at": "2026-06-01T00:00:00Z"
+            }
+        }))
+        .await;
+
+    let then = agmem
+        .recall(json!({ "query": "deploy", "as_of": "2026-03-01T00:00:00Z" }))
+        .await;
+    assert_eq!(
+        hit_contents(&then),
+        ["the deploy ran from a laptop"],
+        "text recorded after the instant was not known then: {then}"
+    );
+    agmem.shutdown().await;
+}
+
+#[tokio::test]
 async fn a_filters_only_recall_ranks_on_decay_alone() {
     let agmem = Harness::start(Arc::new(KeywordEmbedder)).await;
     agmem

--- a/crates/agmem-server/tests/snapshots/protocol__list_tools.snap
+++ b/crates/agmem-server/tests/snapshots/protocol__list_tools.snap
@@ -1097,7 +1097,7 @@ expression: "&tools.tools"
       "properties": {
         "as_of": {
           "default": null,
-          "description": "What was believed at this instant, RFC3339 — corrections are dated, so\nthis returns the claim that was live then rather than the one that\nreplaced it.",
+          "description": "What was believed at this instant, RFC3339 — corrections are dated, so\nthis returns the claim that was live then rather than the one that\nreplaced it. Verbatim text is dated too: an episode recorded after\nthe instant stays out of the answer.",
           "type": [
             "string",
             "null"

--- a/crates/agmem-store/src/migrate.rs
+++ b/crates/agmem-store/src/migrate.rs
@@ -21,6 +21,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("migrations/v1_schema.surql"),
     include_str!("migrations/v2_derived_from.surql"),
     include_str!("migrations/v3_supersedes_list.surql"),
+    include_str!("migrations/v4_chunk_occurred_at.surql"),
 ];
 
 /// The schema version this binary produces.

--- a/crates/agmem-store/src/migrations/v4_chunk_occurred_at.surql
+++ b/crates/agmem-store/src/migrations/v4_chunk_occurred_at.surql
@@ -1,0 +1,20 @@
+-- Schema v4 — episode chunks learn when they happened.
+--
+-- `as_of` asks what was known at an instant. The memory arms answer through
+-- `valid_from`/`invalid_at`, but chunk rows carried no date at all, so a
+-- chunk stored today came back — ranked first — for an `as_of` years before
+-- its episode occurred. The episode row has always known its `occurred_at`;
+-- this copies it onto the retrieval unit, the same denormalisation `space`
+-- already rides: a chunk is queried without its episode, so what the query
+-- filters on has to sit on the chunk. The copy cannot drift — an episode is
+-- append-only, never updated, and a content-hash duplicate writes no new
+-- chunks.
+--
+-- `option<datetime>`, not required-with-a-default: `repo::reindex` UPDATEs
+-- every chunk row to re-embed it, and an UPDATE re-coerces every schemafull
+-- field on the row, mentioned or not (v3's lesson) — a required field a row
+-- lacks would fail that write. The UPDATE below is the backfill; a row it
+-- somehow misses reads NONE, and `NONE <= $as_of` is falsy, so it drops out
+-- of as-of results rather than lying about its date.
+DEFINE FIELD IF NOT EXISTS occurred_at ON episode_chunk TYPE option<datetime>;
+UPDATE episode_chunk SET occurred_at = episode.occurred_at WHERE occurred_at IS NONE;

--- a/crates/agmem-store/src/queries/read.rs
+++ b/crates/agmem-store/src/queries/read.rs
@@ -193,14 +193,17 @@ pub(crate) fn search(search: &Search, terms: &[String]) -> Script {
         arms.push("$vs");
     }
     // Episodes are verbatim and append-only: they are never superseded, so
-    // liveness and the memory-side filters have nothing to say about them.
+    // the memory-side filters have nothing to say about them. Liveness has
+    // exactly one thing to say: text that had not yet been recorded was not
+    // known at `$as_of`, read off the chunk's own `occurred_at` (schema v4).
+    let chunks = chunk_where(search.liveness);
     if search.episodes && !terms.is_empty() {
         // The references restart at 1: they are scoped to the statement, and
         // this is a different statement over a different table.
         let (matches, scores) = fulltext("text", terms);
         builder.push(format!(
             "LET $ftc = (SELECT id, {scores} AS s FROM episode_chunk
-                 WHERE space IN $spaces AND ({matches})
+                 WHERE {chunks} AND ({matches})
                  ORDER BY s DESC LIMIT {pool})"
         ));
         arms.push("$ftc");
@@ -209,9 +212,9 @@ pub(crate) fn search(search: &Search, terms: &[String]) -> Script {
         let inner = pool * OVER_FETCH;
         builder.push(format!(
             "LET $vsc = (SELECT id, d FROM
-                 (SELECT id, space, vector::distance::knn() AS d FROM episode_chunk
+                 (SELECT id, space, occurred_at, vector::distance::knn() AS d FROM episode_chunk
                   WHERE embedding <|{inner},{EF_SEARCH}|> $vector)
-                 WHERE space IN $spaces ORDER BY d LIMIT {pool})"
+                 WHERE {chunks} ORDER BY d LIMIT {pool})"
         ));
         arms.push("$vsc");
     }
@@ -485,6 +488,20 @@ fn memory_where(filters: &Filters, liveness: Liveness) -> String {
     clauses.join(" AND ")
 }
 
+/// The `WHERE` clauses every `episode_chunk` read shares.
+///
+/// Chunks carry none of the memory-side filters, so this is spaces plus at
+/// most one clause: a chunk whose episode had not yet occurred was not known
+/// at `$as_of`. A pre-v4 row the backfill missed reads `occurred_at = NONE`,
+/// which fails the comparison and drops out — conservative, never wrong
+/// about the date. `Any` matches everything, as it does for memories.
+fn chunk_where(liveness: Liveness) -> String {
+    match liveness {
+        Liveness::AsOf(_) => "space IN $spaces AND occurred_at <= $as_of".to_owned(),
+        Liveness::Live | Liveness::Any => "space IN $spaces".to_owned(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use agmem_core::Kind;
@@ -584,6 +601,34 @@ mod tests {
             assert!(
                 !clause.contains(" AND "),
                 "a predicate rides the gate's scan: {clause}"
+            );
+        }
+    }
+
+    #[test]
+    fn as_of_dates_the_chunk_arms_and_stays_off_the_scan() {
+        let mut request = Search::new(vec!["test".parse().expect("slug")]);
+        request.vector = Some(vec![0.0; 384]);
+        request.liveness = Liveness::AsOf("2026-03-01T00:00:00Z".parse().expect("timestamp"));
+
+        let script = search(&request, &["red".to_owned()]).text;
+        let chunk_arms: Vec<&str> = script
+            .split("LET ")
+            .filter(|arm| arm.starts_with("$ftc") || arm.starts_with("$vsc"))
+            .collect();
+        assert_eq!(chunk_arms.len(), 2, "{script}");
+        for arm in chunk_arms {
+            assert!(
+                arm.contains("occurred_at <= $as_of"),
+                "an as-of read must date the verbatim side too: {arm}"
+            );
+        }
+        // And the clause filters the scan's result, never the scan itself
+        // (issue #40).
+        for clause in knn_clauses(&script) {
+            assert!(
+                !clause.contains(" AND "),
+                "a predicate rides the scan: {clause}"
             );
         }
     }

--- a/crates/agmem-store/src/queries/write.rs
+++ b/crates/agmem-store/src/queries/write.rs
@@ -44,7 +44,8 @@ pub(crate) fn insert_batch(memories: &[MemoryShape<'_>], with_episode: bool) -> 
                  FOR $chunk IN $ep_chunks {
                      CREATE episode_chunk:ulid() CONTENT {
                          episode: $ep_new.id, space: $space, text: $chunk.text,
-                         position: $chunk.position, embedding: $chunk.embedding
+                         position: $chunk.position, embedding: $chunk.embedding,
+                         occurred_at: $ep_new.occurred_at
                      }
                  };
                  { id: $ep_new.id, created: true }

--- a/crates/agmem-store/tests/migrate.rs
+++ b/crates/agmem-store/tests/migrate.rs
@@ -142,6 +142,48 @@ async fn a_correction_written_before_v3_reads_as_a_one_element_list() {
     assert!(chain[0].supersedes.is_empty(), "the oldest closed nothing");
 }
 
+/// Chunks written before v4 carry no `occurred_at` — the column arrives with
+/// that migration — and the as-of clause reads the date off the chunk, so the
+/// upgrade has to copy each episode's date down. A chunk left at NONE would
+/// silently sit out every as-of recall.
+#[tokio::test]
+async fn a_chunk_written_before_v4_takes_its_episodes_date() {
+    let conn = db::connect("mem://").await.expect("connect mem://");
+    conn.query(include_str!("../src/migrations/v1_schema.surql"))
+        .await
+        .expect("v1")
+        .check()
+        .expect("v1 statements");
+    conn.query(
+        "CREATE episode:01M145SMNET1XRYA713EWAQTE1 SET space = 'test',
+             content = 'an old conversation', content_hash = 'v1-ep',
+             occurred_at = d'2025-05-01T00:00:00Z';
+         CREATE episode_chunk:ulid() SET
+             episode = episode:01M145SMNET1XRYA713EWAQTE1, space = 'test',
+             text = 'an old conversation', position = 0",
+    )
+    .await
+    .expect("seed")
+    .check()
+    .expect("seed statements");
+
+    assert_eq!(
+        migrate::ensure(&conn).await.expect("upgrade"),
+        migrate::SCHEMA_VERSION
+    );
+
+    let mut resp = conn
+        .query("SELECT VALUE <string> occurred_at FROM episode_chunk")
+        .await
+        .expect("read back");
+    let dates: Vec<String> = resp.take(0).expect("dates");
+    assert_eq!(
+        dates,
+        ["2025-05-01T00:00:00Z"],
+        "the backfill copies the episode's date onto its chunk"
+    );
+}
+
 /// A fresh store adopts its first backend's width (issue #29): recording a
 /// 256-wide embedder redefines the HNSW indexes the v1 schema bakes at 384,
 /// so the first write lands instead of failing with "Incorrect vector

--- a/crates/agmem-store/tests/reads.rs
+++ b/crates/agmem-store/tests/reads.rs
@@ -225,6 +225,55 @@ async fn episode_chunks_compete_only_when_asked_for() {
 }
 
 #[tokio::test]
+async fn an_as_of_recall_excludes_chunks_that_had_not_yet_happened() {
+    let db = seeded().await;
+    // A second episode from long before the seeded one (which defaults to
+    // now), sharing the term "coffee" with one of its chunks.
+    repo::insert_batch(
+        &db,
+        Batch {
+            space: space(),
+            episode: Some(NewEpisode {
+                content: "an older conversation".to_owned(),
+                occurred_at: Some(stamp("2025-05-01T00:00:00Z")),
+                session: None,
+                chunks: vec![NewChunk {
+                    text: "coffee fuelled the all-nighter".to_owned(),
+                    embedding: Some(axis(2)),
+                }],
+            }),
+            memories: vec![],
+        },
+    )
+    .await
+    .expect("older episode");
+
+    let mut search = Search::new(vec![space()]);
+    search.text = Some("coffee".to_owned());
+    search.vector = None;
+
+    let now = repo::search_hybrid(&db, &search).await.expect("live");
+    search.liveness = Liveness::AsOf(stamp("2026-03-01T00:00:00Z"));
+    let then = repo::search_hybrid(&db, &search).await.expect("as of");
+
+    let mut all = contents(&now);
+    all.sort_unstable();
+    assert_eq!(
+        all,
+        [
+            "coffee fuelled the all-nighter",
+            "then somebody made coffee"
+        ],
+        "a live recall reads both episodes"
+    );
+    assert_eq!(
+        contents(&then),
+        ["coffee fuelled the all-nighter"],
+        "text recorded after the instant was not known then"
+    );
+}
+
+#[tokio::test]
 async fn a_closed_memory_is_invisible_until_the_window_asks_for_it() {
     let db = seeded().await;
     let old = live_id(&db, "the user prefers Rust").await;

--- a/docs/design.md
+++ b/docs/design.md
@@ -170,6 +170,9 @@ DEFINE FIELD space     ON episode_chunk TYPE string;
 DEFINE FIELD text      ON episode_chunk TYPE string;
 DEFINE FIELD position  ON episode_chunk TYPE int;
 DEFINE FIELD embedding ON episode_chunk TYPE option<array<float>>;
+-- the episode's occurred_at, denormalised like space (v4): as_of filters
+-- chunks without dereferencing a link per candidate
+DEFINE FIELD occurred_at ON episode_chunk TYPE option<datetime>;
 DEFINE INDEX ec_ft  ON episode_chunk COLUMNS text FULLTEXT ANALYZER english BM25 HIGHLIGHTS;
 DEFINE INDEX ec_vec ON episode_chunk FIELDS embedding HNSW DIMENSION 384 DIST COSINE;
 
@@ -717,7 +720,8 @@ recall(q)
  4. rescore in Rust (core::scoring):
       final = 0.6·norm(rrf) + 0.25·retention(m) + 0.15·importance(decay_class)
       norm  = min–max over the pool: (rrf − min) / (max − min)
-      as_of? → filter valid_from ≤ T < invalid_at (walk chains for history)
+      as_of? → filter valid_from ≤ T < invalid_at (walk chains for history);
+              chunks filter on their denormalised occurred_at ≤ T (v4)
  5. take k — the last slot reserved for the best hop-voted row when the cut
     would otherwise drop every one (issue #43, hop::reserve_tail);
     fire-and-forget reinforcement UPDATE (strength+1, last_accessed)


### PR DESCRIPTION
An episode stored today came back — ranked first — for an `as_of` a year before it happened, because chunk rows carried no date while the memory arms answered through `valid_from`/`invalid_at`. Found by the #32 quality eval and sidestepped in its timeline metric.

- **Schema v4**: `occurred_at` lands on `episode_chunk` as `option<datetime>`, backfilled from each chunk's episode. Option rather than required-with-default so `repo::reindex`'s UPDATE (which re-coerces every schemafull field, v3's lesson) keeps working on old rows.
- **Write path**: new chunks copy `$ep_new.occurred_at` at create time; an episode is append-only and a content-hash duplicate writes no chunks, so the copy cannot drift.
- **Read path**: `chunk_where(liveness)` mirrors `memory_where` — under `AsOf` both chunk arms add `occurred_at <= $as_of`, filtered outside the KNN operator (#40); a unit test pins both facts. Excluding chunks from `as_of` entirely was rejected: `as_of` asks what was known at T, and text already recorded then *was* known.
- **Eval un-sidestepped**: timeline checks with `as_of` judge the raw top hit instead of skipping episodes. The recorded baseline passes unchanged — with chunks dated, the as-of checks genuinely return no future episodes, so only the sidestep was removed, not the scores.
- **Tests**: migrate (pre-v4 chunk takes its episode's date via the backfill), store reads (as-of recall excludes the not-yet-recorded chunk), protocol (same end-to-end through `recall`).
- A chunk the backfill misses reads `NONE`, and `NONE <= $as_of` is falsy — it drops out of as-of results rather than lying about its date.

The `list_tools` snapshot moves by one sentence: `as_of`'s parameter doc now says verbatim text is dated too. No desc-eval scenario exercises `as_of`, so there was nothing for the wording gate to measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018grPjAfgrLmi8Y27pNoKtc