### PR TITLE
The reranker auditions and does not get the part (#81)

### DIFF
--- a/crates/agmem-embed/Cargo.toml
+++ b/crates/agmem-embed/Cargo.toml
@@ -15,6 +15,10 @@ onnx = ["dep:fastembed"]
 # The model2vec static backend: pure Rust, no ONNX, instant cold start
 # (design risk #1 contingency).
 static = ["dep:model2vec-rs"]
+# The cross-encoder rerank probe (issue #81): measurement surface only —
+# nothing in the server links it. Rides on `onnx`, so BM25-only builds
+# stay ONNX-free.
+rerank = ["onnx"]
 
 [dependencies]
 fastembed = { workspace = true, optional = true }

--- a/crates/agmem-embed/src/lib.rs
+++ b/crates/agmem-embed/src/lib.rs
@@ -17,6 +17,8 @@ use std::sync::Arc;
 #[cfg(feature = "onnx")]
 pub mod fastembed;
 pub mod noop;
+#[cfg(feature = "rerank")]
+pub mod rerank;
 #[cfg(feature = "static")]
 pub mod static_m2v;
 

--- a/crates/agmem-embed/src/rerank.rs
+++ b/crates/agmem-embed/src/rerank.rs
@@ -1,0 +1,103 @@
+//! The cross-encoder behind the #81 rerank probe: jina-reranker-v1-turbo-en
+//! over ONNX, via fastembed's `TextRerank`.
+//!
+//! Measurement surface only, for now. Nothing in the server constructs this;
+//! the ignored recorder in `tests/rerank.rs` is the one caller, and
+//! `docs/eval/rerank-probe.md` is where its numbers decide whether a
+//! production path gets built at all.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use fastembed::{RerankInitOptions, RerankerModel, TextRerank};
+
+use crate::EmbedError;
+
+/// What a store would record if this model ever wrote one.
+pub const MODEL_ID: &str = "jina-reranker-v1-turbo-en";
+
+/// The model fastembed downloads and runs. Unquantized ONNX, ~150 MB — five
+/// times BGE-small-q, which is part of what the probe's verdict weighs.
+const MODEL: RerankerModel = RerankerModel::JINARerankerV1TurboEn;
+
+/// Local cross-encoder scoring of (query, passage) pairs.
+pub struct FastembedReranker {
+    /// `TextRerank::rerank` takes `&mut self`, so concurrent callers queue —
+    /// the same shape as [`crate::fastembed::FastembedBackend`], for the
+    /// same reason.
+    model: Mutex<TextRerank>,
+}
+
+impl std::fmt::Debug for FastembedReranker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FastembedReranker")
+            .field("model", &MODEL_ID)
+            .finish()
+    }
+}
+
+impl FastembedReranker {
+    /// Load the model, downloading it once if the cache is empty.
+    ///
+    /// `fallback_cache_dir` behaves exactly as the embedder's does:
+    /// `FASTEMBED_CACHE_DIR` stays authoritative (CI points it somewhere
+    /// unwritable to catch an unintended download), and progress bars stay
+    /// off — stdout is never ours.
+    ///
+    /// # Errors
+    /// [`EmbedError::Backend`] when the model cannot be fetched or loaded.
+    pub fn new(fallback_cache_dir: Option<PathBuf>) -> Result<Self, EmbedError> {
+        let mut options = RerankInitOptions::new(MODEL).with_show_download_progress(false);
+        if std::env::var_os("FASTEMBED_CACHE_DIR").is_none()
+            && let Some(dir) = fallback_cache_dir
+        {
+            options = options.with_cache_dir(dir);
+        }
+        let model = TextRerank::try_new(options).map_err(|error| EmbedError::Backend {
+            backend: MODEL_ID,
+            message: error.to_string(),
+        })?;
+        Ok(Self {
+            model: Mutex::new(model),
+        })
+    }
+
+    /// The raw relevance logit for each passage against `query`, in the
+    /// order the passages were given.
+    ///
+    /// Logits, not probabilities: fastembed hands back the model's head
+    /// unsigmoided and unbounded, and the caller calibrating a threshold
+    /// should say which unit it chose. `batch` sizes the ONNX batches;
+    /// `None` takes fastembed's default.
+    ///
+    /// # Errors
+    /// [`EmbedError::Backend`] for anything ONNX or the tokenizer rejects.
+    pub fn scores(
+        &self,
+        query: &str,
+        passages: &[String],
+        batch: Option<usize>,
+    ) -> Result<Vec<f64>, EmbedError> {
+        if passages.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut model = self.model.lock().map_err(|_| EmbedError::Backend {
+            backend: MODEL_ID,
+            message: "a previous caller panicked while scoring".to_owned(),
+        })?;
+        // `rerank` infers one `S` for query and documents both, so the
+        // passages travel as `&str` beside the `&str` query.
+        let passages: Vec<&str> = passages.iter().map(String::as_str).collect();
+        let ranked = model
+            .rerank(query, &passages, false, batch)
+            .map_err(|error| EmbedError::Backend {
+                backend: MODEL_ID,
+                message: error.to_string(),
+            })?;
+        let mut scores = vec![0.0; passages.len()];
+        for result in ranked {
+            scores[result.index] = f64::from(result.score);
+        }
+        Ok(scores)
+    }
+}

