### PR TITLE
Use stops buying time at five horizons

### DIFF
--- a/crates/agmem-core/src/model.rs
+++ b/crates/agmem-core/src/model.rs
@@ -470,7 +470,8 @@ pub struct MemoryRecord {
     pub embedding: Option<Vec<f32>>,
     /// How fast this one fades.
     pub decay_class: DecayClass,
-    /// Ebbinghaus stability: raised by every recall that returns this memory.
+    /// Ebbinghaus stability: raised by every recall that returns this memory,
+    /// up to `scoring::MAX_STABILITY`.
     pub strength: f64,
     /// When recall last returned this memory.
     pub last_accessed: Timestamp,

--- a/crates/agmem-core/src/scoring.rs
+++ b/crates/agmem-core/src/scoring.rs
@@ -21,6 +21,23 @@ pub const WEIGHT_IMPORTANCE: f64 = 0.15;
 /// instead of producing NaN.
 pub const MIN_STABILITY: f64 = 0.01;
 
+/// Ceiling on Ebbinghaus stability (issue #52).
+///
+/// Reinforcement raised `strength` without bound, and since the prune horizon
+/// scales linearly with it, a `fast` note recalled fifty times survived about
+/// three years — outliving the class it was filed under by orders of
+/// magnitude. The cap bounds what use can buy: five times the class's own
+/// horizon, which keeps a hot working note alive for months, not years.
+///
+/// One ceiling for every class, not one per class: the class already sets the
+/// timescale through its rate, and `strength` is the use-multiplier on top of
+/// it — a per-class cap would be a second copy of what `rate()` encodes. A
+/// hard cap rather than a saturating curve for the same reason the curve
+/// lives in one module: the clamp is one expression, and it is repeated
+/// verbatim where the engine evaluates it (`REINFORCE`, `PRUNE_EXPIRED`), so
+/// the three spellings cannot drift apart quietly.
+pub const MAX_STABILITY: f64 = 5.0;
+
 /// Retention below which a `fast` record is closed at startup (`docs/design.md`
 /// §2.3, §5.5).
 ///
@@ -61,8 +78,9 @@ impl DecayClass {
 /// How much of a memory survives, in `(0, 1]`, at `now`.
 ///
 /// `exp(-Δdays · rate / strength)`: reinforcement raises `strength`, which
-/// flattens the curve, so a frequently recalled memory becomes effectively
-/// permanent while an untouched one fades out of the ranking.
+/// flattens the curve, so a frequently recalled memory outlasts an untouched
+/// one — up to [`MAX_STABILITY`], past which more use buys nothing and the
+/// class's own timescale reasserts itself.
 ///
 /// ```
 /// use agmem_core::{DecayClass, scoring};
@@ -85,7 +103,7 @@ pub fn retention(
         return 1.0;
     }
     let days = days_between(last_accessed, now);
-    let stability = strength.max(MIN_STABILITY);
+    let stability = strength.clamp(MIN_STABILITY, MAX_STABILITY);
     (-days * rate / stability).exp()
 }
 
@@ -93,8 +111,8 @@ pub fn retention(
 /// before [`retention`] falls to `threshold`, in seconds.
 ///
 /// The inverse of [`retention`]: `days = −ln(threshold) · strength / rate`, so
-/// a particular row's horizon is this scaled by its own `strength` (floored at
-/// [`MIN_STABILITY`], exactly as `retention` floors it).
+/// a particular row's horizon is this scaled by its own `strength` (clamped to
+/// `[MIN_STABILITY, MAX_STABILITY]`, exactly as `retention` clamps it).
 ///
 /// `None` when there is no such time — a class that never decays never reaches
 /// a threshold below 1, and a threshold outside `(0, 1)` is not one the curve
@@ -325,9 +343,25 @@ mod tests {
     #[test]
     fn reinforcement_slows_decay() {
         let once = retention(DecayClass::Normal, 1.0, days_ago(60), now());
-        let often = retention(DecayClass::Normal, 6.0, days_ago(60), now());
+        let often = retention(DecayClass::Normal, MAX_STABILITY, days_ago(60), now());
         assert!(often > once, "{often} should beat {once}");
-        assert!(often > 0.8, "six recalls make 60 days cheap: {often}");
+        assert!(
+            often > 0.75,
+            "recalls at the cap make 60 days cheap: {often}"
+        );
+    }
+
+    #[test]
+    fn strength_saturates_at_the_cap() {
+        // Fifty recalls and five buy the same curve: past the cap, more use
+        // is worth nothing, and the class's own timescale decides (issue #52).
+        let capped = retention(DecayClass::Fast, MAX_STABILITY, days_ago(120), now());
+        let hot = retention(DecayClass::Fast, 51.0, days_ago(120), now());
+        assert_eq!(hot, capped, "strength above the cap changes nothing");
+        assert!(
+            hot < PRUNE_RETENTION,
+            "a fast note is prunable within months no matter how hot it ran: {hot}"
+        );
     }
 
     #[test]
@@ -338,8 +372,11 @@ mod tests {
 
     #[test]
     fn the_horizon_is_exactly_where_retention_reaches_the_threshold() {
+        // Strengths inside the clamp: the horizon–retention agreement only
+        // holds where the curve actually reads the value, and the prune
+        // selector applies the same clamp before scaling.
         for class in [DecayClass::Fast, DecayClass::Normal, DecayClass::Slow] {
-            for strength in [0.5, 1.0, 7.0] {
+            for strength in [0.5, 1.0, MAX_STABILITY] {
                 let horizon = decay_horizon_secs(class, PRUNE_RETENTION).expect("a decaying class");
                 let idle = SignedDuration::from_secs((horizon * strength) as i64);
                 let at = retention(class, strength, now() - idle, now());

--- a/crates/agmem-server/src/tools/consolidate.rs
+++ b/crates/agmem-server/src/tools/consolidate.rs
@@ -27,7 +27,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-use agmem_core::{MemoryRecord, SpaceName, dedup};
+use agmem_core::{MemoryRecord, SpaceName, dedup, scoring};
 use agmem_store::repo::{self, Embedded};
 use jiff::Timestamp;
 use rmcp::ErrorData;
@@ -364,9 +364,10 @@ fn shared_entities(left: &MemoryRecord, right: &MemoryRecord) -> Vec<String> {
 /// How far past its class one reinforced note has been carried.
 ///
 /// `expires_in_days` is the reprieve strength bought it: the sweep's own
-/// comparison is `last_accessed + horizon · strength < now`, so this is what
-/// is left of that, and a large number means the automatic prune will not
-/// reach this row for a long time yet.
+/// comparison is `last_accessed + horizon · clamp(strength) < now`, so this
+/// is what is left of that — strength clamped exactly as the sweep clamps it
+/// (issue #52), or a row reinforced past the cap would be reported with a
+/// reprieve the prune no longer grants.
 fn overdue(claim: MemoryRecord) -> StaleContext {
     let idle = Timestamp::now()
         .duration_since(claim.last_accessed)
@@ -376,9 +377,12 @@ fn overdue(claim: MemoryRecord) -> StaleContext {
     // zero is a safe reading if that ever stops being true, and reports the
     // row as due rather than inventing a reprieve for it.
     let horizon = repo::prune_horizon_secs().unwrap_or(0.0);
+    let stability = claim
+        .strength
+        .clamp(scoring::MIN_STABILITY, scoring::MAX_STABILITY);
     StaleContext {
         idle_days: idle / SECONDS_PER_DAY,
-        expires_in_days: (horizon * claim.strength - idle).max(0.0) / SECONDS_PER_DAY,
+        expires_in_days: (horizon * stability - idle).max(0.0) / SECONDS_PER_DAY,
         claim: claim.into(),
     }
 }

--- a/crates/agmem-server/tests/protocol.rs
+++ b/crates/agmem-server/tests/protocol.rs
@@ -2028,11 +2028,12 @@ async fn consolidate_reports_short_lived_notes_that_recall_kept_alive() {
         }))
         .await;
     let created = ids(&written["created"]);
-    // Recalled thirty times, so `strength` bought it roughly 620 days against
-    // a class whose unreinforced horizon is twenty.
-    age(&agmem.db, created[0], 200, 31.0, 30).await;
-    // Equally idle and never used: the prune closes this one on its own.
-    age(&agmem.db, created[1], 200, 1.0, 1).await;
+    // Recalled thirty times. Uncapped, that strength bought roughly 620 days
+    // against a class whose unreinforced horizon is twenty; the cap holds the
+    // reprieve to five horizons (#52), and 60 days idle sits inside it.
+    age(&agmem.db, created[0], 60, 31.0, 30).await;
+    // Equally overdue and never used: the prune closes this one on its own.
+    age(&agmem.db, created[1], 60, 1.0, 1).await;
 
     let found = agmem.consolidate(json!({})).await;
     let stale = found["stale_contexts"].as_array().expect("an array");
@@ -2046,10 +2047,12 @@ async fn consolidate_reports_short_lived_notes_that_recall_kept_alive() {
         "{found:#}"
     );
     assert_eq!(stale[0]["claim"]["decay_class"], "fast");
-    assert!(stale[0]["idle_days"].as_f64().expect("a number") > 199.0);
+    assert!(stale[0]["idle_days"].as_f64().expect("a number") > 59.0);
+    let reprieve = stale[0]["expires_in_days"].as_f64().expect("a number");
     assert!(
-        stale[0]["expires_in_days"].as_f64().expect("a number") > 300.0,
-        "the finding is that the sweep will not reach it for a year: {found:#}"
+        (30.0..45.0).contains(&reprieve),
+        "the reprieve reads off the capped strength — five horizons minus the \
+         idle time, not the 559 days the raw strength would claim: {found:#}"
     );
 
     let note = found["note"].as_str().expect("a note");

--- a/crates/agmem-store/src/queries/read.rs
+++ b/crates/agmem-store/src/queries/read.rs
@@ -373,8 +373,14 @@ pub(crate) fn nearest_live(count: usize) -> Script {
 ///
 /// An id naming no row is a silent no-op `UPDATE`, which is what makes this
 /// safe to fire and forget; the returned ids are the ones that existed.
+///
+/// `$cap` is `core::scoring::MAX_STABILITY` (issue #52): past it another
+/// recall still updates `access_count` and `last_accessed`, but buys no more
+/// strength — without the ceiling, the prune horizon scaled linearly with use
+/// and a hot `fast` note became effectively permanent.
 pub(crate) const REINFORCE: &str = "UPDATE $ids
-     SET strength += 1.0, access_count += 1, last_accessed = time::now()
+     SET strength = math::min([strength + 1.0, $cap]),
+         access_count += 1, last_accessed = time::now()
      RETURN VALUE record::id(id)";
 
 /// Every registered space, alphabetically.
@@ -439,12 +445,12 @@ pub(crate) fn live_vectors(limit: usize) -> Script {
 /// This is [`crate::queries::write::PRUNE_EXPIRED`]'s selector with the
 /// `strength` factor taken *out*, which is the whole finding: the sweep scales
 /// each row's horizon by its own strength, so reinforcement buys a working
-/// note more time on every recall, and a `fast` note recalled often enough
-/// outlives the class it was filed under by years. Those rows are not a bug —
-/// the scaling is deliberate — but nothing ever revisits them, so they sit in
-/// the `fast` class holding something that turned out to be durable. The fix
-/// is a judgement call (`remember` it again at a slower class, or `forget`
-/// it), which is why this surfaces candidates instead of acting.
+/// note more time on every recall — months at the strength cap, where it was
+/// years before #52 bounded it. Those rows are not a bug — the scaling is
+/// deliberate — but nothing ever revisits them, so they sit in the `fast`
+/// class holding something that turned out to be durable. The fix is a
+/// judgement call (`remember` it again at a slower class, or `forget` it),
+/// which is why this surfaces candidates instead of acting.
 ///
 /// `$min_count` is what separates "reinforcement kept this alive" from "this
 /// is merely a fast note nobody has touched yet"; the latter is the prune's

--- a/crates/agmem-store/src/queries/write.rs
+++ b/crates/agmem-store/src/queries/write.rs
@@ -149,8 +149,11 @@ pub(crate) const FORGET_SOFT: &str = "UPDATE $memories
 ///
 /// The decay curve is not repeated here. `$horizon` is the idle time at which
 /// unit strength reaches the threshold (`core::scoring::decay_horizon_secs`)
-/// and a row's own horizon is that scaled by its `strength`, floored at
-/// `$floor` the way the Rust formula floors it.
+/// and a row's own horizon is that scaled by its `strength`, clamped between
+/// `$floor` and `$cap` the way the Rust formula clamps it. The cap is what
+/// lets the sweep reach a row reinforced past it before the ceiling existed
+/// (issue #52) — no migration rewrites stored strengths; the comparison just
+/// stops honouring them.
 ///
 /// The comparison is written forwards — `last_accessed + horizon < now` rather
 /// than `now − last_accessed > horizon` — because SurrealDB durations are
@@ -162,7 +165,8 @@ pub(crate) const PRUNE_EXPIRED: &str = "UPDATE memory
      SET invalid_at = time::now(), invalid_reason = 'expired'
      WHERE decay_class = $class AND invalid_at IS NONE
        AND last_accessed
-           + duration::from_secs(<int> math::round($horizon * math::max([strength, $floor])))
+           + duration::from_secs(<int> math::round(
+                 $horizon * math::min([math::max([strength, $floor]), $cap])))
            < time::now()
      RETURN VALUE record::id(id)";
 

--- a/crates/agmem-store/src/repo/read.rs
+++ b/crates/agmem-store/src/repo/read.rs
@@ -474,11 +474,11 @@ pub async fn live_vectors(
 ///
 /// The sweep scales each row's horizon by its own `strength`, so every recall
 /// buys a working note more time — deliberately, and it is the same
-/// reinforcement that flattens the decay curve at read time. The consequence
-/// is that a `fast` note recalled often enough stops being a note with a TTL,
-/// and nothing revisits the class it was filed under. This finds those rows so
-/// an agent can: re-`remember` the claim at a slower class if it turned out to
-/// be durable, or `forget` it if it did not.
+/// reinforcement that flattens the decay curve at read time. Capped at
+/// `scoring::MAX_STABILITY` (issue #52), that still leaves a reinforced note
+/// alive up to five horizons past its class with nothing revisiting it. This
+/// finds those rows so an agent can: re-`remember` the claim at a slower
+/// class if it turned out to be durable, or `forget` it if it did not.
 ///
 /// Selection is the prune's own, with the `strength` factor removed — see
 /// `queries::read::stale_contexts`. Most overdue first.
@@ -526,10 +526,12 @@ pub fn prune_horizon_secs() -> Option<f64> {
 /// Reinforce every memory a recall returned, in one statement.
 ///
 /// Raising `strength` flattens that memory's decay curve, which is the whole
-/// mechanism by which use keeps a memory alive (design §2.3). Ids that name
-/// nothing are skipped rather than refused — this runs after the hits are
-/// already on their way to the agent, so it must not be able to fail a
-/// recall. Returns how many rows were actually touched.
+/// mechanism by which use keeps a memory alive (design §2.3) — up to
+/// `scoring::MAX_STABILITY`, past which a recall refreshes `last_accessed`
+/// but buys no more (issue #52). Ids that name nothing are skipped rather
+/// than refused — this runs after the hits are already on their way to the
+/// agent, so it must not be able to fail a recall. Returns how many rows were
+/// actually touched.
 ///
 /// # Errors
 /// [`StoreError::Db`] for anything the engine rejects.
@@ -538,7 +540,12 @@ pub async fn reinforce(db: &Db, ids: &[MemoryId]) -> Result<usize, StoreError> {
         return Ok(0);
     }
     let refs: Vec<RecordId> = ids.iter().map(types::memory_ref).collect();
-    let mut resp = checked(db.query(queries::REINFORCE).bind(("ids", refs)).await?)?;
+    let mut resp = checked(
+        db.query(queries::REINFORCE)
+            .bind(("ids", refs))
+            .bind(("cap", scoring::MAX_STABILITY))
+            .await?,
+    )?;
     let touched: Vec<String> = resp.take(0)?;
     Ok(touched.len())
 }

--- a/crates/agmem-store/src/repo/write.rs
+++ b/crates/agmem-store/src/repo/write.rs
@@ -433,7 +433,9 @@ pub async fn forget(db: &Db, request: &Forget) -> Result<Forgotten, StoreError> 
 /// considered. That is the TTL class by definition, while the others' end of
 /// life is a correction or a `forget`, so an untouched working note stops
 /// answering `recall` after about twenty days — longer for every recall that
-/// reinforced it, since strength scales the horizon.
+/// reinforced it, since strength scales the horizon, but never past five
+/// horizons: the comparison clamps strength at `scoring::MAX_STABILITY`
+/// (issue #52), so even the hottest note expires within months.
 ///
 /// The close is soft, exactly as `forget`'s is: `invalid_reason = "expired"`,
 /// the chain intact, still readable through `inspect`. A second run changes
@@ -456,6 +458,7 @@ pub async fn prune_expired(db: &Db) -> Result<Vec<MemoryId>, StoreError> {
             .bind(("class", types::decay_class_str(PRUNE_CLASS)))
             .bind(("horizon", horizon))
             .bind(("floor", scoring::MIN_STABILITY))
+            .bind(("cap", scoring::MAX_STABILITY))
             .await?,
     )?;
     let closed: Vec<String> = resp.take(0)?;

--- a/crates/agmem-store/tests/reads.rs
+++ b/crates/agmem-store/tests/reads.rs
@@ -354,6 +354,32 @@ async fn recall_reinforces_what_it_returned() {
 }
 
 #[tokio::test]
+async fn reinforcement_saturates_at_the_strength_cap() {
+    let db = seeded().await;
+    let id = live_id(&db, "the user prefers Rust").await;
+
+    // Nine recalls. Uncapped, this row would sit at strength 10 with a decay
+    // curve to match; the ceiling is what keeps a hot memory on its class's
+    // own timescale (issue #52).
+    for _ in 0..9 {
+        repo::reinforce(&db, std::slice::from_ref(&id))
+            .await
+            .expect("reinforce");
+    }
+
+    let rows = repo::direct_lookup(&db, &Lookup::new(vec![space()]))
+        .await
+        .expect("lookup");
+    let row = rows.iter().find(|m| m.id == id).expect("seeded memory");
+    assert_eq!(
+        row.strength,
+        agmem_core::scoring::MAX_STABILITY,
+        "use past the cap buys no more stability"
+    );
+    assert_eq!(row.access_count, 9, "but every recall still counts");
+}
+
+#[tokio::test]
 async fn direct_lookup_filters_on_the_indexed_columns() {
     let db = seeded().await;
     let contents_of = async |filters: Filters| {
@@ -884,10 +910,11 @@ async fn stale_contexts_are_the_rows_reinforcement_carried_past_the_prune() {
         ids[3].clone(),
     );
 
-    // Recalled thirty times, so `strength` bought it roughly 620 days against
-    // a class whose unreinforced horizon is twenty — the sweep will not reach
-    // it, which is exactly why it needs a decision instead.
-    age(&db, &carried, 200, 31.0, 30).await;
+    // Recalled thirty times. Uncapped, that strength bought roughly 620 days
+    // against a class whose unreinforced horizon is twenty; the cap holds it
+    // to five horizons (#52), and inside that window the sweep still will not
+    // reach it — which is exactly why it needs a decision instead.
+    age(&db, &carried, 60, 31.0, 30).await;
     // Equally idle, but nothing ever used it — the prune's own backlog, and
     // it will close on the next start rather than needing a decision.
     age(&db, &untouched, 200, 1.0, 1).await;

--- a/crates/agmem-store/tests/writes.rs
+++ b/crates/agmem-store/tests/writes.rs
@@ -764,6 +764,30 @@ async fn the_startup_prune_expires_stale_working_context_and_nothing_else() {
 }
 
 #[tokio::test]
+async fn the_prune_reaches_a_row_reinforced_past_the_cap() {
+    let db = store().await;
+    let mut memory = NewMemory::new(Kind::Fact, "the demo login is on the whiteboard");
+    memory.decay_class = Some(DecayClass::Fast);
+    let hot = repo::insert_batch(&db, batch(vec![memory]))
+        .await
+        .expect("write")
+        .memories
+        .remove(0)
+        .into_id();
+
+    // Fifty recalls' worth of strength, idle past the capped horizon (five
+    // times ~20 days) but far inside the uncapped one (~3 years): the row
+    // issue #52 was filed about, written before the ceiling existed.
+    age(&db, &hot, 150, 50.0).await;
+
+    assert_eq!(
+        repo::prune_expired(&db).await.expect("prune"),
+        vec![hot],
+        "the sweep clamps strength in its comparison, so no migration is needed"
+    );
+}
+
+#[tokio::test]
 async fn a_second_prune_moves_nothing_the_first_one_left() {
     let db = store().await;
     let working = |content: &str| {

--- a/docs/design.md
+++ b/docs/design.md
@@ -238,18 +238,21 @@ Notes:
 Decay is **computed at read time** — no background sweeper exists:
 
 ```
-retention(m) = exp(-Δdays(now, m.last_accessed) * rate(m.decay_class) / m.strength)
+retention(m) = exp(-Δdays(now, m.last_accessed) * rate(m.decay_class) / clamp(m.strength, 0.01, 5))
 
 rate: pinned = 0        slow = 0.005      normal = 0.02     fast = 0.15
 ```
 
 Reinforcement: when `recall` returns a memory, the server bumps
-`strength += 1`, `access_count += 1`, `last_accessed = now` (batched,
-fire-and-forget) — MemoryBank's Ebbinghaus model; frequently used memories
-become effectively permanent, untouched ones fade in ranking. `fast` records
-(working context) additionally get lazy TTL pruning: at startup, `fast`
-memories with retention below ~0.05 are closed with
-`invalid_reason = "expired"` (still soft — history remains).
+`strength += 1` (capped at `MAX_STABILITY = 5`, issue #52), `access_count += 1`,
+`last_accessed = now` (batched, fire-and-forget) — MemoryBank's Ebbinghaus
+model; frequently used memories outlast untouched ones, which fade in ranking.
+The cap is uniform across classes — the class sets the timescale through its
+rate, strength is the use-multiplier on top — and it bounds what use can buy
+at five times the class's own horizon: without it a `fast` note recalled fifty
+times survived ~3 years. `fast` records (working context) additionally get
+lazy TTL pruning: at startup, `fast` memories with retention below ~0.05 are
+closed with `invalid_reason = "expired"` (still soft — history remains).
 
 ---
 
@@ -876,8 +879,11 @@ The prune is one `UPDATE`, and the decay curve is not repeated in it. The
 selector is the **inverse** of the retention formula, computed once in
 `core::scoring::decay_horizon_secs`: the idle time at which unit strength
 falls to 0.05 — about twenty days for `fast` — which the engine then scales by
-each row's own `strength`. So the comparison is
-`last_accessed + horizon·strength < now`, written forwards on purpose:
+each row's own `strength`, clamped to `[MIN_STABILITY, MAX_STABILITY]` exactly
+as retention clamps it (issue #52) — which is also how the sweep reaches a row
+reinforced past the cap before the ceiling existed, with no migration. So the
+comparison is `last_accessed + horizon·clamp(strength) < now`, written
+forwards on purpose:
 SurrealDB durations are unsigned, and `now − last_accessed` on a row with a
 future timestamp either errors the statement or comes back large and positive,
 expiring exactly the row that has barely aged.


### PR DESCRIPTION
Closes #52.

Reinforcement raised `strength` without bound, and since #21 the prune horizon scales linearly with it — a `fast` note recalled fifty times survived ~3 years, outliving its class by orders of magnitude.

**The decision** the issue asked for:
- **Hard cap, not a saturating curve**: `scoring::MAX_STABILITY = 5.0`. The clamp is one expression, repeated verbatim at every point the engine evaluates the curve, so the spellings cannot drift apart quietly. A saturating curve buys the same bound with more math in each place.
- **One ceiling for every class**: the class already sets the timescale through its `rate()`; strength is the use-multiplier on top. A per-class cap would be a second copy of what rate encodes. At the cap a hot `fast` note lives ~100 days (five ~20-day horizons) — one order above its class, not three.

**Where it is enforced** (the consistency the issue demanded):
- `scoring::retention` clamps to `[MIN_STABILITY, MAX_STABILITY]` at read time.
- `REINFORCE` writes `math::min([strength + 1.0, $cap])`; `access_count` and `last_accessed` still update past it.
- `PRUNE_EXPIRED` clamps in its comparison — which is also the migration: a row reinforced past the cap before the ceiling existed becomes reachable by the sweep with no stored strength rewritten.
- `consolidate`'s `expires_in_days` clamps identically, so a stale-context report cannot claim a reprieve the sweep no longer grants.

`stale_contexts` needed no change — its selector already drops the strength factor; its window is now idle time between one horizon and five.

Tests: saturation in scoring and through `reinforce` (nine recalls → strength 5, access_count 9), the sweep expiring a strength-50 row at 150 days idle, and the consolidate report pinned to the capped reprieve (30–45 days, where raw strength would claim 559). Three existing fixtures that relied on unbounded strength moved inside the capped window. Local CI green: fmt, clippy, 265 tests, no-default-features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018grPjAfgrLmi8Y27pNoKtc