### PR TITLE
Every write signs its name (#75)

### DIFF
--- a/crates/agmem-core/src/lib.rs
+++ b/crates/agmem-core/src/lib.rs
@@ -12,5 +12,5 @@ pub mod scoring;
 pub use error::CoreError;
 pub use model::{
     ChunkId, DecayClass, Derivation, Episode, EpisodeChunk, EpisodeId, InvalidReason, Kind,
-    MemoryId, MemoryRecord, Source, SpaceName,
+    MemoryId, MemoryRecord, Source, SpaceName, Writer,
 };

--- a/crates/agmem-core/src/model.rs
+++ b/crates/agmem-core/src/model.rs
@@ -445,6 +445,28 @@ impl From<Derivation> for String {
     }
 }
 
+/// Who performed the write that created a row (issue #75).
+///
+/// Distinct from [`Source`]: `source` records where the *content* came from,
+/// `writer` records which client put it in the store — the attribution every
+/// poisoning defense and outcome-feedback signal downstream hangs off. It is
+/// captured at write time because it cannot be reconstructed later: a row
+/// that did not record its writer can never gain one, which is why rows from
+/// before the field existed read as `None` rather than as a sentinel.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Writer {
+    /// The client's name from the MCP `initialize` handshake, or `unknown`
+    /// when the session never offered one.
+    pub client: String,
+    /// The client's version, when it offered one.
+    pub client_version: Option<String>,
+    /// The session the write belonged to: an id the client sent with the
+    /// request, or one the server minted for the connection.
+    pub session: String,
+    /// The agmem verb that performed the write (`remember`, `reflect`).
+    pub tool: String,
+}
+
 /// A distilled, supersedable memory as stored.
 ///
 /// Fields mirror the `memory` table; see `docs/design.md` §2.2. Ranking
