### PR TITLE
The dup gate stops seeing the dead, and a supersede stops rewriting a close

### DIFF
--- a/crates/agmem-server/src/tools/reflect.rs
+++ b/crates/agmem-server/src/tools/reflect.rs
@@ -103,6 +103,10 @@ pub struct ReflectResult {
     /// The ids of the claims closed by a `supersedes` in this call.
     pub superseded: Vec<String>,
 
+    /// `supersedes` targets that were already closed when this call arrived —
+    /// skipped and reported, never rewritten, exactly as `remember` does.
+    pub already_closed: Vec<super::remember::AlreadyClosed>,
+
     /// What to do about a write that did not happen, when there is something
     /// worth doing.
     ///
@@ -201,6 +205,7 @@ pub async fn run(
                     derived_from: Vec::new(),
                     related: Vec::new(),
                     superseded: Vec::new(),
+                    already_closed: Vec::new(),
                     note,
                 });
             }
@@ -253,6 +258,15 @@ pub async fn run(
         },
         related: if created { related } else { Vec::new() },
         superseded: outcome.superseded.iter().map(ToString::to_string).collect(),
+        already_closed: outcome
+            .already_closed
+            .into_iter()
+            .map(|closed| super::remember::AlreadyClosed {
+                id: closed.id.to_string(),
+                reason: closed.reason,
+                superseded_by: closed.by.map(|id| id.to_string()),
+            })
+            .collect(),
         note,
     })
 }

--- a/crates/agmem-server/src/tools/remember.rs
+++ b/crates/agmem-server/src/tools/remember.rs
@@ -135,8 +135,31 @@ pub struct RememberResult {
     /// Ids of the memories closed by a `supersedes` in this call.
     pub superseded: Vec<String>,
 
+    /// `supersedes` targets that were already closed when this call arrived.
+    ///
+    /// Nothing was rewritten for these — a supersede never rewrites another
+    /// close, so each keeps its original date, reason and successor, named
+    /// here. Usually this means the correction already happened (a retried
+    /// call, or another session got there first); check `superseded_by`
+    /// before assuming anything is still open.
+    pub already_closed: Vec<AlreadyClosed>,
+
     /// Id of the episode, whether it was written now or already stored.
     pub episode: Option<String>,
+}
+
+/// A `supersedes` target whose close predates this call.
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AlreadyClosed {
+    /// The id that was sent in `supersedes`.
+    pub id: String,
+
+    /// Why it was already closed: `superseded`, `forgotten` or `expired`.
+    pub reason: Option<String>,
+
+    /// The memory that replaced it, when the reason is a supersession — the
+    /// live claim is there (or further down its chain), not here.
+    pub superseded_by: Option<String>,
 }
 
 /// A live claim near one that was just stored.
@@ -295,6 +318,7 @@ pub async fn run(
             duplicates,
             related: Vec::new(),
             superseded: Vec::new(),
+            already_closed: Vec::new(),
             episode: None,
         });
     }
@@ -348,6 +372,15 @@ pub async fn run(
         duplicates,
         related,
         superseded: outcome.superseded.iter().map(ToString::to_string).collect(),
+        already_closed: outcome
+            .already_closed
+            .into_iter()
+            .map(|closed| AlreadyClosed {
+                id: closed.id.to_string(),
+                reason: closed.reason,
+                superseded_by: closed.by.map(|id| id.to_string()),
+            })
+            .collect(),
         episode: outcome.episode.map(|written| written.into_id().to_string()),
     })
 }

--- a/crates/agmem-server/tests/protocol.rs
+++ b/crates/agmem-server/tests/protocol.rs
@@ -726,6 +726,70 @@ async fn a_correction_closes_the_memory_it_supersedes() {
     agmem.shutdown().await;
 }
 
