### PR TITLE
One paste stops monopolising the model every session shares

### DIFF
--- a/crates/agmem-embed/src/lib.rs
+++ b/crates/agmem-embed/src/lib.rs
@@ -8,7 +8,9 @@
 //! Backends are synchronous — ONNX inference is CPU-bound, and pretending
 //! otherwise would only hide it. The async wrappers [`embed_passages`] and
 //! [`embed_query`] move that work off the runtime with `spawn_blocking`, so
-//! the MCP server never stalls its reactor on a model.
+//! the MCP server never stalls its reactor on a model; [`embed_passages`]
+//! also slices large batches so one caller cannot hold the model for the
+//! whole batch while every other session waits.
 
 use std::sync::Arc;
 
@@ -69,7 +71,14 @@ pub enum EmbedError {
     Join(#[from] tokio::task::JoinError),
 }
 
-/// Embed passages on a blocking thread.
+/// How many passages reach the backend per call.
+///
+/// Backends serialise on one model, so a caller's batch is sliced here and the
+/// backend invoked once per slice — between slices the model is free, and
+/// another session's query gets in instead of waiting out the whole batch.
+const BATCH: usize = 128;
+
+/// Embed passages on a blocking thread, [`BATCH`] at a time.
 ///
 /// # Errors
 /// Whatever the backend reports, or [`EmbedError::Join`] if the task died.
@@ -77,7 +86,14 @@ pub async fn embed_passages(
     embedder: Arc<dyn Embedder>,
     passages: Vec<String>,
 ) -> Result<Vec<Vec<f32>>, EmbedError> {
-    tokio::task::spawn_blocking(move || embedder.embed_passages(&passages)).await?
+    tokio::task::spawn_blocking(move || {
+        let mut vectors = Vec::with_capacity(passages.len());
+        for slice in passages.chunks(BATCH) {
+            vectors.extend(embedder.embed_passages(slice)?);
+        }
+        Ok(vectors)
+    })
+    .await?
 }
 
 /// Embed one query on a blocking thread.
@@ -89,4 +105,57 @@ pub async fn embed_query(
     query: String,
 ) -> Result<Vec<f32>, EmbedError> {
     tokio::task::spawn_blocking(move || embedder.embed_query(&query)).await?
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// Records the size of every slice it is handed; each vector encodes the
+    /// passage's position in the original batch so order survives slicing.
+    struct SliceRecorder {
+        slices: Mutex<Vec<usize>>,
+    }
+
+    impl Embedder for SliceRecorder {
+        fn dim(&self) -> usize {
+            1
+        }
+
+        fn model_id(&self) -> &str {
+            "slice-recorder"
+        }
+
+        fn embed_passages(&self, passages: &[String]) -> Result<Vec<Vec<f32>>, EmbedError> {
+            self.slices.lock().unwrap().push(passages.len());
+            Ok(passages
+                .iter()
+                .map(|passage| vec![passage.parse::<f32>().unwrap()])
+                .collect())
+        }
+
+        fn embed_query(&self, _query: &str) -> Result<Vec<f32>, EmbedError> {
+            unreachable!("not under test")
+        }
+    }
+
+    #[tokio::test]
+    async fn a_large_batch_reaches_the_backend_in_slices_and_in_order() {
+        let embedder = Arc::new(SliceRecorder {
+            slices: Mutex::new(Vec::new()),
+        });
+        let passages: Vec<String> = (0..300).map(|index| index.to_string()).collect();
+
+        let vectors = embed_passages(Arc::clone(&embedder) as Arc<dyn Embedder>, passages)
+            .await
+            .expect("embed passages");
+
+        assert_eq!(*embedder.slices.lock().unwrap(), vec![128, 128, 44]);
+        assert_eq!(vectors.len(), 300);
+        for (index, vector) in vectors.iter().enumerate() {
+            assert_eq!(vector, &vec![index as f32]);
+        }
+    }
 }

--- a/crates/agmem-server/src/tools/remember.rs
+++ b/crates/agmem-server/src/tools/remember.rs
@@ -242,7 +242,9 @@ pub async fn run(
     let mut new_episode = episode.as_ref().map(EpisodeInput::validated).transpose()?;
 
     // 2. One embedding pass for the whole call — the claims and the episode's
-    //    chunks together, so a batch of any size is one model invocation.
+    //    chunks together. agmem-embed slices the batch internally, so the
+    //    shared model breathes between slices instead of being held for the
+    //    call's full duration.
     embed(service, &mut new_memories, new_episode.as_mut()).await?;
 
     // 3. The near-dup gate: the same claim in different words is reported, not
@@ -385,11 +387,35 @@ pub async fn run(
     })
 }
 
