### PR TITLE
The space index admits the cut, and the count gets its stopwatch (#69, #71)

### DIFF
--- a/crates/agmem-server/src/resources.rs
+++ b/crates/agmem-server/src/resources.rs
@@ -10,7 +10,7 @@
 //!
 //! | URI | answer |
 //! |---|---|
-//! | `memory://<space>` | the index: every live claim in the space, slim |
+//! | `memory://<space>` | the index: the space's live claims, slim, marked when cut |
 //! | `memory://<space>/<id>` | the full `inspect` answer for that id |
 //!
 //! `resources/list` serves one entry per registered space; the record form is
@@ -48,11 +48,18 @@ const SCHEME: &str = "memory://";
 struct Index {
     /// The space asked about.
     space: String,
-    /// How many live claims it holds — always `memories.len()`, spelled out so
-    /// a reader need not count to know nothing was truncated.
+    /// How many live claims the space holds — counted independently of
+    /// `memories`, so the number stays honest when the listing is a page.
     live: u64,
-    /// Every live claim, strongest first.
+    /// The live claims, strongest first — all of them unless `truncated` says
+    /// otherwise.
     memories: Vec<IndexEntry>,
+    /// Present when the space holds more live claims than one read serves:
+    /// `memories` is then the strongest page, not the whole space, and this
+    /// says so in words (issue #69) — the same honesty rule as recall's
+    /// `truncated`. Absent means the index really is complete.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    truncated: Option<String>,
 }
 
 /// One line of the index: enough to recognise a claim, and the URI to read it.
@@ -83,8 +90,8 @@ pub async fn list(service: &AgmemService) -> Result<ListResourcesResult, ErrorDa
             Resource::new(format!("{SCHEME}{space}"), space.to_string())
                 .with_title(format!("Memory space `{space}`"))
                 .with_description(
-                    "Every live claim in the space, with the URI that reads \
-                     each one's history and source text.",
+                    "The space's live claims, strongest first, with the URI \
+                     that reads each one's history and source text.",
                 )
                 .with_mime_type(MIME)
         })
@@ -127,7 +134,7 @@ pub async fn read(service: &AgmemService, uri: &str) -> Result<ReadResourceResul
     ]))
 }
 
-/// The `memory://<space>` form: every live claim, slim.
+/// The `memory://<space>` form: the space's live claims, slim.
 async fn index(service: &AgmemService, name: &str) -> Result<String, ErrorData> {
     // Membership first: a URI naming an unregistered space is a resource that
     // does not exist (-32002), not an empty index — a client retrying a typo
@@ -140,14 +147,16 @@ async fn index(service: &AgmemService, name: &str) -> Result<String, ErrorData> 
         return Err(unknown_space(name));
     }
 
-    // The live count is the limit, so the index is complete by construction —
-    // an index that quietly truncated would break the one promise it makes.
+    // One lookup serves at most `MAX_POOL` rows however large a limit it is
+    // asked for, so past that the index is a page, not the space. The count
+    // stays the space's own, and `truncated` marks the cut rather than letting
+    // `live: 1500` sit beside 1000 entries as if nothing were missing (#69).
     let stats = repo::stats(service.db(), &space)
         .await
         .map_err(|error| store_error(&error))?;
     let mut lookup = Lookup::new(vec![space.clone()]);
-    lookup.limit = usize::try_from(stats.live).unwrap_or(usize::MAX);
-    let memories = repo::direct_lookup(service.db(), &lookup)
+    lookup.limit = repo::MAX_POOL;
+    let memories: Vec<IndexEntry> = repo::direct_lookup(service.db(), &lookup)
         .await
         .map_err(|error| store_error(&error))?
         .into_iter()
@@ -158,11 +167,21 @@ async fn index(service: &AgmemService, name: &str) -> Result<String, ErrorData> 
             content: memory.content,
         })
         .collect();
+    let truncated = (stats.live > memories.len() as u64).then(|| {
+        format!(
+            "The strongest {listed} of {live} live claims — a page, not the \
+             whole space. `recall` reaches the rest, and every claim still \
+             answers at its own {SCHEME}{space}/<id>.",
+            listed = memories.len(),
+            live = stats.live,
+        )
+    });
 
     render(&Index {
         space: space.to_string(),
         live: stats.live,
         memories,
+        truncated,
     })
 }
 

--- a/crates/agmem-server/tests/protocol.rs
+++ b/crates/agmem-server/tests/protocol.rs
@@ -16,10 +16,10 @@ mod harness;
 
 use std::sync::Arc;
 
-use agmem_core::Source;
+use agmem_core::{Kind, Source};
 use agmem_embed::NoopEmbedder;
 use agmem_server::config::ToolDescriptions;