@@ -491,6 +513,8 @@ pub struct MemoryRecord {
     pub superseded_by: Option<MemoryId>,
     /// Provenance.
     pub source: Source,
+    /// Who wrote the row; `None` on rows from before the store recorded it.
+    pub writer: Option<Writer>,
     /// The memories and episodes this claim was reflected out of. Empty for
     /// everything a `reflect` call did not write.
     pub derived_from: Vec<Derivation>,
@@ -704,6 +728,12 @@ mod tests {
             source: Source::Episode {
                 episode: EpisodeId::new("01M145SMNET1XRYA713EWAQTD3").unwrap(),
             },
+            writer: Some(Writer {
+                client: "claude-code".to_owned(),
+                client_version: Some("2.0.1".to_owned()),
+                session: "1234-5678".to_owned(),
+                tool: "remember".to_owned(),
+            }),
             derived_from: vec![Derivation::Memory(
                 MemoryId::new("01M145SMNET1XRYA713EWAQTD4").unwrap(),
             )],

--- a/crates/agmem-core/src/scoring.rs
+++ b/crates/agmem-core/src/scoring.rs
@@ -305,6 +305,7 @@ mod tests {
             supersedes: Vec::new(),
             superseded_by: None,
             source: crate::model::Source::Agent,
+            writer: None,
             derived_from: vec![],
             created_at: days_ago(100),
         }

--- a/crates/agmem-server/src/service.rs
+++ b/crates/agmem-server/src/service.rs
@@ -68,6 +68,11 @@ pub struct AgmemService {
     /// conversation: the daemon builds one service per connection, so a scope
     /// one agent confirmed can never authorise another agent's delete.
     pending_forget: Pending,
+    /// The session id this connection's writes are attributed to (issue #75),
+    /// unless a request carries its own in `_meta`. Minted here because the
+    /// daemon builds one service per connection — which is exactly the
+    /// granularity a session is.
+    session: String,
     /// The routes this session serves, with `config.tool_desc` already
     /// applied. Held as a field rather than rebuilt per request — which is
     /// what a bare `#[tool_handler]` does — so the surface is decided once, at
@@ -87,6 +92,13 @@ impl AgmemService {
             db,
             embedder,
             pending_forget: Pending::default(),
+            // Distinct per connection and sortable by start time; not a ULID
+            // only because nothing in this crate mints those.
+            session: format!(
+                "{}-{}",
+                std::process::id(),
+                jiff::Timestamp::now().as_nanosecond()
+            ),
             tool_router: described(Self::tool_router(), &config),
             prompt_router: Self::prompt_router(),
             config,
@@ -111,6 +123,11 @@ impl AgmemService {
     /// The gate a `forget` by query has to pass (design §5.4).
     pub(crate) fn pending_forget(&self) -> &Pending {
         &self.pending_forget
+    }
+
+    /// The session id this connection's writes fall back to (issue #75).
+    pub(crate) fn session(&self) -> &str {
+        &self.session
     }
 }
 
@@ -191,8 +208,10 @@ than acted on. When one of them says something your claim contradicts, send your
     async fn remember(
         &self,
         Parameters(params): Parameters<RememberParams>,
+        context: RequestContext<RoleServer>,
     ) -> Result<Json<RememberResult>, ErrorData> {
-        remember::run(self, params).await.map(Json)
+        let writer = crate::tools::writer(self, &context, "remember");
+        remember::run(self, params, writer).await.map(Json)
     }
 
     /// The read verb (design §5.3).
@@ -391,8 +410,10 @@ text, for the same decision.",
     async fn reflect(
         &self,
         Parameters(params): Parameters<ReflectParams>,
+        context: RequestContext<RoleServer>,
     ) -> Result<Json<ReflectResult>, ErrorData> {
-        reflect::run(self, params).await.map(Json)
+        let writer = crate::tools::writer(self, &context, "reflect");
+        reflect::run(self, params, writer).await.map(Json)
     }
 }
 

--- a/crates/agmem-server/src/tools/consolidate.rs
+++ b/crates/agmem-server/src/tools/consolidate.rs
@@ -523,6 +523,7 @@ mod tests {
             supersedes: Vec::new(),
             superseded_by: None,
             source: Source::Agent,
+            writer: None,
             derived_from: Vec::new(),
             created_at: Timestamp::UNIX_EPOCH,
         }

--- a/crates/agmem-server/src/tools/inspect.rs
+++ b/crates/agmem-server/src/tools/inspect.rs
@@ -140,6 +140,13 @@ pub struct MemoryView {
     /// Where it came from: `agent`, `episode:<id>`, or `external:<origin>`.
     pub source: String,
 
+    /// Who wrote the row: the MCP client, the session the write belonged to,
+    /// and the verb that performed it. Absent on rows stored before agmem
+    /// recorded writers — absence means "not recorded", never "unknown
+    /// client" (see the `derived_from` note below on why this is `Option`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub writer: Option<WriterView>,
+
     /// What this claim was reflected out of, when `reflect` wrote it: the
     /// memories and episodes it was drawn from, as refs to hand straight back
     /// to `inspect`. Absent on a claim that cites nothing.
@@ -191,6 +198,24 @@ pub struct MemoryView {
 
     /// When the row was written, RFC3339.
     pub created_at: String,
+}
+
+/// Who performed the write that created a row (issue #75).
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct WriterView {
+    /// The client's name from its MCP handshake; `unknown` when the session
+    /// never introduced itself.
+    pub client: String,
+
+    /// The client's version, when it offered one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_version: Option<String>,
+
+    /// The session the write belonged to.
+    pub session: String,
+
+    /// The verb that performed the write: `remember` or `reflect`.
+    pub tool: String,
 }
 
 /// Verbatim text as stored — never rewritten, never superseded.
@@ -589,6 +614,12 @@ impl From<MemoryRecord> for MemoryView {
             entities: memory.entities,
             tags: memory.tags,
             source: provenance(&memory.source),
+            writer: memory.writer.map(|writer| WriterView {
+                client: writer.client,
+                client_version: writer.client_version,
+                session: writer.session,
+                tool: writer.tool,
+            }),
             derived_from: (!memory.derived_from.is_empty()).then(|| {
                 memory
                     .derived_from

--- a/crates/agmem-server/src/tools/mod.rs
+++ b/crates/agmem-server/src/tools/mod.rs
@@ -79,9 +79,9 @@ pub const NAMES: [&str; 7] = [
     "reflect",
 ];
 
-use agmem_core::{MemoryId, Source, SpaceName};
+use agmem_core::{MemoryId, Source, SpaceName, Writer};
 use agmem_store::{StoreError, repo};
-use rmcp::ErrorData;
+use rmcp::{ErrorData, RoleServer, service::RequestContext};
 
 use crate::service::AgmemService;
 
@@ -180,6 +180,46 @@ pub(crate) async fn resolve_space(
             .map_err(|error| store_error(&error))?;
     }
     Ok(space)
+}
+
+/// The `_meta` key a client may send to name the session a write belongs to.
+///
+/// Speculative on purpose (issue #75): no MCP field carries a host session id
+/// over stdio today, but the seam costs nothing and a client that starts
+/// sending one is attributed correctly from that moment on.
+const SESSION_META_KEY: &str = "agmem/session";
+
+/// Who is performing this write (issue #75), assembled from the request.
+///
+/// The client name and version come from the MCP `initialize` handshake,
+/// which rmcp keeps on the connection; the session is the id a client offered
+/// in `_meta`, falling back to the one the service minted for this
+/// connection. `unknown` stands in for a client that never introduced itself
+/// — a fact about the session, not a guess about the writer.
+pub(crate) fn writer(
+    service: &AgmemService,
+    context: &RequestContext<RoleServer>,
+    tool: &str,
+) -> Writer {
+    let client = context.client_info();
+    Writer {
+        client: client
+            .as_ref()
+            .map(|info| info.name.clone())
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| "unknown".to_owned()),
+        client_version: client
+            .as_ref()
+            .map(|info| info.version.clone())
+            .filter(|version| !version.is_empty()),
+        session: context
+            .meta
+            .get(SESSION_META_KEY)
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned)
+            .unwrap_or_else(|| service.session().to_owned()),
+        tool: tool.to_owned(),
+    }
 }
 
 /// A memory id as sent, with or without the `memory:` table prefix agmem's own

--- a/crates/agmem-server/src/tools/reflect.rs
+++ b/crates/agmem-server/src/tools/reflect.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use agmem_core::{Derivation, Kind, MemoryId, SpaceName, dedup};
+use agmem_core::{Derivation, Kind, MemoryId, SpaceName, Writer, dedup};
 use agmem_store::repo::{self, Batch, NewMemory};
 use rmcp::ErrorData;
 use schemars::JsonSchema;
@@ -143,6 +143,7 @@ pub struct Related {
 pub async fn run(
     service: &AgmemService,
     params: ReflectParams,
+    writer: Writer,
 ) -> Result<ReflectResult, ErrorData> {
     let ReflectParams {
         space,
@@ -227,6 +228,7 @@ pub async fn run(
             space,
             episode: None,
             memories: vec![memory],
+            writer,
         },
     )
     .await

--- a/crates/agmem-server/src/tools/remember.rs
+++ b/crates/agmem-server/src/tools/remember.rs
@@ -13,7 +13,7 @@
 
 use std::sync::Arc;
 
-use agmem_core::{DecayClass, Kind, chunk, dedup};
+use agmem_core::{DecayClass, Kind, Writer, chunk, dedup};
 use agmem_store::repo::{self, Batch, NewChunk, NewEpisode, NewMemory, Written};
 use jiff::Timestamp;
 use rmcp::ErrorData;
@@ -219,6 +219,7 @@ pub struct Duplicate {
 pub async fn run(
     service: &AgmemService,
     params: RememberParams,
+    writer: Writer,
 ) -> Result<RememberResult, ErrorData> {
     let RememberParams {
         space,
@@ -331,6 +332,7 @@ pub async fn run(
             space,
             episode: new_episode,
             memories: batch,
+            writer,
         },
     )
     .await

--- a/crates/agmem-server/tests/knn_probe.rs
+++ b/crates/agmem-server/tests/knn_probe.rs
@@ -17,7 +17,7 @@
 
 #![cfg(feature = "onnx")]
 
-use agmem_core::{Kind, SpaceName};
+use agmem_core::{Kind, SpaceName, Writer};
 use agmem_embed::Embedder;
 use agmem_embed::fastembed::FastembedBackend;
 use agmem_store::db::Db;
@@ -235,6 +235,7 @@ async fn write_session(url: &str, name: &str, memories: Vec<NewMemory>) {
             space: space(name),
             episode: None,
             memories,
+            writer: Writer::default(),
         },
     )
     .await

--- a/crates/agmem-server/tests/protocol.rs
+++ b/crates/agmem-server/tests/protocol.rs
@@ -16,7 +16,7 @@ mod harness;
 
 use std::sync::Arc;
 
-use agmem_core::{Kind, Source};
+use agmem_core::{Kind, Source, Writer};
 use agmem_embed::NoopEmbedder;
 use agmem_server::config::ToolDescriptions;
 use agmem_store::repo::{self, Batch, Lookup, NewMemory};
@@ -282,6 +282,7 @@ async fn a_space_index_larger_than_one_read_marks_the_cut() {
             memories: (0..over)
                 .map(|n| NewMemory::new(Kind::Fact, format!("claim number {n}")))
                 .collect(),
+            writer: Writer::default(),
         },
     )
     .await
@@ -555,6 +556,49 @@ async fn remember_stores_a_batch_and_provenances_it_to_the_episode() {
         (stats.live, stats.episodes, stats.chunks),
         (2, 1, 1),
         "the episode is stored verbatim and chunked for retrieval"
+    );
+    agmem.shutdown().await;
+}
+
+/// Issue #75: every write records who made it, and `inspect` shows it. The
+/// client name is whatever the MCP client introduced itself as — asserted
+/// non-empty rather than as a literal, because the test client reports
+/// rmcp's own build info — and `tool` names the verb that wrote the row.
+#[tokio::test]
+async fn a_write_records_its_writer_and_inspect_shows_it() {
+    let agmem = Harness::start(Arc::new(NoopEmbedder)).await;
+    let diff = agmem
+        .remember(json!({ "memories": [{ "content": "The deploy target moved to Railway." }] }))
+        .await;
+    let remembered = ids(&diff["created"])[0].to_owned();
+
+    let found = agmem.inspect(&remembered).await;
+    let writer = &found["found"]["memory"]["writer"];
+    assert_eq!(writer["tool"].as_str(), Some("remember"), "{found}");
+    assert!(
+        writer["client"]
+            .as_str()
+            .is_some_and(|name| !name.is_empty()),
+        "the writer names the client that introduced itself: {found}"
+    );
+    assert!(
+        writer["session"]
+            .as_str()
+            .is_some_and(|session| !session.is_empty()),
+        "a client that offers no session id gets the connection's: {found}"
+    );
+
+    let insight = agmem
+        .reflect(json!({
+            "insight": "Deploys keep moving toward automation.",
+            "derived_from": [remembered]
+        }))
+        .await;
+    let reflected = agmem.inspect(insight["id"].as_str().expect("an id")).await;
+    assert_eq!(
+        reflected["found"]["memory"]["writer"]["tool"].as_str(),
+        Some("reflect"),
+        "each verb stamps its own name: {reflected}"
     );
     agmem.shutdown().await;
 }

--- a/crates/agmem-server/tests/reindex.rs
+++ b/crates/agmem-server/tests/reindex.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use agmem_core::{Kind, SpaceName};
+use agmem_core::{Kind, SpaceName, Writer};
 use agmem_embed::{EmbedError, Embedder, NoopEmbedder};
 use agmem_server::reindex;
 use agmem_store::db::Db;
@@ -77,6 +77,7 @@ async fn bm25_only_store() -> Db {
                 NewMemory::new(Kind::Fact, "the user prefers Rust over Python"),
                 NewMemory::new(Kind::Instruction, "answer in English"),
             ],
+            writer: Writer::default(),
         },
     )
     .await

--- a/crates/agmem-server/tests/snapshots/protocol__list_tools.snap
+++ b/crates/agmem-server/tests/snapshots/protocol__list_tools.snap
@@ -241,6 +241,17 @@ expression: "&tools.tools"
             "valid_from": {
               "description": "When the claim started being true, RFC3339.",
               "type": "string"
+            },
+            "writer": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WriterView"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Who wrote the row: the MCP client, the session the write belonged to,\nand the verb that performed it. Absent on rows stored before agmem\nrecorded writers — absence means \"not recorded\", never \"unknown\nclient\" (see the `derived_from` note below on why this is `Option`)."
             }
           },
           "required": [
@@ -307,6 +318,36 @@ expression: "&tools.tools"
             "claim",
             "idle_days",
             "expires_in_days"
+          ],
+          "type": "object"
+        },
+        "WriterView": {
+          "description": "Who performed the write that created a row (issue #75).",
+          "properties": {
+            "client": {
+              "description": "The client's name from its MCP handshake; `unknown` when the session\nnever introduced itself.",
+              "type": "string"
+            },
+            "client_version": {
+              "description": "The client's version, when it offered one.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "session": {
+              "description": "The session the write belonged to.",
+              "type": "string"
+            },
+            "tool": {
+              "description": "The verb that performed the write: `remember` or `reflect`.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "client",
+            "session",
+            "tool"
           ],
           "type": "object"
         }
@@ -960,6 +1001,17 @@ expression: "&tools.tools"
             "valid_from": {
               "description": "When the claim started being true, RFC3339.",
               "type": "string"
+            },
+            "writer": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WriterView"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Who wrote the row: the MCP client, the session the write belonged to,\nand the verb that performed it. Absent on rows stored before agmem\nrecorded writers — absence means \"not recorded\", never \"unknown\nclient\" (see the `derived_from` note below on why this is `Option`)."
             }
           },
           "required": [
@@ -1032,6 +1084,36 @@ expression: "&tools.tools"
             "episodes",
             "chunks",
             "live_by_kind"
+          ],
+          "type": "object"
+        },
+        "WriterView": {
+          "description": "Who performed the write that created a row (issue #75).",
+          "properties": {
+            "client": {
+              "description": "The client's name from its MCP handshake; `unknown` when the session\nnever introduced itself.",
+              "type": "string"
+            },
+            "client_version": {
+              "description": "The client's version, when it offered one.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "session": {
+              "description": "The session the write belonged to.",
+              "type": "string"
+            },
+            "tool": {
+              "description": "The verb that performed the write: `remember` or `reflect`.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "client",
+            "session",
+            "tool"
           ],
           "type": "object"
         }

--- a/crates/agmem-store/src/migrate.rs
+++ b/crates/agmem-store/src/migrate.rs
@@ -23,6 +23,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("migrations/v3_supersedes_list.surql"),
     include_str!("migrations/v4_chunk_occurred_at.surql"),
     include_str!("migrations/v5_live_dedup.surql"),
+    include_str!("migrations/v6_writer.surql"),
 ];
 
 /// The schema version this binary produces.