+/// The most characters one claim may hold.
+///
+/// A memory is one distilled claim; anything longer is an artifact, and
+/// artifacts belong on disk with their path stored here instead. The cap also
+/// bounds what a single `remember` can put through the shared embedding model.
+const MAX_MEMORY_CHARS: usize = 10_000;
+
+/// The most characters an episode may hold — roughly seventy retrieval chunks.
+///
+/// Without it one multi-megabyte paste becomes thousands of chunks embedded
+/// and stored in a single call, monopolising the model every other session
+/// shares. Ground truth bigger than this belongs in a file, with a memory
+/// pointing at it.
+const MAX_EPISODE_CHARS: usize = 100_000;
+
 impl MemoryInput {
     /// This input as a store row, or the reason it cannot be one.
     fn validated(&self, index: usize) -> Result<NewMemory, ErrorData> {
         if self.content.trim().is_empty() {
             return Err(invalid(format!("memories[{index}].content is empty")));
+        }
+        let length = self.content.chars().count();
+        if length > MAX_MEMORY_CHARS {
+            return Err(invalid(format!(
+                "memories[{index}].content is {length} characters; the limit is \
+                 {MAX_MEMORY_CHARS}. One memory holds one distilled claim — verbatim \
+                 text goes in `episode`, and anything larger belongs on disk with its \
+                 path stored here instead"
+            )));
         }
         let mut memory = NewMemory::new(self.kind.unwrap_or(Kind::Fact), self.content.clone());
         memory.entities.clone_from(&self.entities);
@@ -418,6 +444,14 @@ impl EpisodeInput {
     fn validated(&self) -> Result<NewEpisode, ErrorData> {
         if self.content.trim().is_empty() {
             return Err(invalid("episode.content is empty"));
+        }
+        let length = self.content.chars().count();
+        if length > MAX_EPISODE_CHARS {
+            return Err(invalid(format!(
+                "episode.content is {length} characters; the limit is \
+                 {MAX_EPISODE_CHARS}. Store the artifact on disk and remember its \
+                 path alongside the claims distilled from it"
+            )));
         }
         Ok(NewEpisode {
             content: self.content.clone(),
@@ -463,7 +497,7 @@ async fn embed(
         return Ok(());
     }
 
-    let mut vectors = agmem_embed::embed_passages(Arc::clone(service.embedder()), passages.clone())
+    let mut vectors = agmem_embed::embed_passages(Arc::clone(service.embedder()), passages)
         .await
         .map_err(|error| internal(format!("embedding failed: {error}")))?;
     if vectors.len() != memories.len() + chunks {
@@ -507,6 +541,40 @@ mod tests {
         };
         let error = input.validated(1).expect_err("blank content is refused");
         assert!(error.message.contains("memories[1].content"), "{error:?}");
+    }
+
+    #[test]
+    fn an_oversized_memory_is_refused_naming_the_limit() {
+        let input = MemoryInput {
+            content: "c".repeat(MAX_MEMORY_CHARS + 1),
+            kind: None,
+            entities: Vec::new(),
+            tags: Vec::new(),
+            decay_class: None,
+            supersedes: Vec::new(),
+            valid_from: None,
+        };
+        let error = input.validated(0).expect_err("oversized claim is refused");
+        assert!(error.message.contains("memories[0].content"), "{error:?}");
+        assert!(
+            error.message.contains(&MAX_MEMORY_CHARS.to_string()),
+            "the refusal names the limit: {error:?}"
+        );
+    }
+
+    #[test]
+    fn an_oversized_episode_is_refused_naming_the_limit() {
+        let input = EpisodeInput {
+            content: "e".repeat(MAX_EPISODE_CHARS + 1),
+            occurred_at: None,
+            session: None,
+        };
+        let error = input.validated().expect_err("oversized episode is refused");
+        assert!(error.message.contains("episode.content"), "{error:?}");
+        assert!(
+            error.message.contains(&MAX_EPISODE_CHARS.to_string()),
+            "the refusal names the limit: {error:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #67.

All embedding funnels through one model behind one lock, shared by every
session attached to the daemon — and `remember` could hand it a whole
multi-megabyte episode as a single batch, blocking every other session's
recall for the batch's full CPU duration.

Two halves, matching the issue's fix shape:

- **The wrapper slices.** `agmem_embed::embed_passages` now invokes the
  backend 128 passages at a time, so the lock is released between slices and
  a waiting query interleaves instead of waiting out the whole batch. All
  three call sites (remember, reflect, reindex) get this through the one
  funnel; reindex keeps its own 128-row DB paging on top.
- **Validation refuses, naming the limit.** A claim over 10,000 characters
  or an episode over 100,000 (~70 retrieval chunks) is refused at
  validation, before anything is embedded or written, with the limit and the
  alternative (artifacts on disk, a memory pointing at them) in the message.

Tests: a slice-recording embedder proves a 300-passage batch reaches the
backend as 128/128/44 with order preserved; both refusals are asserted to
name their limit. `cargo test --workspace` 281 passed; clippy clean.

Sibling issue #70 (daemon idle-shutdown races) was closed separately as
refuted after a verifier pass — see its closing comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGe48K3fQ2boQnp9DRP1gL