--- a/crates/agmem-embed/tests/rerank.rs
+++ b/crates/agmem-embed/tests/rerank.rs
@@ -1,0 +1,168 @@
+//! The #81 stage-0 probe: score every eval-fixture query against every
+//! fixture passage with the real cross-encoder, commit the map, and print
+//! the two blocks `docs/eval/rerank-probe.md` records — the abstention
+//! decision table and the latency budget. The decision rule lives in that
+//! document and was committed before this ran.
+
+#![cfg(feature = "rerank")]
+
+use std::collections::BTreeMap;
+use std::time::Instant;
+
+use agmem_embed::rerank::{FastembedReranker, MODEL_ID};
+
+fn sigmoid(logit: f64) -> f64 {
+    1.0 / (1.0 + (-logit).exp())
+}
+
+fn median(mut samples: Vec<f64>) -> f64 {
+    samples.sort_by(f64::total_cmp);
+    samples[samples.len() / 2]
+}
+
+/// One scenario's material: what may be asked, against what could answer.
+struct Material {
+    name: String,
+    /// `(kind, query)` — `probe` pages must answer, `abstain` must not,
+    /// `other` is recorded for a future `RecordedReranker` replay.
+    queries: Vec<(&'static str, String)>,
+    /// Seed contents and episode texts, the whole candidate surface.
+    passages: Vec<String>,
+}
+
+fn strings_of(section: &serde_json::Value, field: &str) -> Vec<String> {
+    section
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry[field].as_str())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn materials() -> Vec<Material> {
+    let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../agmem-server/tests/fixtures/eval/scenarios");
+    let mut paths: Vec<_> = std::fs::read_dir(&dir)
+        .expect("read the scenario dir")
+        .map(|entry| entry.expect("dir entry").path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .collect();
+    paths.sort();
+    paths
+        .iter()
+        .map(|path| {
+            let raw = std::fs::read_to_string(path).expect("read scenario");
+            let scenario: serde_json::Value = serde_json::from_str(&raw).expect("parse scenario");
+            let mut queries: Vec<(&'static str, String)> = Vec::new();
+            for query in strings_of(&scenario["probes"], "query") {
+                queries.push(("probe", query));
+            }
+            for query in strings_of(&scenario["abstain"], "query") {
+                queries.push(("abstain", query));
+            }
+            for section in ["timeline", "temporal", "context"] {
+                for query in strings_of(&scenario[section], "query") {
+                    if !queries.iter().any(|(_, seen)| *seen == query) {
+                        queries.push(("other", query));
+                    }
+                }
+            }
+            let mut passages = strings_of(&scenario["seeds"], "content");
+            passages.extend(strings_of(&scenario["seeds"], "episode"));
+            Material {
+                name: scenario["name"].as_str().expect("a name").to_owned(),
+                queries,
+                passages,
+            }
+        })
+        .collect()
+}
+
+/// Runs the real model. Downloads ~150 MB on the first run; deliberate.
+#[test]
+#[ignore = "downloads and runs the real reranker; writes a committed fixture"]
+fn record_rerank_scores() {
+    let cache = std::env::temp_dir().join("agmem-model-cache");
+    let loading = Instant::now();
+    let reranker = FastembedReranker::new(Some(cache.clone())).expect("load the reranker");
+    let load_ms = loading.elapsed().as_secs_f64() * 1000.0;
+
+    let materials = materials();
+    // BTreeMaps so the committed file diffs by text, as vectors.json does.
+    let mut pairs: BTreeMap<String, BTreeMap<String, f64>> = BTreeMap::new();
+    eprintln!("== decision table (sigmoid of the page's best logit) ==");
+    for material in &materials {
+        for (kind, query) in &material.queries {
+            let scores = reranker
+                .scores(query, &material.passages, None)
+                .expect("score the scenario");
+            let best = scores
+                .iter()
+                .copied()
+                .max_by(f64::total_cmp)
+                .expect("scenarios have passages");
+            if *kind != "other" {
+                eprintln!(
+                    "{kind} [{}] best {:.4} (logit {:+.3}) {query:?}",
+                    material.name,
+                    sigmoid(best),
+                    best,
+                );
+            }
+            let slot = pairs.entry(query.clone()).or_default();
+            for (passage, score) in material.passages.iter().zip(&scores) {
+                slot.insert(passage.clone(), *score);
+            }
+        }
+    }
+
+    // The latency block: a 30-candidate page per call, the shape the issue
+    // names, against the one-off load and the embedder call a recall
+    // already pays.
+    let page: Vec<String> = materials
+        .iter()
+        .flat_map(|material| material.passages.iter().cloned())
+        .cycle()
+        .take(30)
+        .collect();
+    let question = "how do releases go out";
+    for batch in [8_usize, 16, 32] {
+        let runs: Vec<f64> = (0..5)
+            .map(|_| {
+                let start = Instant::now();
+                reranker
+                    .scores(question, &page, Some(batch))
+                    .expect("score the page");
+                start.elapsed().as_secs_f64() * 1000.0
+            })
+            .collect();
+        eprintln!(
+            "latency: 30 candidates, batch {batch}: p50 {:.0} ms",
+            median(runs)
+        );
+    }
+    let embedder =
+        agmem_embed::fastembed::FastembedBackend::new(Some(cache)).expect("load the embedder");
+    let embeds: Vec<f64> = (0..5)
+        .map(|_| {
+            let start = Instant::now();
+            agmem_embed::Embedder::embed_query(&embedder, question).expect("embed");
+            start.elapsed().as_secs_f64() * 1000.0
+        })
+        .collect();
+    eprintln!(
+        "latency: model load {load_ms:.0} ms one-off; embed_query p50 {:.0} ms",
+        median(embeds)
+    );
+
+    let out = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../agmem-server/tests/fixtures/eval/rerank.json");
+    let document = serde_json::json!({ "model": MODEL_ID, "pairs": pairs });
+    std::fs::write(
+        &out,
+        serde_json::to_string_pretty(&document).expect("serialize") + "\n",
+    )
+    .expect("write fixture");
+    eprintln!("wrote {}", out.display());
+}

--- a/crates/agmem-server/tests/fixtures/eval/rerank.json
+++ b/crates/agmem-server/tests/fixtures/eval/rerank.json
@@ -1,0 +1,218 @@
+{
+  "model": "jina-reranker-v1-turbo-en",
+  "pairs": {
+    "how are the automated checks executed?": {
+      "A fiddle-leaf fig sits by the office window and needs weekly watering.": -3.949223518371582,
+      "CI runs the test suite with pytest under tox.": -2.8579719066619873,
+      "Cold cargo caches make the first CI build take twenty minutes; a nightly job keeps them warm.": -3.424945592880249,
+      "The project formats Python with black.": -4.021042346954346,
+      "The project switched its Python formatter to ruff format; black is retired.": -3.43699312210083,
+      "The team orders Neapolitan pizza for Friday lunch.": -4.440381050109863,
+      "The user edits in Helix, not VS Code.": -2.282088041305542
+    },
+    "how deployments work": {
+      "Database migrations must run before the new pods roll out, or the old schema panics.": -3.208909034729004,
+      "Deployments are run by hand from the lead developer's laptop.": -1.0312473773956299,
+      "Deployments run from the CI pipeline on every tagged release.": -2.2373595237731934,
+      "Never force-push to the main branch.": -3.436434745788574,
+      "The API gateway lives in the infra repository and is deployed separately.": -2.7064385414123535,
+      "The espresso machine on the third floor is broken again.": -4.528151512145996,
+      "The user works from the Europe/Budapest timezone.": -3.2775509357452393,
+      "We spent the afternoon moving the deploy job into CI. The laptop flow kept breaking on SSH keys, so tagged releases now trigger the pipeline instead.": -1.29938805103302
+    },
+    "how do I claim travel expenses for the client visit?": {
+      "A circuit breaker sheds search traffic before the cluster saturates.": -3.7964940071105957,
+      "Post-incident review of the search cluster outage: we walked the whole timeline, from the first elevated latencies to full recovery, and noted what every subsystem did while search was down.": -3.902017116546631,
+      "Query timeouts had to be raised from two seconds to eight while search recovered.": -3.990903854370117,
+      "Result caching masked the problem at first, serving stale search hits for forty minutes.": -2.851766586303711,
+      "Search's coordinator node needed two restarts before the cluster finally held.": -4.190290451049805,
+      "The load balancer shed a third of incoming search queries at the height of the incident.": -4.0425848960876465,
+      "The marketing site got a new logo in June.": -4.11456823348999,
+      "The nightly index rebuild was paused to free memory while the search cluster was down.": -4.262015342712402,
+      "The on-call pager stayed silent for the first eleven minutes, well after users saw errors.": -3.8331046104431152,
+      "The search cluster now keeps a second replica of every shard, so a single node failure is survivable.": -4.3619160652160645
+    },
+    "how do releases go out": {
+      "Database migrations must run before the new pods roll out, or the old schema panics.": -3.2507901191711426,
+      "Deployments are run by hand from the lead developer's laptop.": -3.5103397369384766,
+      "Deployments run from the CI pipeline on every tagged release.": -3.3655052185058594,
+      "Never force-push to the main branch.": -4.052469253540039,
+      "The API gateway lives in the infra repository and is deployed separately.": -4.166182518005371,
+      "The espresso machine on the third floor is broken again.": -4.265393257141113,
+      "The user works from the Europe/Budapest timezone.": -3.982334613800049,
+      "We spent the afternoon moving the deploy job into CI. The laptop flow kept breaking on SSH keys, so tagged releases now trigger the pipeline instead.": -2.1788992881774902
+    },
+    "python formatter": {
+      "A fiddle-leaf fig sits by the office window and needs weekly watering.": -3.9206199645996094,
+      "CI runs the test suite with pytest under tox.": -2.169764518737793,
+      "Cold cargo caches make the first CI build take twenty minutes; a nightly job keeps them warm.": -3.390869617462158,
+      "The project formats Python with black.": -0.6090502142906189,
+      "The project switched its Python formatter to ruff format; black is retired.": 1.4472992420196533,
+      "The team orders Neapolitan pizza for Friday lunch.": -4.359029293060303,
+      "The user edits in Helix, not VS Code.": -3.2566025257110596
+    },
+    "what animal shares the user's home?": {
+      "A grey cat named Miso lives with the user.": -0.5633310079574585,
+      "The user is vegetarian and allergic to peanuts.": -1.042036533355713,
+      "The user lives in London.": -1.3314337730407715,
+      "The user prefers Rust for systems tools and reaches for it by default.": -3.3605313301086426,
+      "The user relocated to Lisbon in the spring.": -2.2361745834350586,
+      "The user visited Lisbon on holiday in 2019.": -3.302272319793701,
+      "The user's sister lives in Manchester.": -1.7285163402557373
+    },
+    "what are the gym's opening hours on public holidays?": {
+      "A fiddle-leaf fig sits by the office window and needs weekly watering.": -3.147177219390869,
+      "CI runs the test suite with pytest under tox.": -3.9036808013916016,
+      "Cold cargo caches make the first CI build take twenty minutes; a nightly job keeps them warm.": -1.9900245666503906,
+      "The project formats Python with black.": -4.002676963806152,
+      "The project switched its Python formatter to ruff format; black is retired.": -4.065518856048584,
+      "The team orders Neapolitan pizza for Friday lunch.": -3.515026807785034,
+      "The user edits in Helix, not VS Code.": -3.925137519836426
+    },
+    "what discount applies to the annual conference tickets?": {
+      "Database migrations must run before the new pods roll out, or the old schema panics.": -3.5426619052886963,
+      "Deployments are run by hand from the lead developer's laptop.": -4.280275344848633,
+      "Deployments run from the CI pipeline on every tagged release.": -3.9048659801483154,
+      "Never force-push to the main branch.": -3.879149913787842,
+      "The API gateway lives in the infra repository and is deployed separately.": -4.305229187011719,
+      "The espresso machine on the third floor is broken again.": -4.317305088043213,
+      "The user works from the Europe/Budapest timezone.": -3.233253002166748,
+      "We spent the afternoon moving the deploy job into CI. The laptop flow kept breaking on SSH keys, so tagged releases now trigger the pipeline instead.": -4.3554301261901855
+    },
+    "what does the developer write code in?": {
+      "A fiddle-leaf fig sits by the office window and needs weekly watering.": -3.5795717239379883,
+      "CI runs the test suite with pytest under tox.": -1.8988661766052246,
+      "Cold cargo caches make the first CI build take twenty minutes; a nightly job keeps them warm.": -3.023982048034668,
+      "The project formats Python with black.": -2.2837634086608887,
+      "The project switched its Python formatter to ruff format; black is retired.": -2.5514636039733887,
+      "The team orders Neapolitan pizza for Friday lunch.": -4.440514087677002,
+      "The user edits in Helix, not VS Code.": -1.0860872268676758
+    },
+    "what food restrictions should dinner plans respect?": {
+      "A grey cat named Miso lives with the user.": -3.562260627746582,
+      "The user is vegetarian and allergic to peanuts.": -2.16243314743042,
+      "The user lives in London.": -3.819281578063965,
+      "The user prefers Rust for systems tools and reaches for it by default.": -4.0865583419799805,
+      "The user relocated to Lisbon in the spring.": -4.456507682800293,
+      "The user visited Lisbon on holiday in 2019.": -4.530107498168945,
+      "The user's sister lives in Manchester.": -4.1901960372924805
+    },
+    "what happened during the search cluster outage?": {
+      "A circuit breaker sheds search traffic before the cluster saturates.": -1.2054295539855957,
+      "Post-incident review of the search cluster outage: we walked the whole timeline, from the first elevated latencies to full recovery, and noted what every subsystem did while search was down.": 0.7771620750427246,
+      "Query timeouts had to be raised from two seconds to eight while search recovered.": -0.9336259961128235,
+      "Result caching masked the problem at first, serving stale search hits for forty minutes.": -1.2322170734405518,
+      "Search's coordinator node needed two restarts before the cluster finally held.": -1.0311837196350098,
+      "The load balancer shed a third of incoming search queries at the height of the incident.": -1.0337631702423096,
+      "The marketing site got a new logo in June.": -3.289541721343994,
+      "The nightly index rebuild was paused to free memory while the search cluster was down.": -0.6314963102340698,
+      "The on-call pager stayed silent for the first eleven minutes, well after users saw errors.": -1.1975404024124146,
+      "The search cluster now keeps a second replica of every shard, so a single node failure is survivable.": -0.8230960369110107
+    },
+    "what is the kubernetes ingress configuration for the staging cluster?": {
+      "A grey cat named Miso lives with the user.": -3.412226676940918,
+      "The user is vegetarian and allergic to peanuts.": -3.4910831451416016,
+      "The user lives in London.": -2.6313564777374268,
+      "The user prefers Rust for systems tools and reaches for it by default.": -2.0740904808044434,
+      "The user relocated to Lisbon in the spring.": -2.958056926727295,
+      "The user visited Lisbon on holiday in 2019.": -3.7041049003601074,
+      "The user's sister lives in Manchester.": -3.6065449714660645
+    },
+    "what is the recipe for the team's chilli cook-off entry?": {
+      "A circuit breaker sheds search traffic before the cluster saturates.": -3.381241798400879,
+      "Post-incident review of the search cluster outage: we walked the whole timeline, from the first elevated latencies to full recovery, and noted what every subsystem did while search was down.": -3.9879841804504395,
+      "Query timeouts had to be raised from two seconds to eight while search recovered.": -3.6545634269714355,
+      "Result caching masked the problem at first, serving stale search hits for forty minutes.": -2.7474167346954346,
+      "Search's coordinator node needed two restarts before the cluster finally held.": -3.4606523513793945,
+      "The load balancer shed a third of incoming search queries at the height of the incident.": -2.8098630905151367,
+      "The marketing site got a new logo in June.": -4.027266502380371,
+      "The nightly index rebuild was paused to free memory while the search cluster was down.": -3.9340872764587402,
+      "The on-call pager stayed silent for the first eleven minutes, well after users saw errors.": -3.6113805770874023,
+      "The search cluster now keeps a second replica of every shard, so a single node failure is survivable.": -3.2670624256134033
+    },
+    "what should I know about this person?": {
+      "A grey cat named Miso lives with the user.": -3.2006516456604004,
+      "The user is vegetarian and allergic to peanuts.": -3.084972858428955,
+      "The user lives in London.": -2.7689318656921387,
+      "The user prefers Rust for systems tools and reaches for it by default.": -4.15379524230957,
+      "The user relocated to Lisbon in the spring.": -3.7921299934387207,
+      "The user visited Lisbon on holiday in 2019.": -4.003835678100586,
+      "The user's sister lives in Manchester.": -2.852325916290283
+    },
+    "where does the service that routes external traffic live?": {
+      "Database migrations must run before the new pods roll out, or the old schema panics.": -3.779552459716797,
+      "Deployments are run by hand from the lead developer's laptop.": -3.4043290615081787,
+      "Deployments run from the CI pipeline on every tagged release.": -2.3290271759033203,
+      "Never force-push to the main branch.": -3.5262584686279297,
+      "The API gateway lives in the infra repository and is deployed separately.": -1.5284249782562256,
+      "The espresso machine on the third floor is broken again.": -4.170482158660889,
+      "The user works from the Europe/Budapest timezone.": -0.5757929682731628,
+      "We spent the afternoon moving the deploy job into CI. The laptop flow kept breaking on SSH keys, so tagged releases now trigger the pipeline instead.": -3.225029468536377
+    },
+    "where does the user live": {
+      "A grey cat named Miso lives with the user.": -2.6409788131713867,
+      "The user is vegetarian and allergic to peanuts.": -2.9057822227478027,
+      "The user lives in London.": 0.13796567916870117,
+      "The user prefers Rust for systems tools and reaches for it by default.": -3.2800183296203613,
+      "The user relocated to Lisbon in the spring.": -1.7472503185272217,
+      "The user visited Lisbon on holiday in 2019.": -3.1506152153015137,
+      "The user's sister lives in Manchester.": -1.4350557327270508
+    },
+    "where is the user based these days?": {
+      "A grey cat named Miso lives with the user.": -2.0726280212402344,
+      "The user is vegetarian and allergic to peanuts.": -1.7786519527435303,
+      "The user lives in London.": -0.27333202958106995,
+      "The user prefers Rust for systems tools and reaches for it by default.": -2.143310070037842,
+      "The user relocated to Lisbon in the spring.": -0.736240804195404,
+      "The user visited Lisbon on holiday in 2019.": -1.3315545320510864,
+      "The user's sister lives in Manchester.": -1.0138533115386963
+    },
+    "which cloud region hosts the customer analytics warehouse?": {
+      "A fiddle-leaf fig sits by the office window and needs weekly watering.": -4.015856742858887,
+      "CI runs the test suite with pytest under tox.": -3.8123979568481445,
+      "Cold cargo caches make the first CI build take twenty minutes; a nightly job keeps them warm.": -3.8308606147766113,
+      "The project formats Python with black.": -3.5999245643615723,
+      "The project switched its Python formatter to ruff format; black is retired.": -4.249223232269287,
+      "The team orders Neapolitan pizza for Friday lunch.": -4.3710174560546875,
+      "The user edits in Helix, not VS Code.": -3.0328049659729004
+    },
+    "which herbs grow best on a shaded balcony?": {
+      "A grey cat named Miso lives with the user.": -3.332353115081787,
+      "The user is vegetarian and allergic to peanuts.": -1.995227575302124,
+      "The user lives in London.": -3.6140940189361572,
+      "The user prefers Rust for systems tools and reaches for it by default.": -4.568090915679932,
+      "The user relocated to Lisbon in the spring.": -4.470047950744629,
+      "The user visited Lisbon on holiday in 2019.": -4.368980407714844,
+      "The user's sister lives in Manchester.": -4.3134026527404785
+    },
+    "which tool tidies up our source code layout?": {
+      "A fiddle-leaf fig sits by the office window and needs weekly watering.": -2.0943148136138916,
+      "CI runs the test suite with pytest under tox.": -2.091312885284424,
+      "Cold cargo caches make the first CI build take twenty minutes; a nightly job keeps them warm.": -2.917952537536621,
+      "The project formats Python with black.": -1.605238676071167,
+      "The project switched its Python formatter to ruff format; black is retired.": -2.3135831356048584,
+      "The team orders Neapolitan pizza for Friday lunch.": -4.080488204956055,
+      "The user edits in Helix, not VS Code.": -0.7765235900878906
+    },
+    "who is cast in the theatre production this autumn?": {
+      "Database migrations must run before the new pods roll out, or the old schema panics.": -4.273312568664551,
+      "Deployments are run by hand from the lead developer's laptop.": -3.9614362716674805,
+      "Deployments run from the CI pipeline on every tagged release.": -4.329422950744629,
+      "Never force-push to the main branch.": -4.043063640594482,
+      "The API gateway lives in the infra repository and is deployed separately.": -4.297112464904785,
+      "The espresso machine on the third floor is broken again.": -4.096869468688965,
+      "The user works from the Europe/Budapest timezone.": -2.3294143676757812,
+      "We spent the afternoon moving the deploy job into CI. The laptop flow kept breaking on SSH keys, so tagged releases now trigger the pipeline instead.": -4.228933334350586
+    },
+    "who or what pushes new versions to production?": {
+      "Database migrations must run before the new pods roll out, or the old schema panics.": -2.6363775730133057,
+      "Deployments are run by hand from the lead developer's laptop.": -1.9403191804885864,
+      "Deployments run from the CI pipeline on every tagged release.": -2.1965787410736084,
+      "Never force-push to the main branch.": -1.4429287910461426,
+      "The API gateway lives in the infra repository and is deployed separately.": -3.643364906311035,
+      "The espresso machine on the third floor is broken again.": -3.779343605041504,
+      "The user works from the Europe/Budapest timezone.": -1.5841059684753418,
+      "We spent the afternoon moving the deploy job into CI. The laptop flow kept breaking on SSH keys, so tagged releases now trigger the pipeline instead.": -2.247692823410034
+    }
+  }
+}

--- a/docs/eval/quality.md
+++ b/docs/eval/quality.md
@@ -329,7 +329,13 @@ A third mechanism ran once rather than continuously: the fusion-weight
 sweep (issue #80, `docs/eval/fusion-sweep.md`) measured fixed convex blends
 of the two retrieval arms against RRF across this whole scorecard. RRF
 stays — the write-up records a formal aggregate win that was rejected on
-Pareto and fixture-bias grounds, and what would reopen it.
+Pareto and fixture-bias grounds, and what would reopen it. A fourth,
+the cross-encoder rerank probe (issue #81, `docs/eval/rerank-probe.md`),
+scored every fixture query×passage pair with jina-reranker-v1-turbo-en
+against a pre-registered abstention rule and was measured and dropped:
+the reranker trades the cosine floor's two confusables for two new ones,
+5/8 fired against the cosine's 6/8. Its full score map is committed
+beside the vectors for model-free replay.
 
 ## What the baseline says about the system
 

--- a/docs/eval/rerank-probe.md
+++ b/docs/eval/rerank-probe.md
@@ -1,0 +1,101 @@
+# Cross-encoder rerank probe (issue #81)
+
+Stage 0 of #81: before any production surface exists — no `Search` field, no
+config knob, no `recall.rs` change — the real model
+(fastembed's `TextRerank`, jina-reranker-v1-turbo-en, ONNX) scores every
+eval-fixture query against every fixture passage, offline, and this document
+decides what happens next. The precedent is `fusion-sweep.md`: #80 closed on
+its measurement, and "measured and dropped" is an acceptable end for #81 —
+the reference prior (ARAGOG) measured reranking flat.
+
+The probe aims at **abstention, not ordering**. Ordering verdicts on these
+fixtures are structurally untrustworthy twice over: the probes are
+anti-lexical by design (`fusion-sweep.md`), and ΣMRR moves in quanta of
+0.167–0.5, so any aggregate threshold is decided by a single probe's rank
+flip. Abstention's ground truth — "nothing seeded answers this" — survives
+both, has 17 binary units, and carries two *named* failures the single-cosine
+floor provably cannot catch (the 0.655–0.691 confusion band recorded in
+`quality.md`). A margin signal beyond one cosine is exactly what the #77
+calibration said would move `fired` past 6-of-8.
+
+## Decision rule, fixed before any number was read
+
+- **Primary — abstention.** Adopt only if a threshold `t` on
+  `sigmoid(logit)` exists with zero false abstentions across all nine probe
+  pages **and** `fired ≥ 7/8` (single-cosine baseline: 6/8), with at least
+  0.05 margin between the weakest relevant page and the strongest
+  unanswerable it catches. A `t` that only reproduces 6/8 closes #81 as
+  measured-and-dropped: a 150 MB model must buy more than a 30 MB cosine
+  already does.
+- **Secondary — ordering.** Report-only at this stage, and Pareto or
+  nothing if ever acted on: no scenario's `retrieval.mrr` may fall, no gate
+  column may worsen. Even a Pareto win waits on the keyword-shaped probes
+  `fusion-sweep.md` names as its reopen condition.
+- **Latency.** Warm model load under 3 s (one-off; the daemon amortises
+  it), 30-candidate rerank p50 ≤ 150 ms, reported beside the current
+  `embed_query` cost so the addition is a fraction of something measured.
+
+## Method
+
+`cargo test -p agmem-embed --features rerank --test rerank -- --ignored
+record_rerank_scores --nocapture` walks the committed scenario fixtures,
+scores every query (probes, unanswerables, timeline/temporal/context
+queries) against every passage of the same scenario (seed contents and
+episode texts), commits the full score map to
+`crates/agmem-server/tests/fixtures/eval/rerank.json` (so a later
+`RecordedReranker` can replay it bit-stably, as `RecordedEmbedder` does for
+vectors), and prints the decision table and the latency block this document
+records.
+
+## Results
+
+_(recorded after the rule above was committed)_
+
+<!-- rerank:results -->
+Run 2026-09-01, `sigmoid` of each page's best logit. Full score map in
+`crates/agmem-server/tests/fixtures/eval/rerank.json`.
+
+| page | kind | best |
+|---|---|---|
+| episode-flood "what happened during the search cluster outage?" | probe | 0.685 |
+| user-profile "where is the user based these days?" | probe | 0.432 |
+| deploy-migration "…routes external traffic…" | probe | 0.360 |
+| user-profile "what animal shares the user's home?" | probe | 0.363 |
+| formatter-switch "which tool tidies up our source code layout?" | probe | 0.315 |
+| formatter-switch "what does the developer write code in?" | probe | 0.252 |
+| deploy-migration "who or what pushes new versions…" | probe | 0.191 |
+| **formatter-switch "what are the gym's opening hours…"** | **abstain** | **0.120** |
+| user-profile "which herbs grow best…" | abstain | 0.120 |
+| user-profile kubernetes ingress | abstain | 0.112 |
+| **user-profile "what food restrictions…"** | **probe** | **0.103** |
+| **formatter-switch "how are the automated checks executed?"** | **probe** | **0.093** |
+| deploy-migration theatre casting | abstain | 0.089 |
+| episode-flood chilli cook-off | abstain | 0.060 |
+| episode-flood travel expenses | abstain | 0.055 |
+| formatter-switch cloud region | abstain | 0.046 |
+| deploy-migration conference discount | abstain | 0.038 |
+
+Latency: model load 8.1 s one-off (over the 3 s budget, though the daemon
+would amortise it); 30-candidate rerank p50 96–102 ms across batch sizes
+8/16/32 (inside the 150 ms budget); `embed_query` beside it is 9 ms.
+
+## Verdict
+
+**Measured and dropped.** No threshold satisfies the primary rule: zero
+false abstentions forces `t ≤ 0.093` (the weakest relevant page), and at
+that ceiling only 5 of 8 unanswerables fire — *below* the single-cosine
+floor's 6 of 8, with no margin anywhere near 0.05. The interleaving is the
+finding: the cross-encoder cleanly fixes one of the two cosine confusables
+(the chilli cook-off falls from cosine 0.691 to 0.060) but mints two new
+ones — the gym query now outscores two genuinely answerable pages whose
+probes were written to share no words with their targets. The anti-lexical
+probe style that BGE survives on meaning defeats a cross-encoder asked for
+literal relevance, which is the ARAGOG-flat prior showing up in this
+codebase's own terms.
+
+150 MB of model buys a *different* confusion band here, not a smaller one.
+What would reopen #81 is what would reopen #80: keyword-shaped probes, so
+that literal-relevance signals are measured on queries that reward them —
+plus, per the rule above, an abstention separation the cosine floor cannot
+already provide. The score map is committed, so a future `RecordedReranker`
+replay needs no model to re-examine any of this.


### PR DESCRIPTION
Closes #81 — stage-0 measurement of the optional cross-encoder rerank; verdict: measured and dropped.

## What this PR contains

- `agmem-embed` gains a `rerank` feature (off by default; rides on `onnx`, so BM25-only `--no-default-features` builds stay ONNX-free) with a minimal `FastembedReranker` and an `#[ignore]` recorder test — measurement surface only, nothing in the server links it.
- The committed score map `tests/fixtures/eval/rerank.json` (~836 query×passage logits), so any future re-examination replays without the model.
- `docs/eval/rerank-probe.md`: the decision rule (committed before the model ran), the full decision table, latency block, and the verdict. One cross-link from `quality.md`.

## The verdict, honestly

The probe aimed at **abstention** — the one column these anti-lexical fixtures can decide (ordering ΣMRR moves in quanta of 0.167–0.5, larger than any sane threshold). The pre-registered rule required a threshold with zero false abstentions and `fired ≥ 7/8` (cosine baseline 6/8) with 0.05 margin. No such threshold exists: zero false abstentions caps `t` at 0.093 and fires only **5/8**. The reranker fixes the chilli confusable (0.691 cosine → 0.060) and creates two new ones — the gym query outscores two genuinely answerable probe pages. 150 MB buys a different confusion band, not a smaller one. Latency passed (96 ms p50 / 30 candidates; 8 s one-off load) and didn't matter.

Reopen condition, shared with #80: keyword-shaped probes that reward literal relevance — plus an abstention separation the cosine floor cannot already provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGe48K3fQ2boQnp9DRP1gL