+/// Issue #62: a supersede whose target is already closed is a report, not a
+/// rewrite — the first close keeps its date and successor, and the caller is
+/// told what stands instead of reading silence as a landed closure.
+#[tokio::test]
+async fn a_second_correction_reports_the_close_that_stands() {
+    let agmem = Harness::start(Arc::new(KeywordEmbedder)).await;
+    let first = agmem
+        .remember(json!({ "memories": [{ "content": "The deploy target is Fly.io" }] }))
+        .await;
+    let old = ids(&first["created"])[0].to_owned();
+    let corrected = agmem
+        .remember(json!({
+            "memories": [{ "content": "The deploy target moved to Railway", "supersedes": [old] }]
+        }))
+        .await;
+    let successor = ids(&corrected["created"])[0].to_owned();
+
+    // The same target again — a retried call, or a second session racing.
+    let raced = agmem
+        .remember(json!({
+            "memories": [{ "content": "The deploy target moved to Render", "supersedes": [old] }]
+        }))
+        .await;
+
+    assert_eq!(
+        ids(&raced["created"]).len(),
+        1,
+        "the new claim itself lands: {raced}"
+    );
+    assert!(
+        ids(&raced["superseded"]).is_empty(),
+        "but it closed nothing: {raced}"
+    );
+    let skipped = raced["already_closed"]
+        .as_array()
+        .expect("already_closed is a list");
+    assert_eq!(skipped.len(), 1, "the skipped target is reported: {raced}");
+    assert_eq!(
+        (
+            skipped[0]["id"].as_str(),
+            skipped[0]["reason"].as_str(),
+            skipped[0]["superseded_by"].as_str()
+        ),
+        (
+            Some(old.as_str()),
+            Some("superseded"),
+            Some(successor.as_str())
+        ),
+        "naming the close that stands: {raced}"
+    );
+
+    let memories = agmem.memories().await;
+    let closed = memories
+        .iter()
+        .find(|memory| memory.id.as_str() == old)
+        .expect("the closed memory is still readable");
+    assert_eq!(
+        closed.superseded_by.as_ref().map(|id| id.as_str()),
+        Some(successor.as_str()),
+        "the first close keeps its successor"
+    );
+    agmem.shutdown().await;
+}
+
 /// Issue #57: a word-for-word re-send with `supersedes` used to block at the
 /// exact-hash gate with the supersede riding on the blocked entry — so the
 /// retry the description asks for ("re-send yours with the id in supersedes")