--- a/crates/agmem-store/src/migrations/v6_writer.surql
+++ b/crates/agmem-store/src/migrations/v6_writer.surql
@@ -1,0 +1,28 @@
+-- Schema v6 — every write records who made it (issue #75).
+--
+-- `source` says where the *content* came from; nothing says which client put
+-- it in the store. Every poisoning defense and outcome-feedback idea
+-- downstream needs per-writer attribution, and it is the one field that can
+-- never be backfilled — so it lands before the store grows further.
+--
+-- `writer` is an object of plain strings: the client name and version from
+-- the MCP `initialize` handshake, the session the write belonged to, and the
+-- agmem tool that performed it. Episodes record it too — verbatim text is
+-- just as un-backfillable as a claim.
+--
+-- Deliberately **no backfill**: a pre-v6 row reads as `NONE`, which is true
+-- ("not recorded"), where any sentinel would be a claim to knowledge nothing
+-- has. Every sub-field is `option<string>` for the same reason v3 taught: any
+-- later UPDATE re-coerces every field, and a required sub-field would make
+-- REINFORCE, PRUNE_EXPIRED and FORGET_SOFT refuse to touch a pre-v6 row.
+DEFINE FIELD IF NOT EXISTS writer ON memory TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS writer.client ON memory TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS writer.client_version ON memory TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS writer.session ON memory TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS writer.tool ON memory TYPE option<string>;
+DEFINE INDEX IF NOT EXISTS mem_writer_session ON memory COLUMNS writer.session;
+DEFINE FIELD IF NOT EXISTS writer ON episode TYPE option<object>;
+DEFINE FIELD IF NOT EXISTS writer.client ON episode TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS writer.client_version ON episode TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS writer.session ON episode TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS writer.tool ON episode TYPE option<string>;

--- a/crates/agmem-store/src/queries/read.rs
+++ b/crates/agmem-store/src/queries/read.rs
@@ -108,6 +108,9 @@ const MEMORY_FIELDS: &str = "record::id(id) AS id, space, kind, content, content
      source.kind AS source_kind,
      IF type::is_record(source.ref) { record::id(source.ref) } ELSE { source.ref }
          AS source_ref,
+     IF writer IS NONE { NONE } ELSE { { client: writer.client,
+         client_version: writer.client_version, session: writer.session,
+         tool: writer.tool } } AS writer,
      array::map(derived_from ?? [],
          |$link| { table: record::table($link), id: record::id($link) }) AS derived_from,
      created_at";

--- a/crates/agmem-store/src/repo/write.rs
+++ b/crates/agmem-store/src/repo/write.rs
@@ -6,7 +6,7 @@
 //! what a duplicate means.
 
 use agmem_core::{
-    DecayClass, Derivation, EpisodeId, Kind, MemoryId, Source, SpaceName, dedup, scoring,
+    DecayClass, Derivation, EpisodeId, Kind, MemoryId, Source, SpaceName, Writer, dedup, scoring,
 };
 use jiff::Timestamp;
 use surrealdb::types::RecordId;
@@ -16,7 +16,7 @@ use crate::StoreError;
 use crate::db::Db;
 use crate::queries::write::{self as queries, MemoryShape};
 use crate::types::{
-    self, BatchRow, ChunkRow, EpisodeRow, MemoryRow, PurgedRow, SourceRow, WriteRow,
+    self, BatchRow, ChunkRow, EpisodeRow, MemoryRow, PurgedRow, SourceRow, WriteRow, WriterRow,
 };
 
 /// A memory to write.
@@ -122,6 +122,10 @@ pub struct Batch {
     pub episode: Option<NewEpisode>,
     /// The distilled memories.
     pub memories: Vec<NewMemory>,
+    /// Who is performing this write (issue #75). Stamped on every row the
+    /// batch creates — it is per-call rather than per-memory because one
+    /// `remember` is one writer, whatever it carries.
+    pub writer: Writer,
 }
 
 /// What became of one row a batch asked for.
@@ -251,6 +255,7 @@ async fn insert_batch_once(db: &Db, batch: Batch) -> Result<BatchOutcome, StoreE
         space,
         episode,
         mut memories,
+        writer,
     } = batch;
 
     let targets: Vec<&MemoryId> = memories
