### PR TITLE
The counters wait for something to count (#86)

### DIFF
--- a/crates/agmem-server/tests/harness/mod.rs
+++ b/crates/agmem-server/tests/harness/mod.rs
@@ -23,7 +23,9 @@ use agmem_store::repo::{self, Liveness, Lookup, SpaceStats};
 use clap::Parser as _;
 use rmcp::RoleClient;
 use rmcp::ServiceExt as _;
-use rmcp::model::{CallToolRequestParams, CallToolResult, ContentBlock, ErrorCode};
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, ContentBlock, ErrorCode, MetaObject, RequestMetaObject,
+};
 use rmcp::service::{RunningService, ServiceError};
 use serde_json::{Value, json};
 
@@ -123,6 +125,27 @@ impl Harness {
         self.client
             .call_tool(CallToolRequestParams::new(name).with_arguments(arguments))
             .await
+    }
+
+    /// One `tools/call` attributed to `session` via `_meta` (issue #75) —
+    /// the per-request override `tools::writer` honours before falling back
+    /// to the id the connection was minted. What per-seed writer attribution
+    /// in the eval fixtures (issue #86) will ride on.
+    pub async fn call_as(
+        &self,
+        session: &str,
+        name: &'static str,
+        arguments: Value,
+    ) -> Result<CallToolResult, ServiceError> {
+        let arguments = arguments
+            .as_object()
+            .expect("arguments are an object")
+            .clone();
+        let mut meta = rmcp::model::JsonObject::new();
+        meta.insert("agmem/session".to_owned(), json!(session));
+        let mut params = CallToolRequestParams::new(name).with_arguments(arguments);
+        params.meta = Some(RequestMetaObject(MetaObject(meta)));
+        self.client.call_tool(params).await
     }
 
     /// One successful `remember`, as the structured result an agent reads.

--- a/crates/agmem-server/tests/protocol.rs
+++ b/crates/agmem-server/tests/protocol.rs
@@ -603,6 +603,50 @@ async fn a_write_records_its_writer_and_inspect_shows_it() {
     agmem.shutdown().await;
 }
 
