### PR TITLE
Losing a write race becomes the duplicate report it always meant

### DIFF
--- a/crates/agmem-store/src/repo/write.rs
+++ b/crates/agmem-store/src/repo/write.rs
@@ -202,11 +202,51 @@ pub struct AlreadyClosed {
 /// `supersedes` still closes its targets — in favour of the row that already
 /// holds the content, minus that row itself (issue #57).
 ///
+/// Two *sessions* writing the same claim both pass their own in-transaction
+/// lookup, and the loser's whole batch aborts on the unique index (issue
+/// #64). That is a timing accident, not an error the caller can act on, so
+/// it is retried once: the second pass finds the winner live in the gate and
+/// reports the promised `Duplicate`, and the rest of the batch lands.
+///
 /// # Errors
 /// [`StoreError::UnknownMemory`] when a `supersedes` target is not in this
 /// space, and [`StoreError::Db`] for anything the engine rejects — in which
 /// case nothing at all was written.
 pub async fn insert_batch(db: &Db, batch: Batch) -> Result<BatchOutcome, StoreError> {
+    let mut attempts = 0;
+    loop {
+        match insert_batch_once(db, batch.clone()).await {
+            Err(StoreError::Db(error)) if attempts < 2 && is_write_race(&error) => {
+                attempts += 1;
+                tracing::info!(%error, attempt = attempts, "the batch lost a write race; retrying");
+            }
+            outcome => return outcome,
+        }
+    }
+}
+
+/// Whether an engine error is this batch losing a race, in either of the two
+/// shapes the engine reports one.
+///
+/// A loser whose `CREATE` runs after the winner committed hits the unique
+/// index and the error names it — the two content-hash indexes are the only
+/// ones a batch can legitimately collide on. A loser whose transaction truly
+/// interleaved fails at commit instead, and all the engine says is "failed
+/// transaction" / "Cannot COMMIT" on every statement (the same phrases
+/// [`checked`] classifies as follow-on): an optimistic-concurrency conflict
+/// with no index named. Both mean the same thing here — nothing landed, and
+/// a re-run will see whatever won — so both are retried rather than handed
+/// to a caller who can do nothing but retry blind.
+fn is_write_race(error: &surrealdb::Error) -> bool {
+    let text = error.to_string();
+    text.contains("mem_hash_live")
+        || text.contains("episode_hash")
+        || text.contains("failed transaction")
+        || text.contains("Cannot COMMIT")
+}
+
+/// One attempt at the batch; [`insert_batch`] owns the retry.
+async fn insert_batch_once(db: &Db, batch: Batch) -> Result<BatchOutcome, StoreError> {
     let Batch {
         space,
         episode,

--- a/crates/agmem-store/tests/writes.rs
+++ b/crates/agmem-store/tests/writes.rs
@@ -883,6 +883,48 @@ async fn a_supersede_never_rewrites_another_close() {
     );
 }
 
+/// Issue #64: two sessions writing the same claim both pass their own
+/// in-transaction dup lookup; the loser used to surface the unique-index
+/// abort as a raw DB error. The retry turns it into the promised
+/// `Duplicate`. The engine does not collide on every run, so this drives
+/// many rounds — a pass proves no raw error ever escapes and every round
+/// converges on one row, whichever interleaving happened.
+#[tokio::test]
+async fn concurrent_identical_writes_converge_on_one_row_without_an_error() {
+    let db = store().await;
+    const ROUNDS: usize = 16;
+    for round in 0..ROUNDS {
+        let content = format!("racing claim number {round}");
+        let (left, right) = tokio::join!(
+            repo::insert_batch(
+                &db,
+                batch(vec![NewMemory::new(Kind::Fact, content.clone())])
+            ),
+            repo::insert_batch(&db, batch(vec![NewMemory::new(Kind::Fact, content)])),
+        );
+        let (left, right) = (
+            left.expect("the race is never the caller's error"),
+            right.expect("the race is never the caller's error"),
+        );
+        assert_eq!(
+            left.memories[0].id(),
+            right.memories[0].id(),
+            "both callers are told about the same row"
+        );
+        assert!(
+            left.memories[0].is_created() || right.memories[0].is_created(),
+            "somebody actually wrote it"
+        );
+    }
+    assert_eq!(
+        column::<String>(&db, "SELECT VALUE record::id(id) FROM memory")
+            .await
+            .len(),
+        ROUNDS,
+        "one row per claim, however the interleavings fell"
+    );
+}
+
 #[tokio::test]
 async fn a_standalone_supersede_refuses_a_closed_target() {
     let db = store().await;


### PR DESCRIPTION
Closes #64 (Phase 5 — Hardening; verifier-confirmed: nothing serializes concurrent `insert_batch` transactions through the daemon, `checked()` never catches index conflicts, and `store_error` surfaced them as raw `INTERNAL_ERROR`).

`insert_batch` becomes a bounded retry (≤2) around `insert_batch_once`. The predicate covers both shapes the engine reports a lost race in: a statement-level conflict naming `mem_hash_live`/`episode_hash` (the only indexes a batch can legitimately collide on), and a commit-level optimistic-concurrency failure ("failed transaction"/"Cannot COMMIT" — the empirically observed shape on mem://, code -32003, which never names the index). The batch is atomic, so a retry re-runs from a clean slate; the dup gate then sees the winner live and reports `Duplicate`, and sibling rows land.

Test: `concurrent_identical_writes_converge_on_one_row_without_an_error` — 16 rounds of `tokio::join!`-ed identical pairs; it reliably provoked the commit-level shape before the fix and asserts both callers get the same id with no raw error, one row per claim. Stable across repeated local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGe48K3fQ2boQnp9DRP1gL