### PR TITLE
A stale daemon steps aside instead of serving old code

### DIFF
--- a/crates/agmem-server/src/daemon/client.rs
+++ b/crates/agmem-server/src/daemon/client.rs
@@ -12,11 +12,11 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, bail};
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::UnixStream;
 
 use crate::config::Config;
-use crate::daemon::{DAEMON_LOG_FILE, Handshake, socket_path, spawn_lock_path};
+use crate::daemon::{Ack, DAEMON_LOG_FILE, Handshake, RELEASE, socket_path, spawn_lock_path};
 
 /// How long to queue for the right to start a daemon before giving up. Long
 /// enough for another session to finish starting one, short enough that a
@@ -29,6 +29,10 @@ const READY_DEADLINE: Duration = Duration::from_secs(120);
 
 /// How often to re-try the socket while waiting.
 const POLL: Duration = Duration::from_millis(50);
+
+/// How long a retiring daemon gets to unlink its socket before this session
+/// starts a fresh one anyway.
+const RETIRE_DEADLINE: Duration = Duration::from_secs(15);
 
 /// Attach this session to the shared store, starting the daemon if needed,
 /// and pump stdio until the client goes away.
@@ -43,16 +47,53 @@ pub async fn run(cfg: &Config) -> anyhow::Result<()> {
 }
 
 /// A connection to the shared daemon — found, or started — with this
-/// configuration's [`Handshake`] already sent. What flows next is MCP;
-/// [`run`] pumps stdio into it, `agmem context` (issue #46) speaks it itself.
+/// configuration's [`Handshake`] sent and the daemon's [`Ack`] consumed, so
+/// every byte after it is MCP. [`run`] pumps stdio into it, `agmem context`
+/// (issue #46) speaks it itself.
+///
+/// A daemon from another release answers "retiring" and shuts down (issue
+/// #60); this session waits it out and starts a fresh daemon from its own
+/// binary — once. Two retirements in a row means two binaries are fighting
+/// over the socket, and that is the user's to resolve.
 ///
 /// # Errors
