### PR TITLE
A release becomes one merge

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,67 @@
+# The rolling release PR (the flow is documented in release-plz.toml).
+#
+# Both jobs authenticate with RELEASE_PLZ_TOKEN — a fine-grained PAT with
+# Contents and Pull requests read+write on this repo. The default GITHUB_TOKEN
+# cannot do this job: a PR it opens never runs the required `check` workflows
+# (so the ruleset makes it unmergeable), and a tag it pushes never triggers
+# cargo-dist's release.yml — GitHub suppresses workflow runs caused by
+# workflow tokens. Until the secret exists, these jobs fail; that is the
+# missing-setup signal, not a code problem.
+
+name: release-plz
+
+permissions: {}
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  # Tag when main's version is newer than the last tag — which is what main
+  # looks like right after the release PR (or a manual bump PR) merges. Any
+  # other push is a no-op here. cargo-dist's release.yml reacts to the tag.
+  release:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-release
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          # Change detection verify-builds the last tag's tree in a temp
+          # worktree; a shared, cached target dir is what keeps that to about
+          # a minute instead of a cold surrealdb build per push.
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target
+
+  # Keep one PR on the tip of main proposing the next version. A push that is
+  # not a release merge updates it; merging it is the release decision.
+  # Runs after `release` so that on a release merge the new tag exists before
+  # this job reads tags to propose the version after it.
+  release-pr:
+    needs: release
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-pr
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-core"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "blake3",
  "jiff",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-embed"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "fastembed",
  "model2vec-rs",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-server"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agmem-core",
  "agmem-embed",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-store"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "agmem-core",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -16,10 +16,15 @@ repository = "https://github.com/AlfoldiMate/agmem"
 homepage = "https://github.com/AlfoldiMate/agmem"
 
 [workspace.dependencies]
-agmem-core = { path = "crates/agmem-core" }
-agmem-store = { path = "crates/agmem-store" }
+# The `version` beside each `path` is for `cargo package`, which release-plz
+# runs to compare a crate against its last release: packaging refuses a path
+# dependency with no version requirement. Local builds resolve by path either
+# way, and a caret requirement stays satisfied across the bumps release-plz
+# makes.
+agmem-core = { path = "crates/agmem-core", version = "0.1.3" }
+agmem-store = { path = "crates/agmem-store", version = "0.1.3" }
 # default-features off so a BM25-only build can drop the ONNX half entirely
-agmem-embed = { path = "crates/agmem-embed", default-features = false }
+agmem-embed = { path = "crates/agmem-embed", version = "0.1.3", default-features = false }
 
 # MCP + storage + embeddings (pinned per docs/design.md §4.1)
 rmcp = { version = "3.1", features = ["server", "macros", "transport-io"] }

--- a/README.md
+++ b/README.md
@@ -668,15 +668,24 @@ Changes arrive as pull requests, and CI — fmt, clippy with warnings denied,
 the full suite on Linux and macOS, and the BM25-only build check — must be
 green before merge.
 
-A release is one tag. Bump `[workspace.package] version` in `Cargo.toml`,
-land it, then:
+A release is one merge. release-plz keeps a rolling PR open against `main`
+proposing the next version (patch by default — commit titles here carry no
+conventional-commit markers); merged work accumulates into it, and **merging
+that PR is the release decision**. On the merge, the `release-plz` workflow
+pushes the `vX.Y.Z` tag; the flow is documented in `release-plz.toml`, and
+it authenticates with the `RELEASE_PLZ_TOKEN` repo secret (a fine-grained
+PAT — Contents and Pull requests read+write on this repo).
+
+For a bump the patch default undersells, the old flow still works and lands
+in the same pipe: merge a PR bumping `[workspace.package] version` yourself,
+and the workflow tags it. Hand-pushing the tag also still works:
 
 ```sh
 git tag vX.Y.Z && git push origin vX.Y.Z
 ```
 
-The tag fires the cargo-dist workflow: it builds every prebuilt target,
-publishes the GitHub release with the shell installer and build
+Either way, the tag fires the cargo-dist workflow: it builds every prebuilt
+target, publishes the GitHub release with the shell installer and build
 attestations, and pushes the updated formula to `AlfoldiMate/homebrew-tap`
 — `brew upgrade agmem` sees it as soon as that lands. Nothing after the
 tag is manual.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,47 @@
+# The rolling release PR.
+#
+# release-plz maintains one open PR that accumulates merged work as a version
+# bump; **merging that PR is the release decision** — nothing releases on an
+# ordinary merge. On the push that merge makes, the `release` job pushes the
+# `v{version}` tag, and cargo-dist's release.yml takes over exactly as it does
+# for a hand-pushed tag (build, GitHub release, Homebrew tap publish).
+#
+# The old flow stays valid as the escape hatch: merge a manual version-bump PR
+# (for a minor bump the patch default undersells, say) and the release job
+# tags it the same way — it tags whatever version on main is newer than the
+# last tag, however it got there.
+#
+# Narrative commit titles carry no conventional-commit markers, so the bump
+# defaults to patch; pre-1.0 that is the honest default.
+#
+# Change detection checks out the last tag into a temp worktree and runs
+# `cargo package --workspace` there, verify-build included and no flag to skip
+# it — so the workflow points CARGO_TARGET_DIR at the cached target dir, which
+# turns that build from cold-surrealdb minutes into about one (measured
+# locally: 60s warm for the whole update). It is also why the internal path
+# dependencies in Cargo.toml carry a `version`: packaging refuses a path
+# dependency without one, and the *tagged* tree is what gets packaged — the
+# first tag whose tree carries the versions is where this flow starts working.
+
+[workspace]
+# Nothing here goes to crates.io — the binary ships through cargo-dist — and
+# without `git_only` release-plz would baseline against the registry, find
+# nothing there, and treat every version as an unreleased first release.
+publish = false
+git_only = true
+# cargo-dist creates the GitHub release when the tag lands; a second one from
+# this tool would race it.
+git_release_enable = false
+# One shared workspace version means per-crate changelogs would each see only
+# their own directory's commits and miss the rest of the release. The git log
+# between tags is the changelog, in this repo's own words.
+changelog_update = false
+# Every crate reads its baseline from the shared v* tag (the workspace version
+# is one number), but only the binary crate below *writes* the tag — four
+# crates racing to create the same tag name is three failures.
+git_tag_name = "v{{ version }}"
+git_tag_enable = false
+
+[[package]]
+name = "agmem-server"
+git_tag_enable = true


### PR DESCRIPTION
Implements the rolling release PR flow discussed after #54 closed.

**The flow:** release-plz maintains one open PR proposing the next version; merged work accumulates into it, and merging that PR is the release decision. On that merge the `release-plz` workflow pushes the `v{version}` tag, and cargo-dist's release.yml reacts to it exactly as to a hand-pushed tag. The old flow (manual bump PR, or hand-pushed tag) still works and lands in the same pipe.

**Config, each line load-bearing and locally rehearsed** (full dry-run: clone → tag → change → `release-plz update` bumped 0.1.3→0.1.4 across manifest/dep-reqs/lock in 60s → `release --dry-run` planned exactly one action, `creation of tag 'v0.1.4'`, with libs reporting "no release method enabled"):
- `git_only` — without it release-plz baselines against crates.io, finds nothing, and treats every version as an unreleased first release (measured: "already up-to-date" on a main five PRs past the tag).
- Workspace-level `git_tag_name = "v{{ version }}"` with `git_tag_enable` only on `agmem-server` — every crate *reads* its baseline from the shared tag, one crate *writes* it.
- `git_release_enable = false` — cargo-dist owns the GitHub release.
- No changelog — per-crate changelogs each see only their own directory's commits and would miss the rest of a shared-version release; the narrative git log between tags is the changelog.
- `CARGO_TARGET_DIR` + rust-cache in the workflow — git_only change detection verify-builds the last tag's tree in a temp worktree (hardcoded, no skip flag; confirmed in release-plz source); the shared cached target turns that from cold-surrealdb minutes into ~one.
- Internal path deps gain `version` requirements — `cargo package` refuses them bare, and the **tagged** tree is what gets packaged. Hence the bump to **0.1.3 in this PR**: it bootstraps the first baseline-able tag, and ships #50/#55/#56/#58 to the brew binary.

**One manual step before (or right after) merging:** create a fine-grained PAT (this repo only; Contents + Pull requests read+write) and `gh secret set RELEASE_PLZ_TOKEN`. The default GITHUB_TOKEN cannot serve: PRs it opens never run the required checks, and tags it pushes never trigger release.yml. Until the secret exists the new jobs fail — on this PR's own merge, re-run the `release` job after adding it and v0.1.3 goes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018grPjAfgrLmi8Y27pNoKtc