### PR TITLE
The retry the description asks for finally terminates

### DIFF
--- a/crates/agmem-server/tests/protocol.rs
+++ b/crates/agmem-server/tests/protocol.rs
@@ -726,6 +726,72 @@ async fn a_correction_closes_the_memory_it_supersedes() {
     agmem.shutdown().await;
 }
 
+/// Issue #57: a word-for-word re-send with `supersedes` used to block at the
+/// exact-hash gate with the supersede riding on the blocked entry — so the
+/// retry the description asks for ("re-send yours with the id in supersedes")
+/// looped forever whenever the correction was identical to an already-live
+/// claim. The duplicate must close the targets anyway, in favour of the row
+/// that already holds the content.
+#[tokio::test]
+async fn a_duplicate_carrying_supersedes_still_closes_its_targets() {
+    let agmem = Harness::start(Arc::new(KeywordEmbedder)).await;
+    let seeded = agmem
+        .remember(json!({
+            "memories": [
+                { "content": "The user formats Python with ruff" },
+                { "content": "The user formats Python with black" },
+            ]
+        }))
+        .await;
+    let created = ids(&seeded["created"]);
+    let (live, stale) = (created[0].to_owned(), created[1].to_owned());
+
+    let diff = agmem
+        .remember(json!({
+            "memories": [{
+                "content": "The user formats Python with ruff",
+                "supersedes": [live, stale],
+            }]
+        }))
+        .await;
+
+    let duplicates = diff["duplicates"].as_array().expect("an array");
+    assert_eq!(duplicates.len(), 1, "{diff}");
+    assert_eq!(
+        duplicates[0]["id"], live,
+        "reported against the row that already holds the claim: {diff}"
+    );
+    assert!(ids(&diff["created"]).is_empty(), "{diff}");
+    assert_eq!(
+        ids(&diff["superseded"]),
+        [stale.as_str()],
+        "the target closed even though nothing was written — the retry terminates: {diff}"
+    );
+
+    let memories = agmem.memories().await;
+    let closed = memories
+        .iter()
+        .find(|memory| memory.id.as_str() == stale)
+        .expect("the closed claim is still readable");
+    assert_eq!(
+        (
+            closed.invalid_reason.map(|reason| reason.as_str()),
+            closed.superseded_by.as_ref().map(|id| id.as_str())
+        ),
+        (Some("superseded"), Some(live.as_str())),
+        "closed pointing forward at the already-stored claim"
+    );
+    let survivor = memories
+        .iter()
+        .find(|memory| memory.id.as_str() == live)
+        .expect("the live claim");
+    assert_eq!(
+        survivor.invalid_reason, None,
+        "naming the duplicate row in `supersedes` does not close it against itself"
+    );
+    agmem.shutdown().await;
+}
+
 /// Issue #42: a duplicate cluster is merged by one call, not by one
 /// supersession and N `forget`s. `supersedes` takes a list precisely so the
 /// rest of a cluster keeps its history — `forget` would take it away.