-/// When no daemon can be reached or started, or the handshake will not land.
+/// When no daemon can be reached or started, or the daemon refuses the
+/// handshake. The refusal's message is surfaced here — never swallowed into
+/// a clean exit — because the alternative is a session with no memory tools
+/// and no explanation.
 pub async fn attach(cfg: &Config) -> anyhow::Result<UnixStream> {
     let path = socket_path(&cfg.data_dir)?;
-    let mut stream = match connect(&path).await {
+    match attach_once(cfg, &path).await? {
+        Attached::Serving(stream) => Ok(stream),
+        Attached::DaemonRetired => {
+            wait_for_retirement(&path).await;
+            match attach_once(cfg, &path).await? {
+                Attached::Serving(stream) => Ok(stream),
+                Attached::DaemonRetired => bail!(
+                    "the shared store on {} retired twice in a row: two different agmem \
+                     builds are attaching to it. Align them on one release, or pass \
+                     --no-daemon.",
+                    path.display()
+                ),
+            }
+        }
+    }
+}
+
+/// What one handshake attempt came to.
+enum Attached {
+    /// The daemon took the session; the stream is MCP from here.
+    Serving(UnixStream),
+    /// The daemon is from another release and is shutting down so this
+    /// session can start one from its own binary.
+    DaemonRetired,
+}
+
+/// Connect or start a daemon, hand it the handshake, and read its verdict.
+async fn attach_once(cfg: &Config, path: &Path) -> anyhow::Result<Attached> {
+    let mut stream = match connect(path).await {
         Some(stream) => stream,
-        None => start_one(cfg, &path).await?,
+        None => start_one(cfg, path).await?,
     };
     let mut handshake = serde_json::to_vec(&Handshake::new(cfg))?;
     handshake.push(b'\n');
@@ -60,7 +101,71 @@ pub async fn attach(cfg: &Config) -> anyhow::Result<UnixStream> {
         .write_all(&handshake)
         .await
         .context("the shared store closed before the handshake landed")?;
-    Ok(stream)
+
+    let ack = read_ack(&mut stream, cfg).await?;
+    if ack.ok {
+        return Ok(Attached::Serving(stream));
+    }
+    let why = ack
+        .error
+        .unwrap_or_else(|| "the shared store refused the handshake without saying why".to_owned());
+    if ack.retiring {
+        tracing::info!(%why, "waiting for the old daemon to retire");
+        return Ok(Attached::DaemonRetired);
+    }
+    bail!(why)
+}
+
+/// The daemon's one-line answer to the handshake, read a byte at a time: the
+/// bytes after the newline are MCP and belong to the pump, so nothing here
+/// may buffer past it.
+async fn read_ack(stream: &mut UnixStream, cfg: &Config) -> anyhow::Result<Ack> {
+    let mut line = Vec::new();
+    let mut byte = [0u8; 1];
+    loop {
+        let n = stream
+            .read(&mut byte)
+            .await
+            .context("reading the shared store's handshake ack")?;
+        if n == 0 {
+            // Pre-#60 daemons never wrote an ack: a refusal was a close the
+            // client pumped through and exited 0 on. Meeting that close here
+            // turns it into the message it always should have been.
+            bail!(
+                "the shared store closed without answering the handshake. It is probably \
+                 an agmem older than {RELEASE} still holding {}; stop that process (or \
+                 wait out its idle timeout) and retry. Its log is {}.",
+                cfg.data_dir.display(),
+                log_path(cfg).display()
+            );
+        }
+        if byte[0] == b'\n' {
+            break;
+        }
+        line.push(byte[0]);
+        if line.len() > 4096 {
+            bail!("the shared store's handshake ack never ended");
+        }
+    }
+    serde_json::from_slice(&line).context("the shared store's handshake ack is not JSON")
+}
+
+/// Wait for a retiring daemon to unlink its socket, then a beat longer for
+/// its store lock to release with its process — the fresh daemon this
+/// session is about to start needs both gone.
+async fn wait_for_retirement(path: &Path) {
+    let deadline = Instant::now() + RETIRE_DEADLINE;
+    while Instant::now() < deadline && path.exists() {
+        tokio::time::sleep(POLL).await;
+    }
+    tokio::time::sleep(Duration::from_millis(200)).await;
+}
+
+/// Where the daemon this configuration would start writes its log.
+fn log_path(cfg: &Config) -> std::path::PathBuf {
+    cfg.log_file
+        .clone()
+        .unwrap_or_else(|| cfg.data_dir.join(DAEMON_LOG_FILE))
 }
 
 /// A daemon that answers, or nothing. Every failure is "not there" — the
@@ -129,10 +234,7 @@ async fn queue_to_spawn(path: &Path) -> anyhow::Result<File> {
 fn spawn(cfg: &Config) -> anyhow::Result<()> {
     let exe = std::env::current_exe()
         .context("cannot find this binary to start the shared store from")?;
-    let log_file = cfg
-        .log_file
-        .clone()
-        .unwrap_or_else(|| cfg.data_dir.join(DAEMON_LOG_FILE));
+    let log_file = log_path(cfg);
 
     let mut command = Command::new(exe);
     command
@@ -182,14 +284,10 @@ async fn wait_until_ready(cfg: &Config, path: &Path) -> anyhow::Result<UnixStrea
         }
         tokio::time::sleep(POLL).await;
     }
-    let log = cfg
-        .log_file
-        .clone()
-        .unwrap_or_else(|| cfg.data_dir.join(DAEMON_LOG_FILE));
     bail!(
         "the shared store did not come up within {READY_DEADLINE:?}. Its log is {}; \
          --no-daemon opens the store in this process instead.",
-        log.display()
+        log_path(cfg).display()
     )
 }
 

--- a/crates/agmem-server/src/daemon/mod.rs
+++ b/crates/agmem-server/src/daemon/mod.rs
@@ -51,7 +51,19 @@ pub const DAEMON_LOG_FILE: &str = "daemon.log";
 /// v2 added `tool_desc`. A v1 daemon deserialises the extra field happily and
 /// then serves its own descriptions, so the bump is the only thing that turns
 /// "your override was ignored" into a message someone can read.
-pub const PROTOCOL_VERSION: u32 = 2;
+///
+/// v3 added `release` and the [`Ack`] the daemon now writes back (issue #60).
+/// A v2 daemon reads a v3 handshake, refuses it into its own log, and closes —
+/// which the v3 client, waiting on an ack that never comes, reports loudly
+/// instead of pumping EOF and exiting clean.
+pub const PROTOCOL_VERSION: u32 = 3;
+
+/// The version of the code actually serving. `PROTOCOL_VERSION` only moves
+/// when the wire changes, so it cannot tell a v0.1.3 daemon from a v0.1.4
+/// one — and a daemon that outlives a release keeps serving the old schema,
+/// scoring and tool wording until its idle timeout happens to recycle it
+/// (issue #60, and a real incident: a deleted binary's daemon kept serving).
+pub const RELEASE: &str = env!("CARGO_PKG_VERSION");
 
 /// The longest socket path a `sockaddr_un` can hold. macOS allows 104 bytes
 /// including the terminator and Linux 108; the smaller number travels.
@@ -106,6 +118,10 @@ pub fn spawn_lock_path(data_dir: &Path) -> PathBuf {
 pub struct Handshake {
     /// [`PROTOCOL_VERSION`] of the session that opened the connection.
     pub version: u32,
+    /// [`RELEASE`] of the binary that opened the connection. A mismatch means
+    /// the daemon is code from another release: it retires so the session can
+    /// start one from its own binary, rather than serving stale behaviour.
+    pub release: String,
     /// The store the session expects to be talking to.
     pub db_url: String,
     /// The embedding backend it expects.
@@ -126,6 +142,7 @@ impl Handshake {
     pub fn new(cfg: &Config) -> Self {
         Self {
             version: PROTOCOL_VERSION,
+            release: RELEASE.to_owned(),
             db_url: cfg.db_url.clone(),
             embedder: cfg.embedder,
             space: cfg.space.clone(),
@@ -138,35 +155,119 @@ impl Handshake {
     /// Refuse a session that expects something this daemon is not serving.
     ///
     /// # Errors
-    /// When the protocol version, the store or the embedder disagree. The
-    /// message is the session's to read, so it names both sides.
-    pub fn accept(&self, asked: &Self) -> anyhow::Result<()> {
+    /// When the release, the protocol version, the store or the embedder
+    /// disagree. The message is the session's to read, so it names both
+    /// sides; `retire` says whether this daemon should hand the socket over.
+    pub fn accept(&self, asked: &Self) -> Result<(), Refusal> {
+        // Release first: a version skew subsumes whatever else differs, and
+        // the newest attacher's binary is the one the user just installed —
+        // the daemon defers to it rather than serving code that no longer
+        // matches what is on disk.
+        if asked.release != self.release {
+            return Err(Refusal {
+                retire: true,
+                message: format!(
+                    "the running daemon is agmem {} and this session is agmem {}; the \
+                     daemon is retiring so a fresh one can serve this release.",
+                    self.release, asked.release
+                ),
+            });
+        }
         if asked.version != self.version {
-            bail!(
-                "this session speaks agmem daemon protocol v{} and the running daemon \
-                 speaks v{}; the daemon is an older or newer agmem. Stop it and let this \
-                 one start a fresh daemon.",
-                asked.version,
-                self.version
-            );
+            return Err(Refusal {
+                // Same release but different protocol should be impossible;
+                // if it happens anyway, the newer wire wins the socket.
+                retire: asked.version > self.version,
+                message: format!(
+                    "this session speaks agmem daemon protocol v{} and the running daemon \
+                     speaks v{}; the daemon is an older or newer agmem. Stop it and let \
+                     this one start a fresh daemon.",
+                    asked.version, self.version
+                ),
+            });
         }
         if asked.db_url != self.db_url {
-            bail!(
-                "the running daemon holds {} and this session asked for {}. One data dir \
-                 is one store; pass --no-daemon, or point both at the same --db.",
-                self.db_url,
-                asked.db_url
-            );
+            return Err(Refusal {
+                retire: false,
+                message: format!(
+                    "the running daemon holds {} and this session asked for {}. One data \
+                     dir is one store; pass --no-daemon, or point both at the same --db.",
+                    self.db_url, asked.db_url
+                ),
+            });
         }
         if asked.embedder != self.embedder {
-            bail!(
-                "the running daemon embeds with {} and this session asked for {}. Vectors \
-                 from two models cannot be compared; stop the daemon or match --embedder.",
-                self.embedder.as_str(),
-                asked.embedder.as_str()
-            );
+            return Err(Refusal {
+                retire: false,
+                message: format!(
+                    "the running daemon embeds with {} and this session asked for {}. \
+                     Vectors from two models cannot be compared; stop the daemon or match \
+                     --embedder.",
+                    self.embedder.as_str(),
+                    asked.embedder.as_str()
+                ),
+            });
         }
         Ok(())
+    }
+}
+
+/// Why a daemon turned a session away, and whether it is stepping aside.
+///
+/// `retire` is the difference between "you are misconfigured" (wrong store,
+/// wrong embedder — the daemon stays, the session gets an error) and "I am
+/// stale" (another release — the daemon shuts down so the refused session can
+/// start one from its own binary).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Refusal {
+    /// What to tell the session. Names both sides and the way out.
+    pub message: String,
+    /// Whether the daemon shuts down after refusing.
+    pub retire: bool,
+}
+
+impl std::fmt::Display for Refusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for Refusal {}
+
+/// The one line the daemon writes back after reading a [`Handshake`], before
+/// any MCP flows (issue #60). Without it a refusal was an EOF the client
+/// pumped through and exited 0 on — the session came up with no memory tools
+/// and no explanation beyond a line in `daemon.log`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Ack {
+    /// Whether the daemon accepted the session. When `true` the rest of the
+    /// stream is MCP; when `false`, `error` says why and the stream ends.
+    pub ok: bool,
+    /// The refusal, worded for the session that has to act on it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// The daemon is shutting down so the session can start a fresh one.
+    #[serde(default)]
+    pub retiring: bool,
+}
+
+impl Ack {
+    /// The daemon took the session.
+    pub fn accepted() -> Self {
+        Self {
+            ok: true,
+            error: None,
+            retiring: false,
+        }
+    }
+
+    /// The daemon turned the session away.
+    pub fn refused(refusal: &Refusal) -> Self {
+        Self {
+            ok: false,
+            error: Some(refusal.message.clone()),
+            retiring: refusal.retire,
+        }
     }
 }
 
@@ -210,13 +311,25 @@ mod tests {
             .accept(&asked)
             .expect("a different project is the whole point of sharing");
 
-        for (label, broken) in [
+        for (label, broken, retires) in [
+            (
+                "release",
+                Handshake {
+                    release: "0.0.0-elsewhere".to_owned(),
+                    ..daemon.clone()
+                },
+                // Another release means this daemon is the stale one: it
+                // steps aside rather than serving code that no longer
+                // matches the binary on disk.
+                true,
+            ),
             (
                 "version",
                 Handshake {
                     version: daemon.version + 1,
                     ..daemon.clone()
                 },
+                true,
             ),
             (
                 "store",
@@ -224,6 +337,9 @@ mod tests {
                     db_url: "surrealkv:///elsewhere".to_owned(),
                     ..daemon.clone()
                 },
+                // A wrong store is the session's misconfiguration; the
+                // daemon keeps serving everyone else.
+                false,
             ),
             (
                 "embedder",
@@ -231,16 +347,42 @@ mod tests {
                     embedder: EmbedderKind::None,
                     ..daemon.clone()
                 },
+                false,
             ),
         ] {
-            let error = daemon
+            let refusal = daemon
                 .accept(&broken)
                 .expect_err("{label} disagreeing must be refused");
             assert!(
-                !error.to_string().is_empty(),
+                !refusal.message.is_empty(),
                 "{label} must say what to do about it"
             );
+            assert_eq!(refusal.retire, retires, "{label}: wrong side gives way");
         }
+    }
+
+    #[test]
+    fn an_ack_survives_the_wire_and_a_refusal_carries_its_reason() {
+        for ack in [
+            Ack::accepted(),
+            Ack::refused(&Refusal {
+                message: "another release".to_owned(),
+                retire: true,
+            }),
+        ] {
+            let line = serde_json::to_string(&ack).expect("serialize");
+            assert!(!line.contains('\n'), "the ack is one line: {line}");
+            assert_eq!(
+                serde_json::from_str::<Ack>(&line).expect("deserialize"),
+                ack
+            );
+        }
+        let refused = Ack::refused(&Refusal {
+            message: "why".to_owned(),
+            retire: false,
+        });
+        assert_eq!(refused.error.as_deref(), Some("why"));
+        assert!(!refused.ok && !refused.retiring);
     }
 
     #[test]

--- a/crates/agmem-server/src/daemon/serve.rs
+++ b/crates/agmem-server/src/daemon/serve.rs
@@ -11,12 +11,12 @@ use agmem_embed::Embedder;
 use agmem_store::db::Db;
 use anyhow::Context;
 use rmcp::ServiceExt;
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::mpsc;
 
 use crate::config::Config;
-use crate::daemon::{Handshake, socket_path};
+use crate::daemon::{Ack, Handshake, socket_path};
 use crate::service::AgmemService;
 use crate::{embedder, lock};
 
@@ -59,7 +59,7 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
 
     let idle = Duration::from_secs(cfg.idle_timeout);
     let daemon = Arc::new(cfg);
-    let (ended, mut endings) = mpsc::unbounded_channel::<()>();
+    let (ended, mut endings) = mpsc::unbounded_channel::<SessionEnd>();
     let mut attached: u32 = 0;
 
     loop {
@@ -70,16 +70,29 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
                 let (db, embedder, daemon, ended) =
                     (db.clone(), Arc::clone(&embedder), Arc::clone(&daemon), ended.clone());
                 tokio::spawn(async move {
-                    if let Err(error) = session(stream, db, embedder, &daemon).await {
-                        tracing::warn!(error = %format!("{error:#}"), "session ended badly");
-                    }
+                    let end = match session(stream, db, embedder, &daemon).await {
+                        Ok(end) => end,
+                        Err(error) => {
+                            tracing::warn!(error = %format!("{error:#}"), "session ended badly");
+                            SessionEnd::Detached
+                        }
+                    };
                     // The receiver lives as long as the loop, so this only
                     // fails once we are already shutting down.
-                    let _ = ended.send(());
+                    let _ = ended.send(end);
                 });
             }
-            Some(()) = endings.recv() => {
+            Some(end) = endings.recv() => {
                 attached = attached.saturating_sub(1);
+                if matches!(end, SessionEnd::Retiring) {
+                    // Sessions may still be attached, but they are attached
+                    // to code from a release that is no longer on disk;
+                    // cutting them loose is the fix, not the damage
+                    // (issue #60 — a stale daemon otherwise serves old
+                    // schema and scoring until its idle timeout).
+                    tracing::info!(attached, "another release attached; retiring so its binary can serve");
+                    break;
+                }
                 tracing::debug!(attached, "session detached");
             }
             () = idle_elapsed(idle, attached == 0) => {
@@ -106,14 +119,24 @@ async fn idle_elapsed(idle: Duration, nothing_attached: bool) {
     tokio::time::sleep(idle).await;
 }
 
-/// One attached session: find out who is asking, then hand rmcp the socket.
+/// How one attached session ended, as far as the accept loop cares.
+enum SessionEnd {
+    /// The ordinary way: the client went away, the daemon keeps serving.
+    Detached,
+    /// The session ran a different release; the daemon refused it and now
+    /// shuts down so that session can start a daemon from its own binary.
+    Retiring,
+}
+
+/// One attached session: find out who is asking, answer with an [`Ack`],
+/// then hand rmcp the socket.
 async fn session(
     stream: UnixStream,
     db: Db,
     embedder: Arc<dyn Embedder>,
     daemon: &Config,
-) -> anyhow::Result<()> {
-    let (read, write) = stream.into_split();
+) -> anyhow::Result<SessionEnd> {
+    let (read, mut write) = stream.into_split();
     let mut read = BufReader::new(read);
     let mut line = String::new();
     let bytes = read
@@ -123,11 +146,32 @@ async fn session(
     if bytes == 0 {
         // Connect-and-leave is how `--doctor` asks whether a daemon is here.
         tracing::debug!("a probe attached and left without a handshake");
-        return Ok(());
+        return Ok(SessionEnd::Detached);
     }
     let asked: Handshake = serde_json::from_str(line.trim())
         .context("the session handshake is not the JSON this daemon expects")?;
-    Handshake::new(daemon).accept(&asked)?;
+
+    // The ack goes over the socket either way (issue #60): a refusal that
+    // only lands in daemon.log is one the session pumps through as EOF and
+    // exits 0 on — no memory tools, no explanation.
+    let decision = Handshake::new(daemon).accept(&asked);
+    let ack = match &decision {
+        Ok(()) => Ack::accepted(),
+        Err(refusal) => Ack::refused(refusal),
+    };
+    let mut ack_line = serde_json::to_vec(&ack)?;
+    ack_line.push(b'\n');
+    write
+        .write_all(&ack_line)
+        .await
+        .context("writing the handshake ack")?;
+    if let Err(refusal) = decision {
+        if refusal.retire {
+            tracing::warn!(%refusal, "refused a session from another release");
+            return Ok(SessionEnd::Retiring);
+        }
+        return Err(refusal.into());
+    }
 
     // `main.rs` does this at startup for the in-process path (design §5.1
     // step 8). Here the connection is the startup: the daemon has never heard
@@ -153,7 +197,7 @@ async fn session(
     let running = service.serve((read, write)).await?;
     let reason = running.waiting().await?;
     tracing::info!(?reason, "session detached");
-    Ok(())
+    Ok(SessionEnd::Detached)
 }
 
 /// Keep the data dir to its owner: the socket has no password, and the

--- a/crates/agmem-server/tests/daemon.rs
+++ b/crates/agmem-server/tests/daemon.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use agmem_server::config::{Cli, Config, ToolDescriptions};
-use agmem_server::daemon::{self, Handshake};
+use agmem_server::daemon::{self, Ack, Handshake};
 use clap::Parser as _;
 use rmcp::model::{CallToolRequestParams, ProtocolVersion};
 use rmcp::service::RunningService;
@@ -100,6 +100,14 @@ impl Shared {
             .write_all(&self.handshake_with(space, tool_desc))
             .await
             .expect("send the handshake");
+        // The daemon answers the handshake before MCP starts (issue #60);
+        // the buffered reader must carry into rmcp, or bytes it read ahead
+        // would be lost.
+        let mut read = BufReader::new(read);
+        let mut ack = String::new();
+        read.read_line(&mut ack).await.expect("read the ack");
+        let ack: Ack = serde_json::from_str(&ack).expect("the ack is JSON");
+        assert!(ack.ok, "the daemon takes the session: {ack:?}");
         ().serve((read, write)).await.expect("initialize")
     }
 }
@@ -196,11 +204,14 @@ async fn a_handshake_and_a_request_in_one_write_are_both_seen() {
         .await
         .expect("both lines in one write");
 
+    let mut read = BufReader::new(read);
+    let mut ack = String::new();
+    read.read_line(&mut ack).await.expect("the ack");
+    let ack: Ack = serde_json::from_str(&ack).expect("the ack is JSON");
+    assert!(ack.ok, "{ack:?}");
+
     let mut reply = String::new();
-    BufReader::new(read)
-        .read_line(&mut reply)
-        .await
-        .expect("a reply");
+    read.read_line(&mut reply).await.expect("a reply");
     let reply: Value = serde_json::from_str(&reply).expect("the reply is JSON");
     assert_eq!(
         reply["result"]["serverInfo"]["name"],
@@ -211,7 +222,7 @@ async fn a_handshake_and_a_request_in_one_write_are_both_seen() {
 }
 
 #[tokio::test]
-async fn a_session_expecting_another_store_is_refused() {
+async fn a_session_expecting_another_store_is_refused_and_told_so() {
     let shared = Shared::start().await;
     let mut asked = Handshake::new(&config(shared.data.path(), "elsewhere"));
     asked.db_url = "surrealkv:///somewhere/else".to_owned();
@@ -221,15 +232,64 @@ async fn a_session_expecting_another_store_is_refused() {
     let (read, mut write) = shared.connect().await.into_split();
     write.write_all(&line).await.expect("send the handshake");
 
+    let mut read = BufReader::new(read);
     let mut reply = String::new();
-    let bytes = BufReader::new(read)
-        .read_line(&mut reply)
-        .await
-        .expect("read");
+    read.read_line(&mut reply).await.expect("read the ack");
+    let ack: Ack = serde_json::from_str(&reply).expect("the refusal is an ack, not a bare close");
+    assert!(!ack.ok, "{ack:?}");
+    assert!(
+        ack.error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("--no-daemon"),
+        "the refusal names a way out (issue #60): {ack:?}"
+    );
+    assert!(
+        !ack.retiring,
+        "a misconfigured session is not a reason to stop serving everyone else: {ack:?}"
+    );
+
+    reply.clear();
+    let bytes = read.read_line(&mut reply).await.expect("read");
     assert_eq!(
         bytes, 0,
-        "a daemon that cannot serve what was asked for closes, rather than \
-         serving something else: {reply:?}"
+        "after refusing, the daemon closes rather than serving something \
+         else: {reply:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_session_from_another_release_retires_the_daemon() {
+    let mut shared = Shared::start().await;
+    let mut asked = Handshake::new(&config(shared.data.path(), "upgraded"));
+    asked.release = "999.0.0".to_owned();
+    let mut line = serde_json::to_vec(&asked).expect("serialize");
+    line.push(b'\n');
+
+    let (read, mut write) = shared.connect().await.into_split();
+    write.write_all(&line).await.expect("send the handshake");
+
+    let mut reply = String::new();
+    BufReader::new(read)
+        .read_line(&mut reply)
+        .await
+        .expect("read the ack");
+    let ack: Ack = serde_json::from_str(&reply).expect("the ack is JSON");
+    assert!(!ack.ok && ack.retiring, "{ack:?}");
+
+    // Retiring is not just a word: the daemon's run loop actually returns,
+    // releasing the socket and the store lock so the refused session can
+    // start a daemon from its own binary.
+    tokio::time::timeout(Duration::from_secs(10), &mut shared.daemon)
+        .await
+        .expect("the daemon shuts down after refusing another release")
+        .expect("cleanly")
+        .expect("without error");
+    assert!(
+        !daemon::socket_path(shared.data.path())
+            .expect("socket path")
+            .exists(),
+        "the retiring daemon unlinks its socket so the fresh one can bind"
     );
 }
 


### PR DESCRIPTION
Closes #60 (Phase 5 — Hardening; corroborated by both reviewers and the 2026-08-31 incident).

Two halves, both in the daemon handshake:

- **Version staleness.** The handshake only carried `PROTOCOL_VERSION`, which moves when the wire changes — never between ordinary releases. The handshake now also carries the crate version (`RELEASE`); a session from another release gets refused with `retiring: true`, the daemon's run loop returns (releasing socket and store lock), and the client waits it out and starts a fresh daemon from its own binary — once; two retirements in a row is reported as two binaries fighting.
- **Silent refusal.** The daemon now answers every handshake with a one-line JSON ack before MCP starts. A refusal reaches the session as a non-zero exit carrying the daemon's message instead of an EOF pumped through as a clean exit 0. Meeting a pre-v3 daemon — which closes without answering — is detected and reported, naming daemon.log and the likely stale process.

Tests: retire-on-release-mismatch (asserts the daemon task actually returns and unlinks its socket), refusal-carries-its-reason ack, ack round-trip, plus the existing daemon suite updated to consume the ack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGe48K3fQ2boQnp9DRP1gL