+/// Issue #75's speculative seam, exercised for the first time (issue #86): a
+/// client that names its session in `_meta["agmem/session"]` is attributed
+/// to it, and one that stays silent gets the connection's minted id — never
+/// a leftover from another request.
+#[tokio::test]
+async fn a_meta_session_override_is_what_the_writer_records() {
+    let agmem = Harness::start(Arc::new(NoopEmbedder)).await;
+
+    let result = agmem
+        .call_as(
+            "seed-7",
+            "remember",
+            json!({ "memories": [{ "content": "The override names this row's session." }] }),
+        )
+        .await
+        .expect("remember");
+    assert_ne!(result.is_error, Some(true), "{result:?}");
+    let diff = result.structured_content.expect("structured content");
+    let overridden = ids(&diff["created"])[0].to_owned();
+
+    let found = agmem.inspect(&overridden).await;
+    assert_eq!(
+        found["found"]["memory"]["writer"]["session"].as_str(),
+        Some("seed-7"),
+        "{found}"
+    );
+
+    // Silence on the next request falls back to the connection's id, not to
+    // the override the previous request carried.
+    let plain = agmem
+        .remember(json!({ "memories": [{ "content": "No override on this row." }] }))
+        .await;
+    let fallback = ids(&plain["created"])[0].to_owned();
+    let found = agmem.inspect(&fallback).await;
+    let session = found["found"]["memory"]["writer"]["session"]
+        .as_str()
+        .expect("a session id");
+    assert!(
+        !session.is_empty() && session != "seed-7",
+        "the fallback is the connection's own id: {found}"
+    );
+    agmem.shutdown().await;
+}
+
 #[tokio::test]
 async fn a_restatement_comes_back_as_the_id_that_already_holds_it() {
     let agmem = Harness::start(Arc::new(KeywordEmbedder)).await;

--- a/docs/eval/outcome-counters.md
+++ b/docs/eval/outcome-counters.md
@@ -1,0 +1,76 @@
+# Outcome-proxy counters — availability gate (issue #86)
+
+#86 proposes per-memory counters approximating "did this memory actually
+help" without a judge model: recalled-then-cited-in-`derived_from` (+),
+recalled-then-superseded-soon (−), riding in `signals` at a small weight the
+quality harness would have to justify. Before any of that is buildable into a
+*measurable* win, the store has to hold observations to count. This is that
+check, run 2026-09-01 against a snapshot of the live dogfood store.
+
+**Verdict: parked — zero observations, and the blocker is data, not code.**
+No schema change, no new columns, no `signals` field until the trigger below
+fires.
+
+## Measured
+
+`scripts/outcome-probe.nu` (snapshot copy, counts through `surreal sql`;
+costs nothing). Against the live store at
+`~/Library/Application Support/dev.agmem.agmem/agmem.db`:
+
+| count | value |
+|---|---|
+| `schema_version` | 4 |
+| memories / live / superseded | 159 / 92 / 65 |
+| rows carrying `derived_from` (live or closed) | **0** |
+| rows carrying `writer` | **0** |
+| rows carrying `novelty` | **0** |
+
+The recorded JSON is `docs/eval/outcome-counts.json`; re-running the probe
+overwrites it.
+
+## Why this parks the issue
+
+- **The positive arm has nothing to count.** A citation already lives on the
+  citing row (`derived_from`), so the count is derivable at read time with
+  zero new state — but the live store holds none, because the daily-driver
+  binary is agmem 0.1.3 at schema v4, from before `reflect` citations,
+  `writer` (#75) and `novelty` (#83) recorded anything. Any rank feature
+  built now would ship with a guaranteed-null measurement, which the #83
+  precedent (novelty measured dead, shipped report-only) says is not worth a
+  permanent per-hit schema surface when the signal loses nothing by waiting.
+- **The negative arm is structurally inert for ranking.** It penalises a row
+  that supersession already closed, and `Liveness::Live` excludes closed rows
+  from every live page, `context` included. Its only non-inert form is a
+  per-writer aggregate down-weighting a bad session's *other, still-live*
+  claims — which needs `writer` data that does not exist yet either.
+- **The un-backfillable part is known and bounded.** The counts themselves
+  are derivable any time from `derived_from` and the dated supersession
+  chain. What cannot be reconstructed later is only the *recalled-then-*
+  qualifier: `REINFORCE` overwrites `last_accessed` and there is no access
+  log. That is the one thing that would justify new state — and only once
+  the arms have observations at all.
+
+What #86 "depends on writer provenance" turns out to need is smaller than
+assumed: the server has honoured a per-request `_meta["agmem/session"]`
+override since #75 (`tools::writer`), so per-seed attribution in the eval
+fixtures is a test-harness change, not server plumbing. The harness now has
+`call_as`, and the override has its first test
+(`a_meta_session_override_is_what_the_writer_records` in
+`tests/protocol.rs`).
+
+## Reopen trigger
+
+Re-run `nu scripts/outcome-probe.nu` after the installed binary catches up
+to ≥0.1.6 and summaries/reflections accumulate. The counters come off the
+shelf when **≥20 live rows carry `derived_from`** in the dogfood store —
+enough observations for the #54-style free measurement to say whether cited
+rows actually rank-separate from uncited ones. If months of use never get
+there, #86 was measuring `reflect` adoption, not memory worth, and closes on
+that finding instead.
+
+Sized-out next steps for that day: read-time cite count → `Signals.cited_by`
+at `WEIGHT_CITED = 0.0` (one grouped `derived_from CONTAINSANY` repo query
+plus an index-only migration, ~half a day and a baseline re-record), and a
+`session` field on the eval `Seed` with a scripted recall-before-reflect
+step — in a new scenario, since seeding recalls reinforce and would shift an
+existing scenario's strengths.

--- a/docs/eval/outcome-counts.json
+++ b/docs/eval/outcome-counts.json
@@ -1,0 +1,14 @@
+{
+  "probed_at": "2026-09-01T21:24:00.984188+02:00",
+  "store": "/Users/Matthew/Library/Application Support/dev.agmem.agmem/agmem.db",
+  "counts": {
+    "schema_version": 4,
+    "memories": 159,
+    "live": 92,
+    "superseded": 65,
+    "live_with_citations": 0,
+    "cited_rows": 0,
+    "with_writer": 0,
+    "with_novelty": 0
+  }
+}

--- a/scripts/outcome-probe.nu
+++ b/scripts/outcome-probe.nu
@@ -1,0 +1,102 @@
+#!/usr/bin/env nu
+
+# Does the store hold what the outcome-proxy counters would count? (issue #86)
+#
+# #86's positive arm rewards a memory that gets cited in `derived_from` after
+# being recalled; its negative arm penalises one superseded soon after. Both
+# are derivable at read time from rows the schema already keeps — a citation
+# lives on the citing row, a supersession is dated — so before any of it is
+# built, this asks the only question that decides anything: *are there any
+# observations to rank on?* Run it against the live dogfood store; the
+# counters stay parked until the citation count clears the trigger recorded
+# in `docs/eval/outcome-counters.md`.
+#
+#     nu scripts/outcome-probe.nu
+#     nu scripts/outcome-probe.nu --store ~/somewhere/agmem.db
+#
+# Costs nothing but time: no model, no server — a snapshot copy and a few
+# counts through `surreal sql`. Never points surreal at the original dir; the
+# daemon holds its LOCK, and this must stay a read of a copy.
+
+def main [
+    --store: string = ""       # an agmem data dir; defaults to the live one
+    --out: string = "docs/eval" # where the counts land as JSON
+] {
+    if (which surreal | is-empty) {
+        error make {msg: "no `surreal` on PATH — install surrealdb to run the probe"}
+    }
+    let store = if ($store | is-empty) { default-store } else { $store | path expand }
+    if not ($store | path exists) {
+        error make {msg: $"no store at ($store)"}
+    }
+
+    # Snapshot first: the daemon holds the LOCK in the live dir, and surreal
+    # refuses (or worse, contends) when pointed at it.
+    let copy = ((mktemp -d) | path join "agmem.db")
+    cp -r $store $copy
+    rm -f ($copy | path join "LOCK")
+
+    let counts = [
+        [name, query];
+        ["schema_version" "SELECT VALUE schema_version FROM meta:main;"]
+        ["memories" "SELECT count() FROM memory GROUP ALL;"]
+        ["live" "SELECT count() FROM memory WHERE invalid_at IS NONE GROUP ALL;"]
+        ["superseded" "SELECT count() FROM memory WHERE invalid_reason = 'superseded' GROUP ALL;"]
+        ["live_with_citations" "SELECT count() FROM memory WHERE invalid_at IS NONE AND array::len(derived_from ?? []) > 0 GROUP ALL;"]
+        ["cited_rows" "SELECT count() FROM memory WHERE array::len(derived_from ?? []) > 0 GROUP ALL;"]
+        ["with_writer" "SELECT count() FROM memory WHERE writer IS NOT NONE GROUP ALL;"]
+        ["with_novelty" "SELECT count() FROM memory WHERE novelty IS NOT NONE GROUP ALL;"]
+    ] | each {|row|
+        {name: $row.name, value: (ask $copy $row.query)}
+    }
+
+    let measured = {
+        probed_at: (date now | format date "%+")
+        store: $store
+        counts: ($counts | transpose --header-row --as-record)
+    }
+    mkdir $out
+    $measured | to json | save -f ($out | path join "outcome-counts.json")
+    $counts | print
+    print -e $"wrote ($out)/outcome-counts.json"
+}
+
+# One statement against the snapshot, answered as a single number.
+def ask [copy: string, query: string] {
+    let spoken = (
+        $query
+        | surreal sql --endpoint $"surrealkv://($copy)" --ns agmem --db main --json --hide-welcome
+        | complete
+    )
+    if $spoken.exit_code != 0 {
+        error make {msg: $"surreal exited ($spoken.exit_code): ($spoken.stderr)"}
+    }
+    # `--json` prints one line: an array with one entry per statement. One
+    # statement goes in, so its result is entry 0 — a count comes back as
+    # [{count: n}], an empty result as [], a `SELECT VALUE` as bare scalars.
+    let rows = (
+        $spoken.stdout
+        | lines
+        | where ($it | str trim | is-not-empty)
+        | last
+        | from json
+        | get 0?
+        | default []
+    )
+    let first = ($rows | get 0? | default 0)
+    if (($first | describe -d | get type) == "record") {
+        $first | get count? | default 0
+    } else {
+        $first
+    }
+}
+
+# Where the embedded store lives when nothing says otherwise.
+def default-store [] {
+    let base = if $nu.os-info.name == "macos" {
+        [$nu.home-dir "Library" "Application Support" "dev.agmem.agmem"] | path join
+    } else {
+        [$nu.home-dir ".local" "share" "agmem"] | path join
+    }
+    $base | path join "agmem.db"
+}


### PR DESCRIPTION
Parks #86 on a measurement rather than building it, per the architect pass and the #83/#84 discipline (harness-gated; measure before persisting).

## What this ships
- **`scripts/outcome-probe.nu`** — snapshots the live store (never touches the daemon's LOCK) and counts what the counters would rank on; writes `docs/eval/outcome-counts.json`.
- **`docs/eval/outcome-counters.md`** — the measurement and the parking argument: 0 rows carry `derived_from`/`writer`/`novelty` in the live store (the installed binary is 0.1.3 at schema v4); the negative arm is structurally inert for live pages (supersession already closes what it would penalise); the counts are derivable at read time with zero new state, so nothing is lost by waiting. **Reopen trigger: ≥20 live cited rows in the dogfood store.**
- **Harness `call_as` + first test of the #75 `_meta["agmem/session"]` override** — the "writer provenance dependency" turned out to be a test-client change, not server plumbing; this is the enabler the deferred fixture work rides on.

No schema change, no `signals` field, no rank weight.

Refs #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpiYNUHtWjqnGvP2dHhXdp