### PR TITLE
An audit read stops paying rent into present rankings

### DIFF
--- a/crates/agmem-server/src/tools/recall.rs
+++ b/crates/agmem-server/src/tools/recall.rs
@@ -313,7 +313,11 @@ pub async fn run(service: &AgmemService, params: RecallParams) -> Result<RecallR
     let considered = ranked.len();
 
     // 3. Being recalled is what keeps a memory alive; verbatim text has no
-    //    curve to be pushed back up.
+    //    curve to be pushed back up. Historical reads don't count (issue #63):
+    //    an `as_of` or `include_invalidated` call asks what *was* believed,
+    //    and a read that mutates present ranking state answers a different
+    //    question than it was asked — the same reasoning that keeps `context`
+    //    from reinforcing on a schedule.
     let touched: Vec<MemoryId> = ranked
         .iter()
         .filter_map(|(hit, _)| match hit {
@@ -321,7 +325,9 @@ pub async fn run(service: &AgmemService, params: RecallParams) -> Result<RecallR
             StoreHit::Chunk(_) => None,
         })
         .collect();
-    reinforce(service, &touched).await;
+    if liveness == Liveness::Live {
+        reinforce(service, &touched).await;
+    }
 
     // 4. `take(k)` is silent, and a full page is the one shape that cannot be
     //    read as complete or partial from the outside. Count only when the

--- a/crates/agmem-server/tests/protocol.rs
+++ b/crates/agmem-server/tests/protocol.rs
@@ -1307,6 +1307,45 @@ async fn a_returned_memory_is_reinforced_and_a_k_past_the_ceiling_is_refused() {
 }
 
 #[tokio::test]
+async fn a_historical_read_reinforces_nothing() {
+    let agmem = Harness::start(Arc::new(NoopEmbedder)).await;
+    agmem
+        .remember(json!({ "memories": [{ "content": "The user prefers Rust" }] }))
+        .await;
+
+    // Both audit shapes return the row and leave its ranking state alone
+    // (issue #63): "what was believed at T" must not change what is believed
+    // to matter now.
+    let audit = agmem
+        .recall(json!({ "as_of": "2999-01-01T00:00:00Z" }))
+        .await;
+    assert_eq!(hits(&audit).len(), 1, "{audit}");
+    let memory = agmem.memories().await.remove(0);
+    assert_eq!(
+        (memory.strength, memory.access_count),
+        (1.0, 0),
+        "an as_of read mutates nothing"
+    );
+
+    let everything = agmem.recall(json!({ "include_invalidated": true })).await;
+    assert_eq!(hits(&everything).len(), 1, "{everything}");
+    assert_eq!(
+        agmem.memories().await.remove(0).access_count,
+        0,
+        "an include_invalidated read mutates nothing"
+    );
+
+    let present = agmem.recall(json!({})).await;
+    assert_eq!(hits(&present).len(), 1, "{present}");
+    assert_eq!(
+        agmem.memories().await.remove(0).access_count,
+        1,
+        "a live-present read still reinforces"
+    );
+    agmem.shutdown().await;
+}
+
+#[tokio::test]
 async fn context_lays_out_the_sections_in_a_fixed_order_and_reinforces_nothing() {
     let agmem = Harness::start(Arc::new(NoopEmbedder)).await;
     let written = agmem


### PR DESCRIPTION
Closes #63 (Phase 5 — Hardening; verifier-confirmed: the reinforce call site had no branch on `as_of`/`include_invalidated`, and the store-side REINFORCE update has no liveness clause, so closed rows fetched through audit reads were mutated).

`recall` now reinforces only when the read is live-present (`Liveness::Live`); `as_of` and `include_invalidated` reads leave strength, access_count and last_accessed untouched — same reasoning `context` has always used for not reinforcing scheduled reads.

Test: `a_historical_read_reinforces_nothing` covers both audit shapes and confirms the live-present read still reinforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGe48K3fQ2boQnp9DRP1gL