-use agmem_store::repo::{self, Lookup};
+use agmem_store::repo::{self, Batch, Lookup, NewMemory};
 use harness::*;
 use rmcp::model::{
     ContentBlock, ErrorCode, GetPromptRequestParams, ReadResourceRequestParams, Role,
@@ -258,6 +258,51 @@ async fn a_space_index_lists_live_claims_and_their_uris() {
         entry["uri"],
         format!("memory://default/{live}"),
         "each entry carries the URI that reads it whole"
+    );
+    assert!(
+        index.get("truncated").is_none(),
+        "an index that fits in one read carries no truncation marker: {index}"
+    );
+
+    agmem.shutdown().await;
+}
+
+/// Issue #69: a space larger than one lookup serves must say so — `live`
+/// keeps the true count and `truncated` marks the cut, instead of the index
+/// rendering 1000 entries beside a bigger number as if it were complete.
+#[tokio::test]
+async fn a_space_index_larger_than_one_read_marks_the_cut() {
+    let agmem = Harness::start(Arc::new(NoopEmbedder)).await;
+    let over = repo::MAX_POOL + 1;
+    repo::insert_batch(
+        &agmem.db,
+        Batch {
+            space: space(),
+            episode: None,
+            memories: (0..over)
+                .map(|n| NewMemory::new(Kind::Fact, format!("claim number {n}")))
+                .collect(),
+        },
+    )
+    .await
+    .expect("seed past MAX_POOL");
+
+    let index = read_json(&agmem, "memory://default").await;
+    assert_eq!(
+        index["live"], over as u64,
+        "the count is the space's: {index}"
+    );
+    assert_eq!(
+        index["memories"].as_array().expect("memories").len(),
+        repo::MAX_POOL,
+        "the listing is one lookup's page"
+    );
+    let note = index["truncated"]
+        .as_str()
+        .unwrap_or_else(|| panic!("a cut index must carry the marker in words: {index}"));
+    assert!(
+        note.contains(&repo::MAX_POOL.to_string()) && note.contains(&over.to_string()),
+        "the marker names both sides of the cut: {note}"
     );
 
     agmem.shutdown().await;

--- a/crates/agmem-store/tests/count_probe.rs
+++ b/crates/agmem-store/tests/count_probe.rs
@@ -60,6 +60,8 @@ async fn count_matching_cost_by_store_size() {
         let elapsed = started.elapsed();
 
         assert_eq!(counted, rows as u64, "the probe count must be exact");
-        println!("count_matching over {rows} rows: {elapsed:?}");
+        // Stderr: stdout is the MCP wire and denied workspace-wide, and a
+        // probe's numbers must survive the harness either way.
+        eprintln!("count_matching over {rows} rows: {elapsed:?}");
     }
 }

--- a/crates/agmem-store/tests/count_probe.rs
+++ b/crates/agmem-store/tests/count_probe.rs
@@ -1,0 +1,65 @@
+//! Issue #71: `count_matching` is an unindexed scan of `memory`, paid by
+//! every recall whose page fills. The issue's own gate is "measure before
+//! optimising" — this probe is the measurement, kept so the number can be
+//! re-taken whenever the schema or the engine moves.
+//!
+//! Ignored by default: it seeds tens of thousands of rows, which has no place
+//! in the suite. It runs on `mem://`, so what it times is the scan's own
+//! per-row cost, not disk; a real store pays at least this much.
+//!
+//! Run with `cargo test -p agmem-store --test count_probe -- --ignored --nocapture`.
+
+use std::time::Instant;
+
+use agmem_core::{Kind, SpaceName};
+use agmem_store::db::Db;
+use agmem_store::repo::{self, Batch, Lookup, NewMemory};
+use agmem_store::{db, migrate};
+
+fn space() -> SpaceName {
+    "probe".parse().expect("valid slug")
+}
+
+/// A migrated store of `rows` live claims, no embeddings — the count's
+/// predicate reads `space` and `invalid_at` only, so vectors would just make
+/// seeding slow.
+async fn seeded(rows: usize) -> Db {
+    let db = db::connect("mem://").await.expect("connect mem://");
+    migrate::ensure(&db).await.expect("migrate");
+    for start in (0..rows).step_by(1_000) {
+        let memories = (start..(start + 1_000).min(rows))
+            .map(|n| NewMemory::new(Kind::Fact, format!("claim number {n}")))
+            .collect();
+        repo::insert_batch(
+            &db,
+            Batch {
+                space: space(),
+                episode: None,
+                memories,
+            },
+        )
+        .await
+        .expect("seed batch");
+    }
+    db
+}
+
+#[tokio::test]
+#[ignore = "a measurement, not a test — seeds tens of thousands of rows"]
+async fn count_matching_cost_by_store_size() {
+    for rows in [1_000_usize, 10_000, 50_000] {
+        let db = seeded(rows).await;
+        let lookup = Lookup::new(vec![space()]);
+        // One warm pass, so first-query setup is not what gets measured.
+        repo::count_matching(&db, &lookup)
+            .await
+            .expect("warm count");
+
+        let started = Instant::now();
+        let counted = repo::count_matching(&db, &lookup).await.expect("count");
+        let elapsed = started.elapsed();
+
+        assert_eq!(counted, rows as u64, "the probe count must be exact");
+        println!("count_matching over {rows} rows: {elapsed:?}");
+    }
+}


### PR DESCRIPTION
## Summary
- `memory://<space>` fetched `stats.live` rows through `direct_lookup`, which silently re-clamps to `MAX_POOL` (1000) — a 1500-claim space rendered `live: 1500` beside 1000 entries with nothing marking the cut. The index now asks for exactly one `MAX_POOL` page, keeps `live` as the space's independently counted total, and carries a `truncated` note in words whenever the two disagree, mirroring recall's honesty rule. The "every live claim" wording is softened everywhere it overpromised.
- Issue #71's own gate is "measure before optimising": this adds `count_probe.rs`, an ignored measurement probe (the `knn_probe.rs` pattern) timing `count_matching` at 1k/10k/50k rows, so the number exists and can be re-taken as the schema moves. Numbers and the resulting decision land on the issue.

Both findings were CONFIRMED by verifier passes before fixing.

Closes #69.

## Test plan
- New `a_space_index_larger_than_one_read_marks_the_cut` seeds `MAX_POOL + 1` claims and asserts the true count, the one-page listing, and a marker naming both sides of the cut.
- Existing index test now also asserts the marker is absent when the index is complete.
- `cargo fmt --check`, `clippy -D warnings`, and the full workspace suite (282 tests) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGe48K3fQ2boQnp9DRP1gL