--- a/crates/agmem-server/tests/snapshots/protocol__list_tools.snap
+++ b/crates/agmem-server/tests/snapshots/protocol__list_tools.snap
@@ -1476,6 +1476,33 @@ expression: "&tools.tools"
     },
     "outputSchema": {
       "$defs": {
+        "AlreadyClosed": {
+          "description": "A `supersedes` target whose close predates this call.",
+          "properties": {
+            "id": {
+              "description": "The id that was sent in `supersedes`.",
+              "type": "string"
+            },
+            "reason": {
+              "description": "Why it was already closed: `superseded`, `forgotten` or `expired`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "superseded_by": {
+              "description": "The memory that replaced it, when the reason is a supersession — the\nlive claim is there (or further down its chain), not here.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
         "Related": {
           "description": "A live claim near the insight that was just stored.",
           "properties": {
@@ -1503,6 +1530,13 @@ expression: "&tools.tools"
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "already_closed": {
+          "description": "`supersedes` targets that were already closed when this call arrived —\nskipped and reported, never rewritten, exactly as `remember` does.",
+          "items": {
+            "$ref": "#/$defs/AlreadyClosed"
+          },
+          "type": "array"
+        },
         "content": {
           "description": "What is stored under `id` — your wording when it was written, the\nexisting claim's when it was not.",
           "type": "string"
@@ -1550,7 +1584,8 @@ expression: "&tools.tools"
         "content",
         "derived_from",
         "related",
-        "superseded"
+        "superseded",
+        "already_closed"
       ],
       "type": "object"
     },
@@ -1744,6 +1779,33 @@ expression: "&tools.tools"
     },
     "outputSchema": {
       "$defs": {
+        "AlreadyClosed": {
+          "description": "A `supersedes` target whose close predates this call.",
+          "properties": {
+            "id": {
+              "description": "The id that was sent in `supersedes`.",
+              "type": "string"
+            },
+            "reason": {
+              "description": "Why it was already closed: `superseded`, `forgotten` or `expired`.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "superseded_by": {
+              "description": "The memory that replaced it, when the reason is a supersession — the\nlive claim is there (or further down its chain), not here.",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
         "Duplicate": {
           "description": "A claim that was already in the store.",
           "properties": {
@@ -1809,6 +1871,13 @@ expression: "&tools.tools"
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "already_closed": {
+          "description": "`supersedes` targets that were already closed when this call arrived.\n\nNothing was rewritten for these — a supersede never rewrites another\nclose, so each keeps its original date, reason and successor, named\nhere. Usually this means the correction already happened (a retried\ncall, or another session got there first); check `superseded_by`\nbefore assuming anything is still open.",
+          "items": {
+            "$ref": "#/$defs/AlreadyClosed"
+          },
+          "type": "array"
+        },
         "created": {
           "description": "Ids of the memories stored, in the order they were sent, skipping the\npositions reported in `duplicates`.",
           "items": {
@@ -1849,7 +1918,8 @@ expression: "&tools.tools"
         "created",
         "duplicates",
         "related",
-        "superseded"
+        "superseded",
+        "already_closed"
       ],
       "type": "object"
     },

--- a/crates/agmem-store/src/error.rs
+++ b/crates/agmem-store/src/error.rs
@@ -19,6 +19,16 @@ pub enum StoreError {
     #[error("episode {id} does not exist in space {space}")]
     UnknownEpisode { space: SpaceName, id: EpisodeId },
 
+    /// A supersede named a target that is already closed. The close that
+    /// stands is the original one (issue #62); `by` names the successor when
+    /// the reason is a supersession.
+    #[error("memory {id} is already closed ({reason}); its close stands")]
+    AlreadyClosed {
+        id: MemoryId,
+        reason: String,
+        by: Option<MemoryId>,
+    },
+
     /// A row came back in a shape the schema cannot have minted — a record id
     /// that is not a ULID, or an enum spelling this agmem does not know.
     #[error("malformed row from the store: {0}")]

--- a/crates/agmem-store/src/migrate.rs
+++ b/crates/agmem-store/src/migrate.rs
@@ -22,6 +22,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("migrations/v2_derived_from.surql"),
     include_str!("migrations/v3_supersedes_list.surql"),
     include_str!("migrations/v4_chunk_occurred_at.surql"),
+    include_str!("migrations/v5_live_dedup.surql"),
 ];
 
 /// The schema version this binary produces.

--- a/crates/agmem-store/src/migrations/v5_live_dedup.surql
+++ b/crates/agmem-store/src/migrations/v5_live_dedup.surql
@@ -1,0 +1,33 @@
+-- Schema v5 — the exact-duplicate gate stops seeing the dead (issue #61).
+--
+-- `mem_hash` was UNIQUE over `(space, content_hash)` with no regard for
+-- liveness, which made two promises at once and could only keep one:
+-- supersession says a closed claim stays on disk, and the index says its
+-- hash may never appear again. So content that was superseded or forgotten
+-- could never be re-asserted — the dead row answered as the duplicate, and
+-- the documented retry ("re-send with the id in `supersedes`") then closed
+-- live rows in favour of a dead one.
+--
+-- The index cannot simply gain a liveness clause — an index has no WHERE —
+-- and it cannot move to `(space, content_hash, invalid_at)` either, because
+-- a unique index skips rows where a column is NONE (SQL NULL semantics), so
+-- two *live* duplicates would both land and the race protection the old
+-- index provided (issue #64) would silently vanish. Hence `dedup_key`: a
+-- computed field that reads 'live' while `invalid_at` is NONE and the close
+-- time once it is set. One live row per `(space, content_hash)` stays
+-- enforced — every live row shares the 'live' key — while closed rows
+-- coexist, each keyed by when it was closed. VALUE recomputes on every
+-- write, so a supersede or forget moves the row out of the 'live' slot in
+-- the same statement that closes it, and nothing can drift.
+--
+-- The bare UPDATE is the backfill: writing a row is what makes a VALUE
+-- field compute, and it must run before the new index builds so no row
+-- enters it keyless. Two closes of the same content at the same instant
+-- would collide in the new index; closes take their boundary from distinct
+-- successors' `valid_from`, so that needs two writers landing the same
+-- nanosecond — the transaction abort it would cause is acceptable where
+-- silently resurrecting history is not.
+DEFINE FIELD IF NOT EXISTS dedup_key ON memory TYPE string VALUE <string>(invalid_at ?? 'live');
+UPDATE memory;
+REMOVE INDEX IF EXISTS mem_hash ON TABLE memory;
+DEFINE INDEX IF NOT EXISTS mem_hash_live ON memory COLUMNS space, content_hash, dedup_key UNIQUE;

--- a/crates/agmem-store/src/queries/write.rs
+++ b/crates/agmem-store/src/queries/write.rs
@@ -85,27 +85,44 @@ pub(crate) fn insert_batch(memories: &[MemoryShape<'_>], with_episode: bool) -> 
                 .map(|old| format!("memory:{old}"))
                 .collect::<Vec<_>>()
                 .join(", ");
+            // `invalid_at IS NONE` is the guard `FORGET_SOFT` has always had
+            // (issue #62): a supersede must never rewrite another close. The
+            // caller filtered already-closed targets out before this query
+            // was built, so a shortfall here means a target was closed or
+            // deleted by another writer between that check and this
+            // transaction — abort rather than half-land.
             (
                 format!(
                     "LET $sup{index} = (UPDATE $old{index} SET superseded_by = $new{index}.id,
-                         invalid_at = $new{index}.valid_from, invalid_reason = 'superseded');
+                         invalid_at = $new{index}.valid_from, invalid_reason = 'superseded'
+                         WHERE invalid_at IS NONE);
                      IF array::len($sup{index}) != {count} {{
-                         THROW 'supersedes targets {named} — one of them does not exist'
+                         THROW 'supersedes targets {named} — one of them is gone or was \
+                          closed by another writer'
                      }};"
                 ),
                 format!(
                     "LET $keep{index} = array::complement($old{index}, [$dup{index}]);
                      LET $sup{index} = (UPDATE $keep{index} SET superseded_by = $dup{index},
-                         invalid_at = $row{index}.valid_from, invalid_reason = 'superseded');
+                         invalid_at = $row{index}.valid_from, invalid_reason = 'superseded'
+                         WHERE invalid_at IS NONE);
                      IF array::len($sup{index}) != array::len($keep{index}) {{
-                         THROW 'supersedes targets {named} — one of them does not exist'
+                         THROW 'supersedes targets {named} — one of them is gone or was \
+                          closed by another writer'
                      }};"
                 ),
             )
         };
+        // Live rows only (issue #61): a superseded or forgotten claim is not
+        // a duplicate of a new assertion of the same words — it is history,
+        // and blocking on it made closed content unrepeatable forever. The
+        // v5 index (`space, content_hash, dedup_key`) scopes uniqueness the
+        // same way, so the gate and the index agree on what "already stored"
+        // means.
         builder.push(format!(
             "LET $dup{index} = (SELECT VALUE id FROM memory
-                 WHERE space = $space AND content_hash = $hash{index} LIMIT 1)[0]"
+                 WHERE space = $space AND content_hash = $hash{index}
+                   AND invalid_at IS NONE LIMIT 1)[0]"
         ));
         builder.push(format!(
             "LET $res{index} = IF $dup{index} IS NOT NONE {{
@@ -144,13 +161,25 @@ pub(crate) const EXISTING_MEMORIES: &str =
 
 /// Close `$old` in favour of `$new`, taking the boundary from the successor so
 /// the history chain has no gap and no overlap.
+///
+/// `invalid_at IS NONE` for the same reason `FORGET_SOFT` carries it (issue
+/// #62): a close that stands keeps its own date, reason and successor. The
+/// caller checks liveness first and reports the no-op; the guard here is the
+/// backstop against a close landing between that check and this transaction.
 pub(crate) const SUPERSEDE: &str = "BEGIN;
 LET $valid_from = (SELECT VALUE valid_from FROM $new)[0];
 IF $valid_from IS NONE { THROW 'the superseding memory does not exist' };
 LET $done = (UPDATE $old SET superseded_by = $new,
-    invalid_at = $valid_from, invalid_reason = 'superseded');
-IF array::len($done) = 0 { THROW 'the superseded memory does not exist' };
+    invalid_at = $valid_from, invalid_reason = 'superseded'
+    WHERE invalid_at IS NONE);
+IF array::len($done) = 0 { THROW 'the superseded memory is gone or already closed' };
 COMMIT;";
+
+/// Which of `$ids` in `$space` are already closed, and what closed them —
+/// what a supersede must skip (issue #62) and report rather than rewrite.
+pub(crate) const CLOSED_MEMORIES: &str = "SELECT record::id(id) AS id, invalid_reason,
+     IF superseded_by IS NONE { NONE } ELSE { record::id(superseded_by) } AS superseded_by
+     FROM memory WHERE space = $space AND id IN $ids AND invalid_at IS NOT NONE";
 
 /// Close every live memory in `$memories` that one of `$spaces` holds
 /// (design §5.4).

--- a/crates/agmem-store/src/repo/mod.rs
+++ b/crates/agmem-store/src/repo/mod.rs
@@ -17,8 +17,8 @@ pub use read::{
     reinforce, search_hybrid, spaces, stale_contexts, stats,
 };
 pub use write::{
-    Batch, BatchOutcome, Forget, Forgotten, NewChunk, NewEpisode, NewMemory, Written, ensure_space,
-    forget, insert_batch, prune_expired, supersede,
+    AlreadyClosed, Batch, BatchOutcome, Forget, Forgotten, NewChunk, NewEpisode, NewMemory,
+    Written, ensure_space, forget, insert_batch, prune_expired, supersede,
 };
 
 use agmem_core::{MemoryId, SpaceName};

--- a/crates/agmem-store/src/repo/write.rs
+++ b/crates/agmem-store/src/repo/write.rs
@@ -171,6 +171,26 @@ pub struct BatchOutcome {
     /// The memories this batch closed — the `supersedes` targets of the
     /// memories that were actually created.
     pub superseded: Vec<MemoryId>,
+    /// `supersedes` targets that were already closed when the batch arrived
+    /// (issue #62). Nothing was rewritten for these — the close that stands
+    /// is the one reported here.
+    pub already_closed: Vec<AlreadyClosed>,
+}
+
+/// A `supersedes` target that was closed before this call reached it.
+///
+/// A supersede never rewrites another close (issue #62, the same principle
+/// design §5.4 states for `forget`), so the target kept its own date, reason
+/// and successor — and the caller is told, because a silently dropped closure
+/// reads as a landed one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlreadyClosed {
+    /// The target that was already closed.
+    pub id: MemoryId,
+    /// Why it closed: `superseded`, `forgotten` or `expired`.
+    pub reason: Option<String>,
+    /// The memory that replaced it, when the reason is a supersession.
+    pub by: Option<MemoryId>,
 }
 
 /// Write a whole `remember` call in one transaction.
@@ -190,7 +210,7 @@ pub async fn insert_batch(db: &Db, batch: Batch) -> Result<BatchOutcome, StoreEr
     let Batch {
         space,
         episode,
-        memories,
+        mut memories,
     } = batch;
 
     let targets: Vec<&MemoryId> = memories
@@ -198,6 +218,19 @@ pub async fn insert_batch(db: &Db, batch: Batch) -> Result<BatchOutcome, StoreEr
         .flat_map(|memory| memory.supersedes.iter())
         .collect();
     ensure_memories_exist(db, &space, &targets).await?;
+
+    // Already-closed targets are skipped and reported, never rewritten
+    // (issue #62): the transaction's UPDATE only ever sees live ids, and its
+    // own `invalid_at IS NONE` guard covers the race between this check and
+    // the commit.
+    let already_closed = closed_memories(db, &space, &targets).await?;
+    if !already_closed.is_empty() {
+        for memory in &mut memories {
+            memory
+                .supersedes
+                .retain(|id| !already_closed.iter().any(|closed| closed.id == *id));
+        }
+    }
 
     let shapes: Vec<MemoryShape<'_>> = memories
         .iter()
@@ -306,7 +339,36 @@ pub async fn insert_batch(db: &Db, batch: Batch) -> Result<BatchOutcome, StoreEr
             .transpose()?,
         memories: outcomes,
         superseded,
+        already_closed,
     })
+}
+
+/// Which of `ids` in `space` are already closed, and what closed them.
+async fn closed_memories(
+    db: &Db,
+    space: &SpaceName,
+    ids: &[&MemoryId],
+) -> Result<Vec<AlreadyClosed>, StoreError> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let refs: Vec<RecordId> = ids.iter().copied().map(types::memory_ref).collect();
+    let mut resp = checked(
+        db.query(queries::CLOSED_MEMORIES)
+            .bind(("space", types::space_str(space)))
+            .bind(("ids", refs))
+            .await?,
+    )?;
+    let rows: Vec<types::ClosedRow> = resp.take(0)?;
+    rows.into_iter()
+        .map(|row| {
+            Ok(AlreadyClosed {
+                id: MemoryId::new(row.id)?,
+                reason: row.invalid_reason,
+                by: row.superseded_by.map(MemoryId::new).transpose()?,
+            })
+        })
+        .collect()
 }
 
 /// Register `space` in the space registry unless it is already there.
@@ -333,7 +395,9 @@ pub async fn ensure_space(db: &Db, space: &SpaceName) -> Result<(), StoreError> 
 /// backwards from a timestamp lands on exactly one live claim.
 ///
 /// # Errors
-/// [`StoreError::UnknownMemory`] when either id is not in `space`.
+/// [`StoreError::UnknownMemory`] when either id is not in `space`, and
+/// [`StoreError::AlreadyClosed`] when `old` is closed — a supersede never
+/// rewrites another close (issue #62), and the error names what stands.
 pub async fn supersede(
     db: &Db,
     space: &SpaceName,
@@ -341,6 +405,13 @@ pub async fn supersede(
     new: &MemoryId,
 ) -> Result<(), StoreError> {
     ensure_memories_exist(db, space, &[old, new]).await?;
+    if let Some(closed) = closed_memories(db, space, &[old]).await?.pop() {
+        return Err(StoreError::AlreadyClosed {
+            id: closed.id,
+            reason: closed.reason.unwrap_or_else(|| "closed".to_owned()),
+            by: closed.by,
+        });
+    }
     checked(
         db.query(queries::SUPERSEDE)
             .bind(("old", types::memory_ref(old)))

--- a/crates/agmem-store/src/types.rs
+++ b/crates/agmem-store/src/types.rs
@@ -159,6 +159,15 @@ pub(crate) struct BatchRow {
     pub(crate) memories: Vec<WriteRow>,
 }
 
+/// One already-closed `supersedes` target (issue #62): what closed it, so the
+/// caller can report the no-op instead of rewriting the close.
+#[derive(SurrealValue)]
+pub(crate) struct ClosedRow {
+    pub(crate) id: String,
+    pub(crate) invalid_reason: Option<String>,
+    pub(crate) superseded_by: Option<String>,
+}
+
 /// Every `memory` column a read projects, minus `embedding`.
 ///
 /// `source` arrives flattened into two scalars because its `ref` is a record

--- a/crates/agmem-store/tests/migrate.rs
+++ b/crates/agmem-store/tests/migrate.rs
@@ -140,6 +140,28 @@ async fn a_correction_written_before_v3_reads_as_a_one_element_list() {
         .expect("the chain still walks");
     assert_eq!(chain.len(), 2, "both links, in one walk");
     assert!(chain[0].supersedes.is_empty(), "the oldest closed nothing");
+
+    // v5's backfill keyed that closed row by its close time, so its wording
+    // is free to be asserted again on the upgraded store (issue #61) — the
+    // proof that the migration reached rows written before it existed.
+    let outcome = repo::insert_batch(
+        &conn,
+        repo::Batch {
+            space,
+            episode: None,
+            memories: vec![repo::NewMemory::new(
+                agmem_core::Kind::Fact,
+                "the user prefers Python",
+            )],
+        },
+    )
+    .await
+    .expect("re-assert closed pre-v5 content");
+    assert!(
+        outcome.memories[0].is_created(),
+        "a row closed before the upgrade does not answer as the duplicate: {:?}",
+        outcome.memories
+    );
 }
 
 /// Chunks written before v4 carry no `occurred_at` — the column arrives with

--- a/crates/agmem-store/tests/writes.rs
+++ b/crates/agmem-store/tests/writes.rs
@@ -738,6 +738,184 @@ async fn an_exact_duplicate_with_supersedes_closes_targets_in_favour_of_the_live
     );
 }
 
+#[tokio::test]
+async fn closed_content_can_be_asserted_again() {
+    let db = store().await;
+    let first = repo::insert_batch(
+        &db,
+        batch(vec![NewMemory::new(
+            Kind::Fact,
+            "the deploy target is Fly.io",
+        )]),
+    )
+    .await
+    .expect("write")
+    .memories
+    .remove(0)
+    .into_id();
+
+    let mut correction = NewMemory::new(Kind::Fact, "the deploy target is Railway");
+    correction.supersedes = vec![first.clone()];
+    let second = repo::insert_batch(&db, batch(vec![correction]))
+        .await
+        .expect("supersede")
+        .memories
+        .remove(0)
+        .into_id();
+
+    // The world changed back. Before v5 the dead first row answered the
+    // exact-hash gate forever, so this wording could never be stored again
+    // (issue #61).
+    let mut outcome = repo::insert_batch(
+        &db,
+        batch(vec![NewMemory::new(
+            Kind::Fact,
+            "the deploy target is Fly.io",
+        )]),
+    )
+    .await
+    .expect("re-assert");
+    let third = match outcome.memories.remove(0) {
+        Written::Created(id) => id,
+        Written::Duplicate(id) => panic!("a dead row answered as the duplicate: {id}"),
+    };
+    assert_ne!(third, first, "a fresh row with its own validity window");
+
+    let rows = all_memories(&db, &space()).await;
+    let row = |id: &MemoryId| {
+        rows.iter()
+            .find(|row| row.id == *id)
+            .expect("the row exists")
+    };
+    assert_eq!(
+        (
+            row(&first).invalid_reason,
+            row(&first).superseded_by.as_ref()
+        ),
+        (Some(InvalidReason::Superseded), Some(&second)),
+        "history is untouched: the first close stands exactly as it was"
+    );
+    assert_eq!(row(&third).invalid_reason, None, "the re-assertion is live");
+
+    // The same door opens after a forget: closed is closed, whatever closed it.
+    repo::forget(
+        &db,
+        &Forget {
+            spaces: vec![space()],
+            memories: vec![third.clone()],
+            episodes: Vec::new(),
+            purge: false,
+        },
+    )
+    .await
+    .expect("forget");
+    let again = repo::insert_batch(
+        &db,
+        batch(vec![NewMemory::new(
+            Kind::Fact,
+            "the deploy target is Fly.io",
+        )]),
+    )
+    .await
+    .expect("re-assert after forget")
+    .memories
+    .remove(0);
+    assert!(again.is_created(), "a forgotten claim can be re-learned");
+}
+
+#[tokio::test]
+async fn a_supersede_never_rewrites_another_close() {
+    let db = store().await;
+    let old = repo::insert_batch(
+        &db,
+        batch(vec![NewMemory::new(Kind::Fact, "the user prefers Python")]),
+    )
+    .await
+    .expect("write")
+    .memories
+    .remove(0)
+    .into_id();
+
+    let mut first_fix = NewMemory::new(Kind::Fact, "the user prefers Rust");
+    first_fix.supersedes = vec![old.clone()];
+    let successor = repo::insert_batch(&db, batch(vec![first_fix]))
+        .await
+        .expect("close old")
+        .memories
+        .remove(0)
+        .into_id();
+
+    // A second correction names the same target — a retried call, or another
+    // session racing this one. The close that stands is the first one; this
+    // call is told so instead of silently rewriting it (issue #62).
+    let mut second_fix = NewMemory::new(Kind::Fact, "the user prefers Go");
+    second_fix.supersedes = vec![old.clone()];
+    let outcome = repo::insert_batch(&db, batch(vec![second_fix]))
+        .await
+        .expect("the write itself lands");
+
+    assert!(outcome.memories[0].is_created(), "the new claim is stored");
+    assert!(
+        outcome.superseded.is_empty(),
+        "nothing was closed by this call: {:?}",
+        outcome.superseded
+    );
+    assert_eq!(
+        outcome.already_closed.len(),
+        1,
+        "the skipped target is reported, not dropped: {:?}",
+        outcome.already_closed
+    );
+    let skipped = &outcome.already_closed[0];
+    assert_eq!(
+        (&skipped.id, skipped.reason.as_deref(), skipped.by.as_ref()),
+        (&old, Some("superseded"), Some(&successor)),
+        "naming the close that stands"
+    );
+
+    let rows = all_memories(&db, &space()).await;
+    let closed = rows.iter().find(|row| row.id == old).expect("the old row");
+    assert_eq!(
+        closed.superseded_by.as_ref(),
+        Some(&successor),
+        "the first close keeps its successor — an as_of read of that window \
+         must find exactly one live claim"
+    );
+}
+
+#[tokio::test]
+async fn a_standalone_supersede_refuses_a_closed_target() {
+    let db = store().await;
+    let ids: Vec<MemoryId> = repo::insert_batch(
+        &db,
+        batch(vec![
+            NewMemory::new(Kind::Fact, "the user prefers Python"),
+            NewMemory::new(Kind::Fact, "the user prefers Rust"),
+            NewMemory::new(Kind::Fact, "the user prefers Go"),
+        ]),
+    )
+    .await
+    .expect("write")
+    .memories
+    .into_iter()
+    .map(Written::into_id)
+    .collect();
+
+    repo::supersede(&db, &space(), &ids[0], &ids[1])
+        .await
+        .expect("the first close lands");
+    let error = repo::supersede(&db, &space(), &ids[0], &ids[2])
+        .await
+        .expect_err("the second must not rewrite it");
+    assert!(
+        matches!(
+            &error,
+            StoreError::AlreadyClosed { id, by: Some(by), .. } if *id == ids[0] && *by == ids[1]
+        ),
+        "{error:?} names the close that stands"
+    );
+}
+
 /// Backdate a row's last use and set the strength a few recalls would have
 /// left it with — the two inputs to the decay curve, and the only two no write
 /// API sets directly.


### PR DESCRIPTION
Closes #61 and #62 (Phase 5 — Hardening; both verifier-confirmed before fixing).

**#61 — exact-hash gate ignores liveness.** The gate matched `(space, content_hash)` over all rows, so superseded/forgotten content could never be re-asserted, and the documented retry could close live rows in favour of a dead one (supersession cycles with zero live claims). The unique `mem_hash` index made a `WHERE` fix impossible on its own — and indexing `invalid_at` directly doesn't work either, because a unique index skips NONE columns (verified against SurrealDB 3.2.3), which would have silently dropped the concurrent-duplicate protection #64 relies on. Schema **v5** adds a computed `dedup_key` (`invalid_at ?? 'live'`, recomputed on every write) and rescopes the index to `(space, content_hash, dedup_key)`: one live row per hash stays enforced, closed rows coexist as history. The gate now selects live rows only.

**#62 — supersede rewrites another close.** Both supersede UPDATEs (batch fragment and standalone) lacked the `invalid_at IS NONE` guard `FORGET_SOFT` has always had. Now: already-closed targets are detected before the transaction, filtered out of the UPDATE, and reported — `remember`/`reflect` results gain `already_closed` (id, reason, `superseded_by`), and the standalone `repo::supersede` returns a new `StoreError::AlreadyClosed`. The in-transaction guard remains as the race backstop.

Tests: `closed_content_can_be_asserted_again` (supersede *and* forget paths, history untouched), `a_supersede_never_rewrites_another_close`, `a_standalone_supersede_refuses_a_closed_target`, and protocol-level `a_second_correction_reports_the_close_that_stands`. The `list_tools` insta snapshot is re-recorded for the new output field (output schema only — no tool *description* wording changed, so no desc-eval run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGe48K3fQ2boQnp9DRP1gL