--- a/crates/agmem-store/src/queries/write.rs
+++ b/crates/agmem-store/src/queries/write.rs
@@ -66,8 +66,17 @@ pub(crate) fn insert_batch(memories: &[MemoryShape<'_>], with_episode: bool) -> 
         // nothing, so fewer rows back than ids sent means one of them is gone.
         // A ULID is Crockford base32 and cannot break out of the literal, so
         // the ids are baked in to name the offenders in the error.
-        let supersede = if shape.supersedes.is_empty() {
-            String::new()
+        //
+        // The duplicate branch honours `supersedes` too (issue #57): the claim
+        // is already live under `$dup`, so the targets close in *its* favour —
+        // minus `$dup` itself, which would otherwise close the one row that
+        // holds the content. Without this, the retry the tool description asks
+        // for ("re-send yours with the id in supersedes") looped forever on a
+        // word-for-word re-send: the gate fired first and the supersede rode on
+        // a blocked entry. The boundary is the caller's `valid_from`, exactly
+        // as the created branch takes it from the new row.
+        let (supersede, dup_supersede) = if shape.supersedes.is_empty() {
+            (String::new(), String::new())
         } else {
             let count = shape.supersedes.len();
             let named = shape
@@ -76,12 +85,22 @@ pub(crate) fn insert_batch(memories: &[MemoryShape<'_>], with_episode: bool) -> 
                 .map(|old| format!("memory:{old}"))
                 .collect::<Vec<_>>()
                 .join(", ");
-            format!(
-                "LET $sup{index} = (UPDATE $old{index} SET superseded_by = $new{index}.id,
-                     invalid_at = $new{index}.valid_from, invalid_reason = 'superseded');
-                 IF array::len($sup{index}) != {count} {{
-                     THROW 'supersedes targets {named} — one of them does not exist'
-                 }};"
+            (
+                format!(
+                    "LET $sup{index} = (UPDATE $old{index} SET superseded_by = $new{index}.id,
+                         invalid_at = $new{index}.valid_from, invalid_reason = 'superseded');
+                     IF array::len($sup{index}) != {count} {{
+                         THROW 'supersedes targets {named} — one of them does not exist'
+                     }};"
+                ),
+                format!(
+                    "LET $keep{index} = array::complement($old{index}, [$dup{index}]);
+                     LET $sup{index} = (UPDATE $keep{index} SET superseded_by = $dup{index},
+                         invalid_at = $row{index}.valid_from, invalid_reason = 'superseded');
+                     IF array::len($sup{index}) != array::len($keep{index}) {{
+                         THROW 'supersedes targets {named} — one of them does not exist'
+                     }};"
+                ),
             )
         };
         builder.push(format!(
@@ -90,6 +109,7 @@ pub(crate) fn insert_batch(memories: &[MemoryShape<'_>], with_episode: bool) -> 
         ));
         builder.push(format!(
             "LET $res{index} = IF $dup{index} IS NOT NONE {{
+                 {dup_supersede}
                  {{ id: record::id($dup{index}), created: false }}
              }} ELSE {{
                  LET $new{index} = (CREATE ONLY memory:ulid()

--- a/crates/agmem-store/src/repo/write.rs
+++ b/crates/agmem-store/src/repo/write.rs
@@ -129,6 +129,9 @@ pub struct Batch {
 /// An exact duplicate is a result, not a failure: `remember` reports the id of
 /// the row that already holds the content and leaves the decision — accept the
 /// NOOP, or re-send with `supersedes` — to the calling agent (design §3.1).
+/// A duplicate that itself carried `supersedes` has already closed those
+/// targets in favour of the reported row (issue #57), so that re-send loop
+/// terminates instead of blocking forever on its own success.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Written<I> {
     /// A new row, with the id it was minted with.
@@ -175,7 +178,9 @@ pub struct BatchOutcome {
 /// Exact duplicates (`(space, content_hash)`) are reported, not inserted:
 /// letting one reach the unique index would abort the entire transaction, so
 /// each insert is guarded by a lookup in the same transaction. Two identical
-/// memories *within* one batch collapse the same way.
+/// memories *within* one batch collapse the same way. A duplicate's
+/// `supersedes` still closes its targets — in favour of the row that already
+/// holds the content, minus that row itself (issue #57).
 ///
 /// # Errors
 /// [`StoreError::UnknownMemory`] when a `supersedes` target is not in this
@@ -286,8 +291,13 @@ pub async fn insert_batch(db: &Db, batch: Batch) -> Result<BatchOutcome, StoreEr
     let superseded = memories
         .iter()
         .zip(&outcomes)
-        .filter(|(_, outcome)| outcome.is_created())
-        .flat_map(|(memory, _)| memory.supersedes.iter().cloned())
+        .flat_map(|(memory, outcome)| {
+            memory.supersedes.iter().filter(move |old| match outcome {
+                Written::Created(_) => true,
+                Written::Duplicate(dup) => *old != dup,
+            })
+        })
+        .cloned()
         .collect();
     Ok(BatchOutcome {
         episode: row

--- a/crates/agmem-store/tests/writes.rs
+++ b/crates/agmem-store/tests/writes.rs
@@ -679,6 +679,65 @@ async fn a_purge_takes_an_episodes_slices_and_leaves_the_claims_drawn_from_it() 
     );
 }
 
+#[tokio::test]
+async fn an_exact_duplicate_with_supersedes_closes_targets_in_favour_of_the_live_row() {
+    let db = store().await;
+    let ids: Vec<MemoryId> = repo::insert_batch(
+        &db,
+        batch(vec![
+            NewMemory::new(Kind::Fact, "the deploy runs from bin/ship.sh"),
+            NewMemory::new(Kind::Fact, "the deploy runs from make deploy"),
+        ]),
+    )
+    .await
+    .expect("write")
+    .memories
+    .into_iter()
+    .map(Written::into_id)
+    .collect();
+    let (live, stale) = (ids[0].clone(), ids[1].clone());
+
+    // The #57 shape: a word-for-word re-send of the live claim, superseding
+    // both the stale claim and the very row it duplicates — which is what a
+    // retry of a half-landed correction looks like.
+    let mut resend = NewMemory::new(Kind::Fact, "the deploy runs from bin/ship.sh");
+    resend.supersedes = vec![live.clone(), stale.clone()];
+    let outcome = repo::insert_batch(&db, batch(vec![resend]))
+        .await
+        .expect("write");
+
+    assert_eq!(
+        outcome.memories,
+        vec![Written::Duplicate(live.clone())],
+        "nothing new was written"
+    );
+    assert_eq!(
+        outcome.superseded,
+        vec![stale.clone()],
+        "the target closed anyway; the row holding the content did not close itself"
+    );
+
+    let rows = all_memories(&db, &space()).await;
+    let row = |id: &MemoryId| {
+        rows.iter()
+            .find(|row| row.id == *id)
+            .expect("the row exists")
+    };
+    assert_eq!(
+        row(&live).invalid_reason,
+        None,
+        "the duplicate stays live — it is the claim"
+    );
+    assert_eq!(
+        (
+            row(&stale).invalid_reason,
+            row(&stale).superseded_by.as_ref()
+        ),
+        (Some(InvalidReason::Superseded), Some(&live)),
+        "closed pointing at the row that already holds the content"
+    );
+}
+
 /// Backdate a row's last use and set the strength a few recalls would have
 /// left it with — the two inputs to the decay curve, and the only two no write
 /// API sets directly.

--- a/docs/design.md
+++ b/docs/design.md
@@ -669,6 +669,10 @@ remember(params)
     exact dup? (space, hash) unique index         → report as duplicate (NOOP)
     …but the check runs *inside* the transaction of step 5: a unique-index
     conflict aborts the whole transaction, so a duplicate must never reach it
+    …and a duplicate carrying `supersedes` still closes those targets, in
+    favour of the row that already holds the content, minus that row itself
+    (issue #57) — otherwise the documented retry ("re-send with the id in
+    supersedes") loops forever on a word-for-word re-send
  3. embed all new contents + episode chunks in one batch
                                                    (spawn_blocking, passage: prefix)
  4. near-dup gate: HNSW top-4 among live memories in space — one pass, two answers


### PR DESCRIPTION
Closes #57.

The repro from the issue: claim A live, stale claim B live, `remember` A-verbatim with `supersedes: [A, B]`. The exact-hash gate fired before `supersedes` was honoured, the entry came back in `duplicates`, and B stayed live — so the tool description's own correction flow ("re-send yours with the id here in supersedes") could never terminate when the wording was identical to the already-stored successor.

**The fix, in the store's duplicate branch** (`queries::write::insert_batch`): a duplicate carrying `supersedes` still closes its targets — in favour of `$dup`, the row that already holds the content, and minus `$dup` itself via `array::complement`, which would otherwise close the one live copy of the claim against itself. The boundary is the caller's `valid_from`, exactly as the created branch takes it from the new row. The repo layer reports these closures in `superseded` (excluding the dup row), so the tool answer shows the close the same way a created correction does.

Why not "create new + close old": the `(space, content_hash)` unique index spans closed rows, so an identical re-send can never reach `CREATE` — keeping the existing row as the successor is the only shape the schema admits, and it is also what the caller means.

The vector gate needed no change — it already skips entries carrying `supersedes` — and `reflect` inherits the fix through the shared `insert_batch`.

Tests: the issue's suggested Harness test at the protocol level (duplicate reported against the live row, `superseded` names only B, B closed pointing at A, A still live) and a store-level `insert_batch` test of the same shape. design.md §5.2 records the semantics. Local CI green: fmt, clippy, 267 tests, no-default-features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018grPjAfgrLmi8Y27pNoKtc