### PR TITLE
The space vocabulary stops meaning different things on read and write

### DIFF
--- a/crates/agmem-server/src/tools/mod.rs
+++ b/crates/agmem-server/src/tools/mod.rs
@@ -143,22 +143,37 @@ pub(crate) async fn embed_query(
 
 /// The space a write lands in, registered if it is a new one.
 ///
+/// The read side's keywords resolve here too (issue #65): `current` is the
+/// configured space and `user` the reserved one, exactly as [`spaces`] reads
+/// them — before this, `remember(space: "current")` created a literal space
+/// *named* `current`, which no future read with the same word would ever look
+/// in. `all` is refused: a write lands in one space, and "all of them" is not
+/// one.
+///
 /// Startup registers the configured space (design §5.1 step 8); a call that
 /// names another one registers it here, so `inspect` can list every space that
 /// actually holds something.
 ///
 /// # Errors
-/// [`ErrorData`] with `INVALID_PARAMS` for a name that is not a valid slug.
+/// [`ErrorData`] with `INVALID_PARAMS` for `all`, or a name that is not a
+/// valid slug.
 pub(crate) async fn resolve_space(
     service: &AgmemService,
     requested: Option<&str>,
 ) -> Result<SpaceName, ErrorData> {
-    let Some(requested) = requested else {
-        return Ok(service.config().space.clone());
+    let space = match requested {
+        None | Some("current") => return Ok(service.config().space.clone()),
+        Some("user") => SpaceName::user(),
+        Some("all") => {
+            return Err(invalid(
+                "a write lands in one space; `all` is read-only vocabulary. Name the \
+                 space, or leave it unset for the current one.",
+            ));
+        }
+        Some(name) => name
+            .parse()
+            .map_err(|error| invalid(format!("space: {error}")))?,
     };
-    let space: SpaceName = requested
-        .parse()
-        .map_err(|error| invalid(format!("space: {error}")))?;
     if space != service.config().space {
         repo::ensure_space(service.db(), &space)
             .await

--- a/crates/agmem-server/tests/protocol.rs
+++ b/crates/agmem-server/tests/protocol.rs
@@ -790,6 +790,64 @@ async fn a_second_correction_reports_the_close_that_stands() {
     agmem.shutdown().await;
 }
 
+/// Issue #65: the read side's space vocabulary works on writes too. Before
+/// this, `remember(space: "current")` created a literal space *named*
+/// `current` — real rows, unreachable by every future read that says the
+/// same word.
+#[tokio::test]
+async fn write_side_space_keywords_resolve_instead_of_becoming_slugs() {
+    let agmem = Harness::start(Arc::new(NoopEmbedder)).await;
+
+    agmem
+        .remember(json!({
+            "space": "current",
+            "memories": [{ "content": "the keyword lands in the configured space" }]
+        }))
+        .await;
+    let rows = agmem.memories().await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].space.as_str(),
+        "default",
+        "`current` is vocabulary, not a slug"
+    );
+
+    agmem
+        .remember(json!({
+            "space": "user",
+            "memories": [{ "content": "a fact that follows the person" }]
+        }))
+        .await;
+    let found = agmem.recall(json!({ "space": "user" })).await;
+    assert_eq!(
+        hits(&found).len(),
+        1,
+        "the write went where the read looks: {found}"
+    );
+
+    let refused = agmem
+        .call(
+            "remember",
+            json!({ "space": "all", "memories": [{ "content": "everywhere at once" }] }),
+        )
+        .await
+        .expect_err("a write into `all` is not a scope");
+    assert!(
+        matches!(&refused, ServiceError::McpError(data)
+            if data.code == ErrorCode::INVALID_PARAMS && data.message.contains("read-only")),
+        "{refused}"
+    );
+
+    let registry = repo::spaces(&agmem.db).await.expect("spaces");
+    assert!(
+        !registry
+            .iter()
+            .any(|space| matches!(space.as_str(), "current" | "all")),
+        "no keyword ever becomes a literal space: {registry:?}"
+    );
+    agmem.shutdown().await;
+}
+
 /// Issue #57: a word-for-word re-send with `supersedes` used to block at the
 /// exact-hash gate with the supersede riding on the blocked entry — so the
 /// retry the description asks for ("re-send yours with the id in supersedes")


### PR DESCRIPTION
Closes #65 (Phase 5 — Hardening; verifier-confirmed: `resolve_space` literal-parsed while `spaces()` resolved keywords, and `SpaceName` accepts `current`/`all`/`user` as valid slugs — remember/reflect were the only two tools on the literal path).

`resolve_space` (the single write-side resolver, shared by `remember` and `reflect`) now maps `current` → the configured space, `user` → the reserved space, and refuses `all` with `INVALID_PARAMS` naming it read-only vocabulary. No tool *description* wording changed (only behavior + a doc comment), so no desc-eval run.

Test: `write_side_space_keywords_resolve_instead_of_becoming_slugs` — keyword lands in the configured space, `user` write is visible to a `user` read, `all` refused, and the registry never gains a literal keyword space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGe48K3fQ2boQnp9DRP1gL