### PR TITLE
chore: release v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-core"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "blake3",
  "jiff",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-embed"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "fastembed",
  "model2vec-rs",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-server"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "agmem-core",
  "agmem-embed",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-store"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "agmem-core",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -21,10 +21,10 @@ homepage = "https://github.com/AlfoldiMate/agmem"
 # dependency with no version requirement. Local builds resolve by path either
 # way, and a caret requirement stays satisfied across the bumps release-plz
 # makes.
-agmem-core = { path = "crates/agmem-core", version = "0.1.4" }
-agmem-store = { path = "crates/agmem-store", version = "0.1.4" }
+agmem-core = { path = "crates/agmem-core", version = "0.1.5" }
+agmem-store = { path = "crates/agmem-store", version = "0.1.5" }
 # default-features off so a BM25-only build can drop the ONNX half entirely
-agmem-embed = { path = "crates/agmem-embed", version = "0.1.4", default-features = false }
+agmem-embed = { path = "crates/agmem-embed", version = "0.1.5", default-features = false }
 
 # MCP + storage + embeddings (pinned per docs/design.md §4.1)
 rmcp = { version = "3.1", features = ["server", "macros", "transport-io"] }


### PR DESCRIPTION



## 🤖 New release

* `agmem-core`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `agmem-store`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `agmem-embed`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `agmem-server`: 0.1.4 -> 0.1.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).