@@ -306,6 +311,7 @@ async fn insert_batch_once(db: &Db, batch: Batch) -> Result<BatchOutcome, StoreE
                     content_hash: hash,
                     occurred_at: types::to_datetime(episode.occurred_at.unwrap_or_else(now)),
                     session: episode.session.clone(),
+                    writer: WriterRow::new(&writer),
                 },
             ))
             .bind(("ep_chunks", chunks));
@@ -334,6 +340,7 @@ async fn insert_batch_once(db: &Db, batch: Batch) -> Result<BatchOutcome, StoreE
                     .iter()
                     .map(types::derivation_ref)
                     .collect(),
+                writer: WriterRow::new(&writer),
             },
         ));
         if !shapes[index].source_is_batch_episode {

--- a/crates/agmem-store/src/types.rs
+++ b/crates/agmem-store/src/types.rs
@@ -15,7 +15,7 @@
 
 use agmem_core::{
     ChunkId, DecayClass, Derivation, Episode, EpisodeChunk, EpisodeId, InvalidReason, Kind,
-    MemoryId, MemoryRecord, Source, SpaceName,
+    MemoryId, MemoryRecord, Source, SpaceName, Writer,
 };
 use jiff::Timestamp;
 use surrealdb::types::{Datetime, RecordId, SurrealValue, Value};
@@ -95,6 +95,41 @@ pub(crate) struct MemoryRow {
     pub(crate) valid_from: Datetime,
     pub(crate) supersedes: Vec<RecordId>,
     pub(crate) derived_from: Vec<RecordId>,
+    pub(crate) writer: WriterRow,
+}
+
+/// The `writer` object: who performed the write (issue #75).
+///
+/// Required on every write row and optional on every read row: new rows
+/// always record their writer, and rows from before v6 never can.
+#[derive(SurrealValue)]
+pub(crate) struct WriterRow {
+    pub(crate) client: String,
+    pub(crate) client_version: Option<String>,
+    pub(crate) session: String,
+    pub(crate) tool: String,
+}
+
+impl WriterRow {
+    /// The row spelling of a writer.
+    pub(crate) fn new(writer: &Writer) -> Self {
+        Self {
+            client: writer.client.clone(),
+            client_version: writer.client_version.clone(),
+            session: writer.session.clone(),
+            tool: writer.tool.clone(),
+        }
+    }
+
+    /// The domain writer this row spells.
+    fn into_writer(self) -> Writer {
+        Writer {
+            client: self.client,
+            client_version: self.client_version,
+            session: self.session,
+            tool: self.tool,
+        }
+    }
 }
 
 /// The `source` object: `{ kind, ref }`, with `ref` absent for `agent`.
@@ -134,6 +169,7 @@ pub(crate) struct EpisodeRow {
     pub(crate) content_hash: String,
     pub(crate) occurred_at: Datetime,
     pub(crate) session: Option<String>,
+    pub(crate) writer: WriterRow,
 }
 
 /// The `episode_chunk` columns a write supplies, minus the ones the query
@@ -193,6 +229,7 @@ pub(crate) struct MemoryReadRow {
     pub(crate) superseded_by: Option<String>,
     pub(crate) source_kind: String,
     pub(crate) source_ref: Option<String>,
+    pub(crate) writer: Option<WriterRow>,
     pub(crate) derived_from: Vec<DerivationRow>,
     pub(crate) created_at: Datetime,
 }
@@ -261,6 +298,7 @@ impl MemoryReadRow {
                 .collect::<Result<_, _>>()?,
             superseded_by: self.superseded_by.map(MemoryId::new).transpose()?,
             source: to_source(&self.source_kind, self.source_ref)?,
+            writer: self.writer.map(WriterRow::into_writer),
             derived_from: self
                 .derived_from
                 .into_iter()

--- a/crates/agmem-store/tests/count_probe.rs
+++ b/crates/agmem-store/tests/count_probe.rs
@@ -11,7 +11,7 @@
 
 use std::time::Instant;
 
-use agmem_core::{Kind, SpaceName};
+use agmem_core::{Kind, SpaceName, Writer};
 use agmem_store::db::Db;
 use agmem_store::repo::{self, Batch, Lookup, NewMemory};
 use agmem_store::{db, migrate};
@@ -33,6 +33,7 @@ async fn seeded(rows: usize) -> Db {
         repo::insert_batch(
             &db,
             Batch {
+                writer: Writer::default(),
                 space: space(),
                 episode: None,
                 memories,

--- a/crates/agmem-store/tests/migrate.rs
+++ b/crates/agmem-store/tests/migrate.rs
@@ -1,6 +1,6 @@
 //! Migration gate against the real (in-memory) engine.
 
-use agmem_core::SpaceName;
+use agmem_core::{SpaceName, Writer};
 use agmem_store::repo::{self, Lookup};
 use agmem_store::{StoreError, db, migrate};
 
@@ -189,6 +189,7 @@ async fn a_correction_written_before_v3_reads_as_a_one_element_list() {
     let outcome = repo::insert_batch(
         &conn,
         repo::Batch {
+            writer: Writer::default(),
             space,
             episode: None,
             memories: vec![repo::NewMemory::new(
@@ -203,6 +204,79 @@ async fn a_correction_written_before_v3_reads_as_a_one_element_list() {
         outcome.memories[0].is_created(),
         "a row closed before the upgrade does not answer as the duplicate: {:?}",
         outcome.memories
+    );
+}
+
+/// A row written before v6 carries no `writer` — the field cannot be
+/// backfilled, which is the whole reason it lands early (issue #75) — so it
+/// must read as `None` rather than fail or invent a sentinel. And because a
+/// SurrealDB UPDATE re-coerces every field (the v3 lesson), the close-path
+/// UPDATEs must still reach a writerless row: a required sub-field would make
+/// supersession refuse every pre-v6 row.
+#[tokio::test]
+async fn a_row_written_before_v6_reads_with_no_writer_and_still_closes() {
+    let conn = db::connect("mem://").await.expect("connect mem://");
+    conn.query(include_str!("../src/migrations/v1_schema.surql"))
+        .await
+        .expect("v1")
+        .check()
+        .expect("v1 statements");
+    conn.query(
+        "CREATE memory:01M145SMNET1XRYA713EWAQTD5 SET space = 'test', kind = 'fact',
+             content_hash = 'v1-w', content = 'recorded before writers existed',
+             source = { kind: 'agent' }",
+    )
+    .await
+    .expect("seed")
+    .check()
+    .expect("seed statement");
+
+    assert_eq!(
+        migrate::ensure(&conn).await.expect("upgrade"),
+        migrate::SCHEMA_VERSION
+    );
+
+    let space: SpaceName = "test".parse().expect("valid slug");
+    let rows = repo::direct_lookup(&conn, &Lookup::new(vec![space.clone()]))
+        .await
+        .expect("lookup");
+    assert_eq!(rows.len(), 1, "the upgrade keeps the row");
+    assert!(
+        rows[0].writer.is_none(),
+        "a pre-v6 row records no writer, and reading it must not fail"
+    );
+
+    // Correcting the old row is the UPDATE that re-coerces it; it has to land.
+    let mut correction =
+        repo::NewMemory::new(agmem_core::Kind::Fact, "recorded after writers existed");
+    correction.supersedes = vec!["01M145SMNET1XRYA713EWAQTD5".parse().expect("a ULID")];
+    let stamp = Writer {
+        client: "test-client".to_owned(),
+        client_version: Some("1.2.3".to_owned()),
+        session: "session-1".to_owned(),
+        tool: "remember".to_owned(),
+    };
+    let outcome = repo::insert_batch(
+        &conn,
+        repo::Batch {
+            space: space.clone(),
+            episode: None,
+            memories: vec![correction],
+            writer: stamp.clone(),
+        },
+    )
+    .await
+    .expect("supersede a writerless row");
+    assert!(outcome.memories[0].is_created());
+
+    let rows = repo::direct_lookup(&conn, &Lookup::new(vec![space]))
+        .await
+        .expect("lookup after the close");
+    assert_eq!(rows.len(), 1, "only the correction is live");
+    assert_eq!(
+        rows[0].writer,
+        Some(stamp),
+        "the new row carries the writer it was stamped with"
     );
 }
 

--- a/crates/agmem-store/tests/reads.rs
+++ b/crates/agmem-store/tests/reads.rs
@@ -11,7 +11,7 @@
 //! fulltext arm's order arbitrary. Every term asserted on here appears in
 //! exactly one row of several.
 
-use agmem_core::{DecayClass, EpisodeId, Kind, MemoryId, Source, SpaceName, dedup};
+use agmem_core::{DecayClass, EpisodeId, Kind, MemoryId, Source, SpaceName, Writer, dedup};
 use agmem_store::db::Db;
 use agmem_store::repo::{
     self, Batch, Candidate, Filters, Forget, Hit, Liveness, Lookup, NewChunk, NewEpisode,
@@ -73,6 +73,7 @@ async fn seeded() -> Db {
     repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: Some(NewEpisode {
                 content: "a long conversation".to_owned(),
@@ -232,6 +233,7 @@ async fn an_as_of_recall_excludes_chunks_that_had_not_yet_happened() {
     repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: Some(NewEpisode {
                 content: "an older conversation".to_owned(),
@@ -283,6 +285,7 @@ async fn a_closed_memory_is_invisible_until_the_window_asks_for_it() {
     repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: None,
             memories: vec![correction],
@@ -491,6 +494,7 @@ async fn a_count_answers_for_the_whole_selection_a_limit_only_pages() {
     repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: None,
             memories: vec![correction],
@@ -521,6 +525,7 @@ async fn a_history_walk_returns_the_whole_chain_from_any_link() {
     let second = repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: None,
             memories: vec![second],
@@ -536,6 +541,7 @@ async fn a_history_walk_returns_the_whole_chain_from_any_link() {
     let third = repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: None,
             memories: vec![third],
@@ -640,6 +646,7 @@ async fn the_near_dup_gate_measures_the_nearest_live_neighbour() {
     repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: None,
             memories: vec![correction],
@@ -764,6 +771,7 @@ async fn the_all_pairs_scan_pairs_every_live_row_with_its_own_vector() {
     repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: None,
             memories: vec![NewMemory::new(
@@ -887,6 +895,7 @@ async fn stale_contexts_are_the_rows_reinforcement_carried_past_the_prune() {
     let ids: Vec<MemoryId> = repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: None,
             memories: vec![

--- a/crates/agmem-store/tests/reindex.rs
+++ b/crates/agmem-store/tests/reindex.rs
@@ -4,7 +4,7 @@
 //! HNSW index will accept — so the negative cases here are the point: they
 //! are what says the clear cannot be skipped.
 
-use agmem_core::{Kind, SpaceName};
+use agmem_core::{Kind, SpaceName, Writer};
 use agmem_store::db::Db;
 use agmem_store::repo::{self, Batch, NewChunk, NewEpisode, NewMemory};
 use agmem_store::{StoreError, db, migrate};
@@ -44,6 +44,7 @@ async fn seed(db: &Db, width: Option<usize>) -> usize {
     repo::insert_batch(
         db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: Some(episode),
             memories: vec![fact, instruction],
@@ -86,6 +87,7 @@ async fn a_new_width_is_refused_until_the_vectors_are_cleared() {
     let err = repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: None,
             memories: vec![narrow],

--- a/crates/agmem-store/tests/writes.rs
+++ b/crates/agmem-store/tests/writes.rs
@@ -5,7 +5,9 @@
 //! reported result rather than an aborted transaction, that a rejected row
 //! takes the whole batch down with it — are proven here rather than assumed.
 
-use agmem_core::{DecayClass, Derivation, InvalidReason, Kind, MemoryId, Source, SpaceName};
+use agmem_core::{
+    DecayClass, Derivation, InvalidReason, Kind, MemoryId, Source, SpaceName, Writer,
+};
 use agmem_store::db::Db;
 use agmem_store::repo::{
     self, Batch, Forget, Liveness, Lookup, NewChunk, NewEpisode, NewMemory, Written,
@@ -44,10 +46,54 @@ async fn column<T: SurrealValue>(db: &Db, query: &str) -> Vec<T> {
 
 fn batch(memories: Vec<NewMemory>) -> Batch {
     Batch {
+        writer: Writer::default(),
         space: space(),
         episode: None,
         memories,
     }
+}
+
+/// Issue #75: the writer stamped on a batch rides every row it creates —
+/// memories read it back typed, and the episode records the same one.
+#[tokio::test]
+async fn a_batch_stamps_its_writer_on_every_row_it_creates() {
+    let db = store().await;
+    let stamp = Writer {
+        client: "test-client".to_owned(),
+        client_version: Some("1.2.3".to_owned()),
+        session: "session-1".to_owned(),
+        tool: "remember".to_owned(),
+    };
+    repo::insert_batch(
+        &db,
+        Batch {
+            writer: stamp.clone(),
+            space: space(),
+            episode: Some(NewEpisode::new("the verbatim text behind the claim")),
+            memories: vec![NewMemory::new(Kind::Fact, "the user prefers Rust")],
+        },
+    )
+    .await
+    .expect("batch");
+
+    let rows = repo::direct_lookup(&db, &Lookup::new(vec![space()]))
+        .await
+        .expect("lookup");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].writer,
+        Some(stamp),
+        "the memory reads back exactly the writer the batch carried"
+    );
+    assert_eq!(
+        column::<String>(&db, "SELECT VALUE writer.client FROM episode").await,
+        ["test-client"],
+        "the episode records the same writer"
+    );
+    assert_eq!(
+        column::<String>(&db, "SELECT VALUE writer.tool FROM episode").await,
+        ["remember"]
+    );
 }
 
 #[tokio::test]
@@ -65,6 +111,7 @@ async fn episode_chunks_and_memories_commit_together() {
     let outcome = repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: Some(NewEpisode {
                 content: "I like Rust. Python is fine too.".to_owned(),
@@ -223,6 +270,7 @@ async fn a_repeated_episode_is_reused_rather_than_re_chunked() {
     let first = repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: Some(episode()),
             memories: vec![NewMemory::new(Kind::Fact, "the user likes Rust")],
@@ -235,6 +283,7 @@ async fn a_repeated_episode_is_reused_rather_than_re_chunked() {
     let second = repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: Some(episode()),
             memories: vec![NewMemory::new(Kind::Fact, "the user dislikes Python")],
@@ -455,6 +504,7 @@ async fn one_rejected_row_rolls_the_whole_batch_back() {
     let error = repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: Some(NewEpisode::new("verbatim ground truth")),
             memories: vec![
@@ -487,6 +537,7 @@ async fn a_supersedes_target_outside_this_space_is_rejected_before_anything_is_w
     let elsewhere = repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: "other".parse().expect("valid slug"),
             episode: None,
             memories: vec![NewMemory::new(Kind::Fact, "a claim in another space")],
@@ -533,6 +584,7 @@ async fn elsewhere(db: &Db, space: &SpaceName, content: &str) -> MemoryId {
     repo::insert_batch(
         db,
         Batch {
+            writer: Writer::default(),
             space: space.clone(),
             episode: None,
             memories: vec![NewMemory::new(Kind::Fact, content)],
@@ -615,6 +667,7 @@ async fn a_purge_takes_an_episodes_slices_and_leaves_the_claims_drawn_from_it() 
     let outcome = repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: Some(NewEpisode {
                 content: "I like Rust. Python is fine too.".to_owned(),
@@ -1150,6 +1203,7 @@ async fn a_reflection_carries_its_citations_and_they_read_back_typed() {
     let seeded = repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: Some(NewEpisode::new("cargo build failed on a cold cache")),
             memories: vec![NewMemory::new(
@@ -1203,6 +1257,7 @@ async fn locate_says_which_table_each_id_belongs_to() {
     let seeded = repo::insert_batch(
         &db,
         Batch {
+            writer: Writer::default(),
             space: space(),
             episode: Some(NewEpisode::new("the verbatim text")),
             memories: vec![NewMemory::new(Kind::Fact, "the distilled claim")],

--- a/docs/design.md
+++ b/docs/design.md
@@ -163,6 +163,8 @@ DEFINE FIELD content_hash ON episode TYPE string;        -- blake3
 DEFINE FIELD occurred_at  ON episode TYPE datetime DEFAULT time::now();
 DEFINE FIELD session      ON episode TYPE option<string>;
 DEFINE FIELD created_at   ON episode TYPE datetime DEFAULT time::now();
+-- v6: which client wrote it (issue #75); sub-fields as on memory.writer
+DEFINE FIELD writer       ON episode TYPE option<object>;
 DEFINE INDEX episode_hash ON episode COLUMNS space, content_hash UNIQUE;
 
 DEFINE TABLE episode_chunk SCHEMAFULL;
@@ -199,6 +201,10 @@ DEFINE FIELD invalid_reason ON memory TYPE option<string>
 DEFINE FIELD supersedes    ON memory TYPE array<record<memory>> DEFAULT [];  -- v3: a list, so one claim can merge a cluster
 DEFINE FIELD superseded_by ON memory TYPE option<record<memory>>;
 DEFINE FIELD source        ON memory TYPE object;   -- { kind: "episode"|"agent"|"external", ref: option }
+-- v6: who performed the write (issue #75) — { client, client_version, session, tool },
+-- every sub-field option<string>; NONE on pre-v6 rows, never backfilled
+DEFINE FIELD writer        ON memory TYPE option<object>;
+DEFINE INDEX mem_writer_session ON memory COLUMNS writer.session;
 -- schema v2: what a `reflect` insight was drawn from; empty for every other write
 DEFINE FIELD derived_from  ON memory TYPE array<record<memory | episode>> DEFAULT [];
 DEFINE FIELD created_at    ON memory TYPE datetime DEFAULT time::now();
@@ -233,6 +239,12 @@ Notes:
   `meta`; switching embedders requires an explicit `agmem --reindex`
   maintenance pass — startup refuses a model/dim mismatch with a clear
   error rather than silently mixing spaces.
+- `writer` (v6) is the attribution `source` never was: `source` says where
+  the content came from, `writer` says which client and session put it in the
+  store, and which verb did the writing. It is stamped server-side from the
+  MCP `initialize` handshake (never trusted from tool arguments), reads as
+  absent on rows older than the field, and is the axis the per-source
+  occupancy defense (issue #76) will slice on.
 
 ### 2.3 Kinds, decay classes, and lifecycle
 


### PR DESCRIPTION
Closes #75 — writer provenance on every memory, the Phase 6 field that cannot be backfilled.

## What

- **Schema v6** (`v6_writer.surql`): `writer` as `option<object>` on `memory` and `episode` — `client`, `client_version`, `session`, `tool`, every sub-field `option<string>` — plus a `mem_writer_session` index. **No backfill**: pre-v6 rows read as absent ("not recorded"), never as a sentinel. Sub-fields are optional so the close-path UPDATEs (the v3 re-coercion lesson) keep reaching writerless rows; a migrate test proves a pre-v6 row still supersedes cleanly.
- **Identity is assembled server-side, per request**: client name/version from rmcp's `RequestContext::client_info()` (the `initialize` handshake), session from an `agmem/session` `_meta` key when a client offers one, else a per-connection id minted in `AgmemService::new` — the daemon builds one service per connection, which is exactly what a session is. `tool` names the verb (`remember` / `reflect`). Never trusted from tool arguments.
- **No daemon protocol bump**: after the one-line v3 handshake the daemon pump is a pure byte pump, so MCP-level identity reaches the per-connection service unchanged.
- **Plumbing**: `Batch.writer` stamps every row the transaction creates — `queries/write.rs` untouched, since rows bind as `CONTENT $row`. Reads project it typed; `MemoryRecord.writer: Option<Writer>`; `inspect` renders a `WriterView` (skipped when absent). `recall` output is unchanged, so the offline eval baseline stands.

## Tests

- migrate: pre-v6 row reads `writer: None` and still closes under a stamped correction.
- writes: a batch's writer rides every row — memory typed round-trip, episode via raw projection.
- protocol: over the wire, `inspect` shows `writer.tool == "remember"` / `"reflect"`, client and session non-empty.
- `list_tools` snapshot re-recorded for the new `writer` field in inspect's schema.

Full workspace suite, `clippy --all-targets -D warnings`, and `fmt --check` are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGe48K3fQ2boQnp9DRP1gL