### PR TITLE
The write gate keeps its measurement (#83)

### DIFF
--- a/crates/agmem-core/src/dedup.rs
+++ b/crates/agmem-core/src/dedup.rs
@@ -41,6 +41,18 @@ pub fn similarity_from_distance(distance: f64) -> f64 {
     1.0 - distance
 }
 
+/// What a write adds over the store's nearest live neighbour (issue #83):
+/// `1 − similarity`, clamped to `[0, 1]`.
+///
+/// Clamped because cosine similarity may be negative — an *opposed* neighbour
+/// would otherwise score above 1 — and the value is persisted, so the range
+/// is a promise to every reader rather than a hope. Spelled here beside
+/// [`similarity_from_distance`] so the write path and any future caller agree
+/// on what "novel" means.
+pub fn novelty(best_similarity: f64) -> f64 {
+    (1.0 - best_similarity).clamp(0.0, 1.0)
+}
+
 /// Cosine similarity below which two memories are simply about different
 /// things, and a neighbour is not worth mentioning.
 ///

--- a/crates/agmem-core/src/model.rs
+++ b/crates/agmem-core/src/model.rs
@@ -515,6 +515,12 @@ pub struct MemoryRecord {
     pub source: Source,
     /// Who wrote the row; `None` on rows from before the store recorded it.
     pub writer: Option<Writer>,
+    /// How much this claim added over its nearest live neighbour at write
+    /// time (issue #83): `1 − similarity`, in `[0, 1]`. `None` when nothing
+    /// measured it — a pre-v7 row, a correction (which skips the gate), or a
+    /// write into a space holding no vectors. Never recomputed: it records
+    /// the store as it stood when the claim arrived.
+    pub novelty: Option<f64>,
     /// The memories and episodes this claim was reflected out of. Empty for
     /// everything a `reflect` call did not write.
     pub derived_from: Vec<Derivation>,
@@ -738,6 +744,7 @@ mod tests {
                 session: "1234-5678".to_owned(),
                 tool: "remember".to_owned(),
             }),
+            novelty: Some(0.42),
             derived_from: vec![Derivation::Memory(
                 MemoryId::new("01M145SMNET1XRYA713EWAQTD4").unwrap(),
             )],

--- a/crates/agmem-core/src/scoring.rs
+++ b/crates/agmem-core/src/scoring.rs
@@ -33,6 +33,26 @@ pub const WEIGHT_TEMPORAL: f64 = 0.15;
 /// February, which is usually exactly the claim the question is about.
 pub const TEMPORAL_TAU_DAYS: f64 = 30.0;
 
+/// Weight of the novelty prior (issue #83) — **measured dead for ranking;
+/// held at zero on purpose** (`docs/eval/novelty-prior.md`). At 0.05 the
+/// recorded eval moved on nothing recall measures and *regressed* the
+/// briefing: write-time novelty is highest for the *first* claim on a topic
+/// — measured when the store had not heard of it yet — so inside a same-tag
+/// flood the term is anti-recency, and it dragged the earliest playbook
+/// lessons back past the #82 cap's most-recent-first tie-break
+/// (playbook-flood 11/11 → 9/11). The signal keeps being persisted — it
+/// records the store as it stood at write time, which no later measurement
+/// can recover — and the term stays wired so a future non-zero weight is one
+/// constant away, but it earns that weight in the eval first.
+///
+/// Shape, for that future reader: like [`WEIGHT_TEMPORAL`], a bonus term
+/// outside the unit sum, so the three main weights stay pinned by the
+/// baseline. Unlike it, *pool-centred* — `WEIGHT_NOVELTY · (novelty − pool
+/// mean)` — because absence here is per-row, not per-call: a pre-v7 row or a
+/// correction carries no measurement, and `unwrap_or(0.0)` would pin it to
+/// the floor forever while centring makes it exactly neutral.
+pub const WEIGHT_NOVELTY: f64 = 0.0;
+
 /// Floor on Ebbinghaus stability, so a zero or corrupt `strength` decays fast
 /// instead of producing NaN.
 pub const MIN_STABILITY: f64 = 0.01;
@@ -254,6 +274,12 @@ pub struct Signals {
     /// untouched.
     #[serde(default)]
     pub temporal: Option<f64>,
+    /// What the claim added over the store when it was written (issue #83),
+    /// in `[0, 1]`. `None` when nothing measured it — a pre-v7 row, a
+    /// correction, a chunk, or a BM25-only deployment — which ranks as
+    /// exactly neutral, never as a penalty.
+    #[serde(default)]
+    pub novelty: Option<f64>,
     /// Retention at query time; 1.0 for anything that does not decay.
     pub retention: f64,
     /// Standing importance of the decay class.
@@ -267,6 +293,7 @@ impl Signals {
             rrf,
             similarity: None,
             temporal: None,
+            novelty: memory.novelty,
             retention: retention(
                 memory.decay_class,
                 memory.strength,
@@ -287,6 +314,7 @@ impl Signals {
             rrf,
             similarity: None,
             temporal: None,
+            novelty: None,
             retention: 1.0,
             importance: DecayClass::Normal.importance(),
         }
@@ -324,7 +352,9 @@ pub struct Ranked {
 /// `score = 0.6·norm(rrf) + 0.25·retention + 0.15·importance` (design §5.3),
 /// where `norm` is min–max across the pool — plus `0.15·temporal` when the
 /// call carried a window (issue #78), a bonus that is exactly zero on the
-/// everyday path.
+/// everyday path, and `WEIGHT_NOVELTY·(novelty − pool mean)` for rows that
+/// carry a write-time novelty measurement (issue #83) — a term wired but held
+/// at weight zero, having measured anti-recency on the recorded eval.
 ///
 /// RRF barely spreads: `1/(60 + rank)` differs by 3% between the first hit and
 /// the fourth, so dividing by the best candidate — the obvious normalisation,
@@ -344,13 +374,26 @@ pub struct Ranked {
 /// The sort is stable: equal scores keep the order the store returned them in.
 pub fn rank<T>(candidates: impl IntoIterator<Item = (T, Signals)>) -> Vec<(T, Ranked)> {
     let candidates: Vec<(T, Signals)> = candidates.into_iter().collect();
-    let (worst, best) = candidates
-        .iter()
-        .map(|(_, signals)| signals.rrf)
-        .fold((f64::INFINITY, f64::NEG_INFINITY), |(lo, hi), rrf| {
-            (lo.min(rrf), hi.max(rrf))
-        });
+    let (worst, best, novelty_sum, novelty_count) = candidates.iter().fold(
+        (f64::INFINITY, f64::NEG_INFINITY, 0.0_f64, 0usize),
+        |(lo, hi, sum, count), (_, signals)| {
+            (
+                lo.min(signals.rrf),
+                hi.max(signals.rrf),
+                sum + signals.novelty.unwrap_or(0.0),
+                count + usize::from(signals.novelty.is_some()),
+            )
+        },
+    );
     let spread = best - worst;
+    // The novelty origin is this pool's own mean, so an unmeasured row and an
+    // exactly average one both add nothing — the term reorders within a page,
+    // it never shifts one against the paths that carry no measurements.
+    let novelty_mean = if novelty_count > 0 {
+        novelty_sum / novelty_count as f64
+    } else {
+        0.0
+    };
 
     let mut ranked: Vec<(T, Ranked)> = candidates
         .into_iter()
@@ -365,7 +408,11 @@ pub fn rank<T>(candidates: impl IntoIterator<Item = (T, Signals)>) -> Vec<(T, Ra
             let score = WEIGHT_RRF * rrf_normalized
                 + WEIGHT_RETENTION * signals.retention
                 + WEIGHT_IMPORTANCE * signals.importance
-                + WEIGHT_TEMPORAL * signals.temporal.unwrap_or(0.0);
+                + WEIGHT_TEMPORAL * signals.temporal.unwrap_or(0.0)
+                + WEIGHT_NOVELTY
+                    * signals
+                        .novelty
+                        .map_or(0.0, |novelty| novelty - novelty_mean);
             (
                 item,
                 Ranked {
@@ -413,6 +460,7 @@ mod tests {
             valid_from: days_ago(100),
             invalid_at: None,
             invalid_reason: None,
+            novelty: None,
             supersedes: Vec::new(),
             superseded_by: None,
             source: crate::model::Source::Agent,
@@ -681,6 +729,60 @@ mod tests {
         let ranked = rank([("only", Signals::for_episode_chunk(0.0))]);
         assert_eq!(ranked[0].1.rrf_normalized, 0.0);
         assert!((ranked[0].1.score - (0.25 + 0.15 * 0.5)).abs() < 1e-9);
+    }
+
+    /// Issue #83: a lone measurement is its own pool mean, so it adds exactly
+    /// nothing — and an unmeasured row beside it is untouched too. The
+    /// unweighted formulas asserted throughout this module double as the
+    /// proof that an all-`None` pool scores as if the term did not exist.
+    #[test]
+    fn a_single_novelty_measurement_is_its_own_neutral() {
+        let mut measured = memory(DecayClass::Normal, 1.0, now());
+        measured.novelty = Some(0.9);
+        let ranked = rank([
+            ("measured", Signals::for_memory(0.03, &measured, now())),
+            (
+                "unmeasured",
+                Signals::for_memory(0.03, &memory(DecayClass::Normal, 1.0, now()), now()),
+            ),
+        ]);
+        for (name, ranked) in &ranked {
+            assert!(
+                (ranked.score - (0.6 + 0.25 + 0.15 * 0.5)).abs() < 1e-9,
+                "{name} scores as if the term did not exist: {ranked:?}"
+            );
+        }
+    }
+
+    /// The term is wired but the weight is zero (see [`WEIGHT_NOVELTY`]):
+    /// even the widest measured spread must move nothing, so a re-tread and a
+    /// maximally novel claim tie and keep the store's order. A future
+    /// non-zero weight flips exactly this test — the gap it must then assert
+    /// is `WEIGHT_NOVELTY · (their pool-centred difference)`.
+    #[test]
+    fn the_novelty_term_carries_no_weight_until_it_earns_one() {
+        let mut novel = memory(DecayClass::Normal, 1.0, now());
+        novel.novelty = Some(1.0);
+        let mut retread = memory(DecayClass::Normal, 1.0, now());
+        retread.novelty = Some(0.0);
+        let ranked = rank([
+            ("retread", Signals::for_memory(0.03, &retread, now())),
+            ("novel", Signals::for_memory(0.03, &novel, now())),
+        ]);
+
+        assert_eq!(
+            ranked[0].1.score, ranked[1].1.score,
+            "at weight zero the measurement reorders nothing: {ranked:?}"
+        );
+        assert_eq!(
+            ranked[0].0, "retread",
+            "so ties keep the store's order, as everywhere else"
+        );
+        assert_eq!(
+            (ranked[0].1.signals.novelty, ranked[1].1.signals.novelty),
+            (Some(0.0), Some(1.0)),
+            "while the signal itself still reaches the caller"
+        );
     }
 
     /// What `search::rrf` hands back for a hit at `position` in one list.

--- a/crates/agmem-server/src/tools/consolidate.rs
+++ b/crates/agmem-server/src/tools/consolidate.rs
@@ -616,6 +616,7 @@ mod tests {
             superseded_by: None,
             source: Source::Agent,
             writer: None,
+            novelty: None,
             derived_from: Vec::new(),
             created_at: Timestamp::UNIX_EPOCH,
         }

--- a/crates/agmem-server/src/tools/context.rs
+++ b/crates/agmem-server/src/tools/context.rs
@@ -559,6 +559,7 @@ mod tests {
             superseded_by: None,
             source: Source::Agent,
             writer: None,
+            novelty: None,
             derived_from: Vec::new(),
             created_at: Timestamp::UNIX_EPOCH,
         }

--- a/crates/agmem-server/src/tools/recall.rs
+++ b/crates/agmem-server/src/tools/recall.rs
@@ -377,6 +377,15 @@ pub struct HitSignals {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temporal: Option<f64>,
 
+    /// How much this claim added over its nearest neighbour when it was
+    /// written, in `[0, 1]` — measured once at write time, never updated.
+    /// Reported for the reader; it carries no rank weight (issue #83,
+    /// `docs/eval/novelty-prior.md`). Absent for rows from before the store
+    /// recorded it, for corrections, for verbatim text, and everywhere in a
+    /// BM25-only deployment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub novelty: Option<f64>,
+
     /// How much of the memory has survived its decay curve since it was last
     /// used. 1.0 for a pinned memory, or for verbatim text.
     pub retention: f64,
@@ -667,6 +676,7 @@ impl RecallHit {
             rrf_normalized: ranked.rrf_normalized,
             similarity: ranked.signals.similarity,
             temporal: ranked.signals.temporal,
+            novelty: ranked.signals.novelty,
             retention: ranked.signals.retention,
             importance: ranked.signals.importance,
         };

--- a/crates/agmem-server/src/tools/reflect.rs
+++ b/crates/agmem-server/src/tools/reflect.rs
@@ -196,6 +196,12 @@ pub async fn run(
         let neighbours = repo::nearest_live(service.db(), &space, std::slice::from_ref(probe))
             .await
             .map_err(|error| store_error(&error))?;
+        // The gate's measurement rides along if the row gets written
+        // (issue #83): neighbours come back closest-first.
+        memory.novelty = neighbours
+            .first()
+            .and_then(|list| list.first())
+            .map(|neighbour| dedup::novelty(neighbour.similarity));
         for neighbour in neighbours.into_iter().flatten() {
             if dedup::is_near_duplicate(neighbour.similarity) {
                 let note = uncited(service, &space, &neighbour.id).await;

--- a/crates/agmem-server/src/tools/remember.rs
+++ b/crates/agmem-server/src/tools/remember.rs
@@ -274,6 +274,13 @@ pub async fn run(
     let mut related: Vec<Related> = Vec::new();
     let mut blocked = vec![false; new_memories.len()];
     for (index, neighbours) in gated.into_iter().zip(neighbours) {
+        // The gate's measurement rides along on what survives it (issue #83):
+        // neighbours come back closest-first, so the first one is the row the
+        // gate itself ruled on. No neighbours means a space with no vectors —
+        // nothing was measured, so nothing is recorded.
+        new_memories[index].novelty = neighbours
+            .first()
+            .map(|neighbour| dedup::novelty(neighbour.similarity));
         for neighbour in neighbours {
             if dedup::is_near_duplicate(neighbour.similarity) {
                 blocked[index] = true;

--- a/crates/agmem-server/tests/protocol.rs
+++ b/crates/agmem-server/tests/protocol.rs
@@ -654,6 +654,91 @@ async fn a_restatement_comes_back_as_the_id_that_already_holds_it() {
     agmem.shutdown().await;
 }
 
+/// Issue #83: the dup-gate's measurement is kept on every row that survives
+/// it — high for a claim about something the store had never heard of, low
+/// for a re-tread of what it held — and absent where nothing measured: the
+/// very first write into an empty space, and `signals` of hits that carry no
+/// measurement.
+#[tokio::test]
+async fn a_write_keeps_the_novelty_the_gate_measured() {
+    let agmem = Harness::start(Arc::new(KeywordEmbedder)).await;
+    agmem
+        .remember(json!({ "memories": [{ "content": "The user prefers Rust" }] }))
+        .await;
+    agmem
+        .remember(json!({
+            "memories": [
+                // Shares the rust axis with the first claim: cosine 0.707,
+                // under the 0.95 gate, so it lands — a partial re-tread.
+                { "content": "Rust and Python both appeal to the user" },
+                // Orthogonal to everything stored: maximally novel.
+                { "content": "The kitchen tap drips at night" }
+            ]
+        }))
+        .await;
+
+    let by_content = |memories: &[agmem_core::MemoryRecord], prefix: &str| {
+        memories
+            .iter()
+            .find(|memory| memory.content.starts_with(prefix))
+            .expect("the row")
+            .novelty
+    };
+    let memories = agmem.memories().await;
+    assert_eq!(
+        by_content(&memories, "The user prefers"),
+        None,
+        "an empty space measured nothing, and nothing is recorded"
+    );
+    let retread = by_content(&memories, "Rust and Python").expect("measured");
+    assert!(
+        (retread - (1.0 - 0.5_f64.sqrt())).abs() < 1e-6,
+        "novelty is one minus the nearest neighbour's similarity: {retread}"
+    );
+    assert_eq!(
+        by_content(&memories, "The kitchen tap"),
+        Some(1.0),
+        "a claim orthogonal to the whole store is maximally novel"
+    );
+
+    // And recall shows the measurement exactly where one exists.
+    let found = agmem
+        .recall(json!({ "query": "what does the kitchen tap do at night" }))
+        .await;
+    let hit = hits(&found)
+        .iter()
+        .find(|hit| {
+            hit["content"]
+                .as_str()
+                .is_some_and(|content| content.starts_with("The kitchen"))
+        })
+        .cloned()
+        .expect("the novel claim is on the page");
+    assert_eq!(
+        hit["signals"]["novelty"].as_f64(),
+        Some(1.0),
+        "a measured hit reports its write-time novelty: {hit}"
+    );
+
+    let found = agmem
+        .recall(json!({ "query": "does the user prefer Rust" }))
+        .await;
+    let hit = hits(&found)
+        .iter()
+        .find(|hit| {
+            hit["content"]
+                .as_str()
+                .is_some_and(|content| content.starts_with("The user prefers"))
+        })
+        .cloned()
+        .expect("the unmeasured claim is on the page");
+    assert!(
+        hit["signals"].get("novelty").is_none(),
+        "no measurement, no field — absence is not a zero: {hit}"
+    );
+    agmem.shutdown().await;
+}
+
 #[tokio::test]
 async fn without_an_embedder_the_exact_gate_still_holds() {
     let agmem = Harness::start(Arc::new(NoopEmbedder)).await;

--- a/crates/agmem-server/tests/snapshots/protocol__list_tools.snap
+++ b/crates/agmem-server/tests/snapshots/protocol__list_tools.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/agmem-server/tests/protocol.rs
+assertion_line: 73
 expression: "&tools.tools"
 ---
 [
@@ -1460,6 +1461,14 @@ expression: "&tools.tools"
               "description": "The standing importance of its decay class — what keeps a rarely\nmatched instruction ahead of a well matched scratch note.",
               "format": "double",
               "type": "number"
+            },
+            "novelty": {
+              "description": "How much this claim added over its nearest neighbour when it was\nwritten, in `[0, 1]` — measured once at write time, never updated.\nReported for the reader; it carries no rank weight (issue #83,\n`docs/eval/novelty-prior.md`). Absent for rows from before the store\nrecorded it, for corrections, for verbatim text, and everywhere in a\nBM25-only deployment.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
             },
             "retention": {
               "description": "How much of the memory has survived its decay curve since it was last\nused. 1.0 for a pinned memory, or for verbatim text.",

--- a/crates/agmem-store/src/migrate.rs
+++ b/crates/agmem-store/src/migrate.rs
@@ -24,6 +24,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("migrations/v4_chunk_occurred_at.surql"),
     include_str!("migrations/v5_live_dedup.surql"),
     include_str!("migrations/v6_writer.surql"),
+    include_str!("migrations/v7_novelty.surql"),
 ];
 
 /// The schema version this binary produces.

--- a/crates/agmem-store/src/migrations/v7_novelty.surql
+++ b/crates/agmem-store/src/migrations/v7_novelty.surql
@@ -1,0 +1,17 @@
+-- Schema v7 — the write path keeps the dup-gate's measurement (issue #83).
+--
+-- Every gated write already probes for its nearest live neighbour and threw
+-- the similarity away once the gate had ruled. Stored as `novelty`
+-- (`1 − nearest similarity`, clamped to [0, 1]), it records how much the
+-- claim added over what the store held *at the moment it arrived* — which is
+-- why `--reindex` must never recompute it: re-measuring against today's store
+-- would answer a different question.
+--
+-- Deliberately **no backfill**, and `option<float>` for the reason v3 and v6
+-- both paid for: any later UPDATE (`REINFORCE`, `PRUNE_EXPIRED`,
+-- `FORGET_SOFT`) re-coerces every field, so a required column would make rows
+-- predating this migration untouchable. A pre-v7 row reads as `NONE` — "not
+-- measured" — as does a correction (`supersedes` skips the gate) and a write
+-- into a space holding no vectors; ranking treats absence as neutral, never
+-- as a floor.
+DEFINE FIELD IF NOT EXISTS novelty ON memory TYPE option<float>;

--- a/crates/agmem-store/src/queries/read.rs
+++ b/crates/agmem-store/src/queries/read.rs
@@ -111,6 +111,7 @@ const MEMORY_FIELDS: &str = "record::id(id) AS id, space, kind, content, content
      IF writer IS NONE { NONE } ELSE { { client: writer.client,
          client_version: writer.client_version, session: writer.session,
          tool: writer.tool } } AS writer,
+     novelty,
      array::map(derived_from ?? [],
          |$link| { table: record::table($link), id: record::id($link) }) AS derived_from,
      created_at";
@@ -456,7 +457,7 @@ pub(crate) const STATS: &str = "RETURN {
 /// The row and its vector come back as two projections over one selection
 /// rather than one wide row, because the `SurrealValue` derive has no
 /// `flatten`: spelling them together would mean a second copy of
-/// [`MEMORY_FIELDS`]'s nineteen columns in Rust. Both carry the id, so the
+/// [`MEMORY_FIELDS`]'s twenty columns in Rust. Both carry the id, so the
 /// caller pairs them by name and depends on nothing about their order.
 pub(crate) fn live_vectors(limit: usize) -> Script {
     let limit = limit.clamp(1, MAX_POOL);

--- a/crates/agmem-store/src/repo/write.rs
+++ b/crates/agmem-store/src/repo/write.rs
@@ -55,6 +55,10 @@ pub struct NewMemory {
     /// belongs to in the first place ([`super::locate`]), and a purge is
     /// allowed to leave a citation pointing at text that is gone.
     pub derived_from: Vec<Derivation>,
+    /// What the dup-gate measured this claim adding over its nearest live
+    /// neighbour (issue #83); `None` when the gate never ran — a correction,
+    /// or a space holding no vectors.
+    pub novelty: Option<f64>,
 }
 
 impl NewMemory {
@@ -71,6 +75,7 @@ impl NewMemory {
             supersedes: Vec::new(),
             source: None,
             derived_from: Vec::new(),
+            novelty: None,
         }
     }
 }
@@ -341,6 +346,7 @@ async fn insert_batch_once(db: &Db, batch: Batch) -> Result<BatchOutcome, StoreE
                     .map(types::derivation_ref)
                     .collect(),
                 writer: WriterRow::new(&writer),
+                novelty: memory.novelty,
             },
         ));
         if !shapes[index].source_is_batch_episode {

--- a/crates/agmem-store/src/types.rs
+++ b/crates/agmem-store/src/types.rs
@@ -96,6 +96,7 @@ pub(crate) struct MemoryRow {
     pub(crate) supersedes: Vec<RecordId>,
     pub(crate) derived_from: Vec<RecordId>,
     pub(crate) writer: WriterRow,
+    pub(crate) novelty: Option<f64>,
 }
 
 /// The `writer` object: who performed the write (issue #75).
@@ -230,6 +231,7 @@ pub(crate) struct MemoryReadRow {
     pub(crate) source_kind: String,
     pub(crate) source_ref: Option<String>,
     pub(crate) writer: Option<WriterRow>,
+    pub(crate) novelty: Option<f64>,
     pub(crate) derived_from: Vec<DerivationRow>,
     pub(crate) created_at: Datetime,
 }
@@ -299,6 +301,10 @@ impl MemoryReadRow {
             superseded_by: self.superseded_by.map(MemoryId::new).transpose()?,
             source: to_source(&self.source_kind, self.source_ref)?,
             writer: self.writer.map(WriterRow::into_writer),
+            // The write path clamps; this guards a hand-edited row, whose
+            // out-of-range value would otherwise skew every pool mean it
+            // enters.
+            novelty: self.novelty.map(|novelty| novelty.clamp(0.0, 1.0)),
             derived_from: self
                 .derived_from
                 .into_iter()

--- a/crates/agmem-store/tests/migrate.rs
+++ b/crates/agmem-store/tests/migrate.rs
@@ -280,6 +280,51 @@ async fn a_row_written_before_v6_reads_with_no_writer_and_still_closes() {
     );
 }
 
+/// A row written before v7 carries no `novelty` column, and never gains one —
+/// the measurement records the store as it stood at write time, which is gone
+/// (issue #83). It must read as `None`, and because a SurrealDB UPDATE
+/// re-coerces every field (the v3 lesson), reinforcement must still reach it.
+#[tokio::test]
+async fn a_row_written_before_v7_reads_with_no_novelty_and_still_reinforces() {
+    let conn = db::connect("mem://").await.expect("connect mem://");
+    conn.query(include_str!("../src/migrations/v1_schema.surql"))
+        .await
+        .expect("v1")
+        .check()
+        .expect("v1 statements");
+    conn.query(
+        "CREATE memory:01M145SMNET1XRYA713EWAQTD7 SET space = 'test', kind = 'fact',
+             content_hash = 'v1-n', content = 'recorded before novelty existed',
+             source = { kind: 'agent' }",
+    )
+    .await
+    .expect("seed")
+    .check()
+    .expect("seed statement");
+
+    assert_eq!(
+        migrate::ensure(&conn).await.expect("upgrade"),
+        migrate::SCHEMA_VERSION
+    );
+
+    let space: SpaceName = "test".parse().expect("valid slug");
+    let rows = repo::direct_lookup(&conn, &Lookup::new(vec![space.clone()]))
+        .await
+        .expect("lookup");
+    assert_eq!(rows.len(), 1, "the upgrade keeps the row");
+    assert!(
+        rows[0].novelty.is_none(),
+        "a pre-v7 row records no novelty, and reading it must not fail"
+    );
+
+    // Reinforcement is the UPDATE that re-coerces the row; it has to land.
+    let id = "01M145SMNET1XRYA713EWAQTD7".parse().expect("a ULID");
+    let touched = repo::reinforce(&conn, std::slice::from_ref(&id))
+        .await
+        .expect("reinforce a noveltyless row");
+    assert_eq!(touched, 1, "the update reached the pre-v7 row");
+}
+
 /// Chunks written before v4 carry no `occurred_at` — the column arrives with
 /// that migration — and the as-of clause reads the date off the chunk, so the
 /// upgrade has to copy each episode's date down. A chunk left at NONE would

--- a/crates/agmem-store/tests/writes.rs
+++ b/crates/agmem-store/tests/writes.rs
@@ -305,6 +305,32 @@ async fn a_repeated_episode_is_reused_rather_than_re_chunked() {
     );
 }
 
+/// Issue #83: the novelty the write path measured rides the row into the
+/// store and back out; a write nothing measured reads `None` rather than a
+/// sentinel.
+#[tokio::test]
+async fn novelty_round_trips_and_absence_reads_as_none() {
+    let db = store().await;
+    let mut measured = NewMemory::new(Kind::Fact, "the user prefers Rust");
+    measured.novelty = Some(0.42);
+    repo::insert_batch(
+        &db,
+        batch(vec![
+            measured,
+            NewMemory::new(Kind::Fact, "written before anything could measure it"),
+        ]),
+    )
+    .await
+    .expect("batch");
+
+    let mut rows = repo::direct_lookup(&db, &Lookup::new(vec![space()]))
+        .await
+        .expect("lookup");
+    rows.sort_by(|left, right| left.content.cmp(&right.content));
+    assert_eq!(rows[0].novelty, Some(0.42), "the measurement round-trips");
+    assert_eq!(rows[1].novelty, None, "no measurement reads as none");
+}
+
 #[tokio::test]
 async fn supersession_closes_the_old_row_and_keeps_it_readable() {
     let db = store().await;

--- a/docs/design.md
+++ b/docs/design.md
@@ -205,6 +205,10 @@ DEFINE FIELD source        ON memory TYPE object;   -- { kind: "episode"|"agent"
 -- every sub-field option<string>; NONE on pre-v6 rows, never backfilled
 DEFINE FIELD writer        ON memory TYPE option<object>;
 DEFINE INDEX mem_writer_session ON memory COLUMNS writer.session;
+-- v7: what the dup-gate measured this claim adding over its nearest live
+-- neighbour at write time (issue #83): clamp(1 − similarity, 0, 1); NONE
+-- where nothing measured, never backfilled, never recomputed
+DEFINE FIELD novelty       ON memory TYPE option<float>;
 -- schema v2: what a `reflect` insight was drawn from; empty for every other write
 DEFINE FIELD derived_from  ON memory TYPE array<record<memory | episode>> DEFAULT [];
 DEFINE FIELD created_at    ON memory TYPE datetime DEFAULT time::now();
@@ -742,6 +746,10 @@ remember(params)
     correction and an id alone cannot be read (issue #38)
     skipped when the memory carries `supersedes` — the agent has already made
     the ADD/UPDATE call, and a correction usually *is* close to what it corrects
+    the probe's measurement is kept (issue #83): each surviving row stores
+    novelty = clamp(1 − nearest similarity, 0, 1) — the store as it stood at
+    write time, never recomputed (not even by --reindex); NONE where nothing
+    measured (a correction, an empty space, BM25-only, any pre-v7 row)
  5. one transaction:
       episode? → insert episode + chunks (chunk.rs) + chunk embeddings
       inserts  → CREATE memory:ulid() CONTENT {...}, source.ref → episode
@@ -787,6 +795,12 @@ recall(q)
  4. rescore in Rust (core::scoring):
       final = 0.6·norm(rrf) + 0.25·retention(m) + 0.15·importance(decay_class)
               [+ 0.15·temporal_fit when the call carried a window — issue #78]
+              [+ W_novelty·(novelty − pool mean) for rows measured at write
+               time — issue #83; pool-centred so an unmeasured row is exactly
+               neutral, never floored: absence here is per-row. W_novelty is
+               0.0, measured-and-held (docs/eval/novelty-prior.md): write-time
+               novelty peaks on the *first* claim of a topic, so in a same-tag
+               flood the term is anti-recency and regressed the briefing]
       norm  = min–max over the pool: (rrf − min) / (max − min)
       as_of? → filter valid_from ≤ T < invalid_at (walk chains for history);
               chunks filter on their denormalised occurred_at ≤ T (v4)

--- a/docs/eval/novelty-prior.md
+++ b/docs/eval/novelty-prior.md
@@ -1,0 +1,57 @@
+# Novelty prior (issue #83)
+
+The write path already computes each gated claim's nearest-live-neighbour
+similarity and, until schema v7, threw it away. v7 persists it as
+`memory.novelty = clamp(1 − similarity, 0, 1)` — measured once, against the
+store as it stood at write time, never recomputed (not even by `--reindex`,
+which would answer a different question). That half of #83 stands on its own:
+the measurement is un-backfillable, so keeping it is near-free insurance for
+any future rank feature, and `signals.novelty` surfaces it on every recall
+hit that carries one.
+
+The other half — using it as a rank feature — was tried and is **held at
+weight zero**. The precedent is `fusion-sweep.md` and `rerank-probe.md`:
+measured-and-dropped is a normal end.
+
+## The arm as tried
+
+`WEIGHT_NOVELTY · (novelty − pool mean)` at 0.05, a bonus term outside the
+unit sum (the `WEIGHT_TEMPORAL` shape), pool-centred because absence is
+per-row here — a pre-v7 row, a correction, a chunk — and `unwrap_or(0.0)`
+would pin those to the floor forever while centring makes them exactly
+neutral. Worst-case swing ±0.03 across the widest measured spread: a tail
+reorderer, under one decay-class step.
+
+## Decision rule
+
+The recorded eval baseline (`cargo test -p agmem-server --test eval`),
+Pareto or nothing: no scenario's retrieval or context column may fall.
+
+## Result — run 2026-09-01, weight 0.05
+
+- Every retrieval column (`found`, `mrr`, `returned`, abstention): unchanged.
+  The predicted null — the fixtures' seeds are hand-written distinct claims,
+  so novelty barely spreads within a page.
+- `playbook-flood` context: **11/11 → 9/11**. Not noise — a mechanism:
+
+Write-time novelty is highest for the *first* claim on a topic, measured
+when the store had not heard of it yet, and lowest for everything that
+follows. Inside a same-tag flood the term is therefore **anti-recency**: the
+#82 per-tag cap defers the *earliest* three of six `role:reviewer` lessons
+by its most-recent-first tie-break, and the novelty term dragged exactly
+those earliest lessons back into the briefing. First-mover bias is not a
+prior on usefulness; playbooks evolve, and the latest lesson superseding an
+old habit is the one worth the budget.
+
+So the verdict is worse than the predicted null: zero on what it hoped to
+help, negative where `Signals::for_memory` is shared with `context`.
+
+## Standing
+
+`WEIGHT_NOVELTY = 0.0` (`core::scoring`), term wired, signal persisted and
+surfaced. Reopen condition: a rank feature that wants novelty must first
+show a scenario where it wins — e.g. distinguishing a re-tread from a first
+statement of one fact *within a recall page* — and must answer the
+anti-recency mechanism above, not just re-run the same sweep. The #86
+outcome counters are the more plausible consumer of the stored field than
+this arm was.


### PR DESCRIPTION
The dup-gate already computes each gated claim's nearest-live-neighbour similarity and threw it away. Schema v7 persists it; the rank arm it was meant to feed was tried, measured, and held at weight zero.

## Persistence (the half that ships on its own merit)

- `memory.novelty = clamp(1 − nearest similarity, 0, 1)` — `option<float>`, **no backfill** (the v3/v6 lesson: any required column makes pre-migration rows untouchable by `REINFORCE`/`PRUNE_EXPIRED`/`FORGET_SOFT`), never recomputed, not even by `--reindex`: it records the store as it stood at write time, which no later measurement can recover.
- `remember` and `reflect` stamp it on every row surviving the gate; corrections (which skip the gate), empty spaces, BM25-only writes and pre-v7 rows honestly read `NONE`. A blocked duplicate writes no row; its distance is already in `duplicates[].similarity`.
- Recall surfaces the measurement as `signals.novelty` (absent where none exists — absence is not a zero).

## The rank arm: measured-and-held-at-zero (`docs/eval/novelty-prior.md`)

Pool-centred `WEIGHT_NOVELTY · (novelty − pool mean)` at 0.05, the `WEIGHT_TEMPORAL` shape. On the recorded eval it moved **nothing** recall measures and **regressed** `playbook-flood`'s context score 11/11 → 9/11, with a mechanism rather than noise: write-time novelty peaks on the *first* claim of a topic — measured when the store hadn't heard of it — so inside a same-tag flood the term is anti-recency, dragging the earliest playbook lessons back past the #82 cap's most-recent-first tie-break. `WEIGHT_NOVELTY = 0.0`; the term stays wired so a future weight is one constant away, but it earns it in the eval first. Reopen condition recorded; the #86 outcome counters are the likelier consumer of the stored field.

## Tests

- migration back-compat: a pre-v7 row reads `None` and still reinforces (the UPDATE re-coercion check)
- store round-trip; protocol-level end-to-end with the keyword embedder (empty-space `None`, 1−0.707 re-tread, orthogonal 1.0, `signals.novelty` present/absent)
- scoring: neutrality of unmeasured rows; weight-zero pins the no-reorder contract
- tool-schema snapshot updated for the new `signals.novelty` field

Closes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpiYNUHtWjqnGvP2dHhXdp