### PR TITLE
The scorecard learns to smell a stale page (#79)

### DIFF
--- a/crates/agmem-server/tests/eval/metrics.rs
+++ b/crates/agmem-server/tests/eval/metrics.rs
@@ -1,4 +1,4 @@
-//! The four scorers and the scorecard they fill (issue #32).
+//! The five scorers and the scorecard they fill (issue #32).
 //!
 //! Every number here is read off a tool call's *returned or stored* result —
 //! never off "the call happened". The scorecard is all integers except MRR:
@@ -28,6 +28,7 @@ pub struct ScenarioScore {
     pub timeline: Ratio,
     pub gate: Gate,
     pub context: Ratio,
+    pub staleness: Staleness,
 }
 
 /// How much of the labelled-relevant set the probes brought back, and how
@@ -64,6 +65,17 @@ pub struct Gate {
     pub wrong_original: u32,
 }
 
+/// Supersession honesty over live pages (FAMA-style, issue #79). `pages` is
+/// how many live recalls the scenario scripts; `stale_hits` how many of
+/// their hits were claims corrected before the query ran. Zero is the only
+/// honest number — anything above it means a superseded claim reached a
+/// caller who never asked for history.
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct Staleness {
+    pub stale_hits: u32,
+    pub pages: u32,
+}
+
 /// Scores every scenario with the given embedder.
 pub async fn scorecard(scenarios: &[Scenario], embedder: Arc<dyn Embedder>) -> Scorecard {
     let mut scores = BTreeMap::new();
@@ -75,6 +87,7 @@ pub async fn scorecard(scenarios: &[Scenario], embedder: Arc<dyn Embedder>) -> S
                 timeline: timeline(scenario, embedder.clone()).await,
                 gate: gate(scenario, embedder.clone()).await,
                 context: context(scenario, embedder.clone()).await,
+                staleness: staleness(scenario, embedder.clone()).await,
             },
         );
     }
@@ -172,6 +185,45 @@ pub async fn timeline(scenario: &Scenario, embedder: Arc<dyn Embedder>) -> Ratio
     Ratio {
         passed,
         total: scenario.timeline.len() as u32,
+    }
+}
+
+/// Replays every live page the scenario scripts — each probe at its own `k`,
+/// each timeline check without `as_of` at the timeline's k of 10 — and
+/// counts hits that are claims some later seed superseded. Ground truth is
+/// the fixture's `supersedes` graph, not the hit's own annotation: a closed
+/// claim that leaks unannotated still counts.
+pub async fn staleness(scenario: &Scenario, embedder: Arc<dyn Embedder>) -> Staleness {
+    let mut pages: Vec<(&str, u16)> = scenario
+        .probes
+        .iter()
+        .map(|probe| (probe.query.as_str(), probe.k))
+        .collect();
+    pages.extend(
+        scenario
+            .timeline
+            .iter()
+            .filter(|check| check.as_of.is_none())
+            .map(|check| (check.query.as_str(), 10)),
+    );
+    let mut stale_hits = 0;
+    for (query, k) in &pages {
+        let seeded = scenario::seed(scenario, embedder.clone()).await;
+        let answer = seeded.agmem.recall(json!({ "query": query, "k": k })).await;
+        let superseded: HashSet<&str> = scenario
+            .superseded_labels()
+            .iter()
+            .map(|label| seeded.id(label))
+            .collect();
+        stale_hits += hit_ids(&answer)
+            .iter()
+            .filter(|id| superseded.contains(*id))
+            .count() as u32;
+        seeded.shutdown().await;
+    }
+    Staleness {
+        stale_hits,
+        pages: pages.len() as u32,
     }
 }
 

--- a/docs/eval/quality.md
+++ b/docs/eval/quality.md
@@ -56,6 +56,10 @@ cap covers exactly the flood the gate lets through.
       "context": {
         "passed": 24,
         "total": 24
+      },
+      "staleness": {
+        "stale_hits": 0,
+        "pages": 3
       }
     },
     "episode-flood": {
@@ -78,6 +82,10 @@ cap covers exactly the flood the gate lets through.
       "context": {
         "passed": 0,
         "total": 0
+      },
+      "staleness": {
+        "stale_hits": 0,
+        "pages": 1
       }
     },
     "formatter-switch": {
@@ -100,6 +108,10 @@ cap covers exactly the flood the gate lets through.
       "context": {
         "passed": 0,
         "total": 0
+      },
+      "staleness": {
+        "stale_hits": 0,
+        "pages": 4
       }
     },
     "user-profile": {
@@ -122,6 +134,10 @@ cap covers exactly the flood the gate lets through.
       "context": {
         "passed": 8,
         "total": 8
+      },
+      "staleness": {
+        "stale_hits": 0,
+        "pages": 4
       }
     }
   }
@@ -143,6 +159,12 @@ Reading it:
 - **context** — the context-block checklist: section order, budget, no claim
   twice, no superseded or verbatim-episode text, every cited id resolves
   through `inspect`, plus each case's own must/must-not entries.
+- **staleness** — supersession honesty, FAMA-style (issue #79): across every
+  live page the scenario scripts (each probe at its own `k`, each timeline
+  check without `as_of` at 10), how many hits were claims already corrected
+  when the query ran. Ground truth is the fixture's `supersedes` graph, not
+  the hit's annotation, so a closed claim leaking unannotated still counts.
+  Zero is the only honest number.
 
 ## Re-running
 
@@ -182,6 +204,25 @@ Two mechanisms answer "would this harness notice a broken scoring change":
   | formatter-switch timeline passed | 2/2 | 1/2 |
   | user-profile retrieval found | 3/3 | 2/3 |
   | user-profile retrieval mrr | 0.8333 | 0.1778 |
+
+  Setting `resolve_liveness`'s live default (`agmem-server/src/tools/recall.rs`)
+  from `Liveness::Live` to `Liveness::Any` — corrected claims competing on
+  every live page, the failure class issue #79 targets — moved six fields
+  (run 2026-09-01):
+
+  | field | baseline | mutated |
+  |---|---|---|
+  | deploy-migration staleness stale_hits | 0 | 3 |
+  | formatter-switch retrieval mrr | 0.5556 | 0.5278 |
+  | formatter-switch timeline passed | 2/2 | 1/2 |
+  | formatter-switch staleness stale_hits | 0 | 4 |
+  | user-profile retrieval mrr | 0.8333 | 0.6111 |
+  | user-profile staleness stale_hits | 0 | 4 |
+
+  In deploy-migration the staleness column is the *only* field that moved:
+  before it existed, a broken live filter passed that scenario's baseline
+  clean. That gap — a run scoring honest while corrected claims surface —
+  is what the column closes.
 
 ## What the baseline says about the system
 


### PR DESCRIPTION
Closes #79.

## What

A fifth scorecard column, **staleness** — FAMA-style supersession honesty. It replays every live page a scenario already scripts (each probe at its own `k`, each timeline check without `as_of` at 10) and counts hits that are claims some later seed superseded. Ground truth is the fixture's `supersedes` graph, not the hit's own annotation, so a closed claim leaking *unannotated* still counts. Zero is the only honest number; the baseline records zero across all twelve live pages.

## Why the harness needed it

The timeline metric spot-checks specific queries with `absent` labels; probes only measure recall of *relevant* claims. A superseded claim surfacing in a probe's page diluted nothing and cost nothing — a run where a corrected claim outranks its correction scored clean.

## Sensitivity

Forcing `resolve_liveness`'s live default from `Liveness::Live` to `Liveness::Any` (corrected claims competing on every live page) moved six fields, recorded in the mutation section of `docs/eval/quality.md`:

| field | baseline | mutated |
|---|---|---|
| deploy-migration staleness stale_hits | 0 | 3 |
| formatter-switch retrieval mrr | 0.5556 | 0.5278 |
| formatter-switch timeline passed | 2/2 | 1/2 |
| formatter-switch staleness stale_hits | 0 | 4 |
| user-profile retrieval mrr | 0.8333 | 0.6111 |
| user-profile staleness stale_hits | 0 | 4 |

In **deploy-migration the staleness column is the only field that moved** — before this metric, a broken live filter passed that scenario's baseline clean. That gap is exactly what #79 names.

No fixture strings changed, so the recorded vectors stand; only the scorecard block and prose in `docs/eval/quality.md` move alongside the scorer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGe48K3fQ2boQnp9DRP1gL