### PR TITLE
The daemon retires only for a newer release, and says so (#112)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,7 @@ dependencies = [
  "jiff",
  "rmcp",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/agmem-server/Cargo.toml
+++ b/crates/agmem-server/Cargo.toml
@@ -32,6 +32,10 @@ tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 directories = { workspace = true }
 jiff = { workspace = true }
+# The daemon retires for a *newer* attacher and keeps serving an older one
+# (issue #112); telling the two apart is a version comparison, not a string
+# one. Already in the tree through surrealdb.
+semver = "1.0"
 # `client` is not only for tests: `agmem context` (issue #46) speaks MCP to
 # the shared daemon from the client side, over the same socket a session uses.
 rmcp = { workspace = true, features = ["client"] }

--- a/crates/agmem-server/src/config.rs
+++ b/crates/agmem-server/src/config.rs
@@ -100,6 +100,13 @@ pub struct Cli {
     #[arg(long, hide = true)]
     pub daemon_serve: bool,
 
+    /// This daemon replaces one that retired for its release, so its ready
+    /// line can say that sessions still on the old one need a restart
+    /// (issue #112). Passed by the session that respawned it; meaningless
+    /// without --daemon-serve.
+    #[arg(long, hide = true, requires = "daemon_serve")]
+    pub took_over: bool,
+
     /// Seconds the shared daemon stays up with no sessions attached. 0 keeps
     /// it until the machine restarts.
     #[arg(
@@ -280,6 +287,7 @@ pub struct Config {
     pub reindex: bool,
     pub no_daemon: bool,
     pub daemon_serve: bool,
+    pub took_over: bool,
     pub idle_timeout: u64,
     /// The one-shot subcommand this run is, if it is one.
     pub command: Option<CliCommand>,
@@ -427,6 +435,7 @@ impl Cli {
             reindex: self.reindex,
             no_daemon: self.no_daemon,
             daemon_serve: self.daemon_serve,
+            took_over: self.took_over,
             idle_timeout: self.idle_timeout,
             command: self.command,
         })

--- a/crates/agmem-server/src/daemon/client.rs
+++ b/crates/agmem-server/src/daemon/client.rs
@@ -17,6 +17,7 @@ use tokio::net::UnixStream;
 
 use crate::config::Config;
 use crate::daemon::{Ack, DAEMON_LOG_FILE, Handshake, RELEASE, socket_path, spawn_lock_path};
+use crate::lock;
 
 /// How long to queue for the right to start a daemon before giving up. Long
 /// enough for another session to finish starting one, short enough that a
@@ -30,9 +31,15 @@ const READY_DEADLINE: Duration = Duration::from_secs(120);
 /// How often to re-try the socket while waiting.
 const POLL: Duration = Duration::from_millis(50);
 
-/// How long a retiring daemon gets to unlink its socket before this session
-/// starts a fresh one anyway.
+/// How long a retiring daemon gets to unlink its socket and release the
+/// store lock before this session starts a fresh one anyway.
 const RETIRE_DEADLINE: Duration = Duration::from_secs(15);
+
+/// How long the daemon has to answer the handshake (issue #112). A daemon
+/// that accepted the connection and says nothing is wedged, not slow: the
+/// ack is one line written before any work, so a read that outlives this is
+/// a session that would otherwise hang with no memory tools and no message.
+const ACK_DEADLINE: Duration = Duration::from_secs(10);
 
 /// Attach this session to the shared store, starting the daemon if needed,
 /// and pump stdio until the client goes away.
@@ -51,7 +58,7 @@ pub async fn run(cfg: &Config) -> anyhow::Result<()> {
 /// every byte after it is MCP. [`run`] pumps stdio into it, `agmem context`
 /// (issue #46) speaks it itself.
 ///
-/// A daemon from another release answers "retiring" and shuts down (issue
+/// A daemon from an older release answers "retiring" and shuts down (issue
 /// #60); this session waits it out and starts a fresh daemon from its own
 /// binary — once. Two retirements in a row means two binaries are fighting
 /// over the socket, and that is the user's to resolve.
@@ -63,11 +70,11 @@ pub async fn run(cfg: &Config) -> anyhow::Result<()> {
 /// and no explanation.
 pub async fn attach(cfg: &Config) -> anyhow::Result<UnixStream> {
     let path = socket_path(&cfg.data_dir)?;
-    match attach_once(cfg, &path).await? {
+    match attach_once(cfg, &path, Takeover::No).await? {
         Attached::Serving(stream) => Ok(stream),
         Attached::DaemonRetired => {
             wait_for_retirement(&path).await;
-            match attach_once(cfg, &path).await? {
+            match attach_once(cfg, &path, Takeover::FromRetired).await? {
                 Attached::Serving(stream) => Ok(stream),
                 Attached::DaemonRetired => bail!(
                     "the shared store on {} retired twice in a row: two different agmem \
@@ -89,11 +96,24 @@ enum Attached {
     DaemonRetired,
 }
 
+/// Whether a daemon this session starts is replacing one that just retired.
+///
+/// It changes one thing: the fresh daemon's ready line, which then says that
+/// the sessions still attached to the old daemon need a restart (issue
+/// #112). That fact is otherwise recorded nowhere.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Takeover {
+    /// The ordinary start: nothing was serving.
+    No,
+    /// The daemon that was serving retired for this session's release.
+    FromRetired,
+}
+
 /// Connect or start a daemon, hand it the handshake, and read its verdict.
-async fn attach_once(cfg: &Config, path: &Path) -> anyhow::Result<Attached> {
+async fn attach_once(cfg: &Config, path: &Path, takeover: Takeover) -> anyhow::Result<Attached> {
     let mut stream = match connect(path).await {
         Some(stream) => stream,
-        None => start_one(cfg, path).await?,
+        None => start_one(cfg, path, takeover).await?,
     };
     let mut handshake = serde_json::to_vec(&Handshake::new(cfg))?;
     handshake.push(b'\n');
@@ -102,7 +122,7 @@ async fn attach_once(cfg: &Config, path: &Path) -> anyhow::Result<Attached> {
         .await
         .context("the shared store closed before the handshake landed")?;
 
-    let ack = read_ack(&mut stream, cfg).await?;
+    let ack = read_ack(&mut stream, cfg, ACK_DEADLINE).await?;
     if ack.ok {
         return Ok(Attached::Serving(stream));
     }
@@ -110,7 +130,10 @@ async fn attach_once(cfg: &Config, path: &Path) -> anyhow::Result<Attached> {
         .error
         .unwrap_or_else(|| "the shared store refused the handshake without saying why".to_owned());
     if ack.retiring {
-        tracing::info!(%why, "waiting for the old daemon to retire");
+        tracing::info!(
+            %why,
+            "waiting for the old daemon to retire; sessions still attached to it need a restart"
+        );
         return Ok(Attached::DaemonRetired);
     }
     bail!(why)
@@ -119,7 +142,28 @@ async fn attach_once(cfg: &Config, path: &Path) -> anyhow::Result<Attached> {
 /// The daemon's one-line answer to the handshake, read a byte at a time: the
 /// bytes after the newline are MCP and belong to the pump, so nothing here
 /// may buffer past it.
-async fn read_ack(stream: &mut UnixStream, cfg: &Config) -> anyhow::Result<Ack> {
+///
+/// Bounded by `deadline` (issue #112): before it, a daemon that accepted and
+/// then hung — mid-migration on a store it could not finish opening, say —
+/// held every new session here forever.
+async fn read_ack(
+    stream: &mut UnixStream,
+    cfg: &Config,
+    deadline: Duration,
+) -> anyhow::Result<Ack> {
+    match tokio::time::timeout(deadline, read_ack_line(stream, cfg)).await {
+        Ok(ack) => ack,
+        Err(_elapsed) => bail!(
+            "the shared store accepted the connection but did not answer the handshake \
+             within {deadline:?}. It is wedged rather than slow{}; stop it and retry. Its \
+             log is {}.",
+            holder_hint(cfg),
+            log_path(cfg).display()
+        ),
+    }
+}
+
+async fn read_ack_line(stream: &mut UnixStream, cfg: &Config) -> anyhow::Result<Ack> {
     let mut line = Vec::new();
     let mut byte = [0u8; 1];
     loop {
@@ -130,12 +174,15 @@ async fn read_ack(stream: &mut UnixStream, cfg: &Config) -> anyhow::Result<Ack> 
         if n == 0 {
             // Pre-#60 daemons never wrote an ack: a refusal was a close the
             // client pumped through and exited 0 on. Meeting that close here
-            // turns it into the message it always should have been.
+            // turns it into the message it always should have been — and
+            // since a daemon that old cannot be retired over the wire, the
+            // message carries the pid to stop by hand (issue #112).
             bail!(
                 "the shared store closed without answering the handshake. It is probably \
-                 an agmem older than {RELEASE} still holding {}; stop that process (or \
+                 an agmem older than {RELEASE} still holding {}{}; stop that process (or \
                  wait out its idle timeout) and retry. Its log is {}.",
                 cfg.data_dir.display(),
+                holder_hint(cfg),
                 log_path(cfg).display()
             );
         }
@@ -150,15 +197,54 @@ async fn read_ack(stream: &mut UnixStream, cfg: &Config) -> anyhow::Result<Ack> 
     serde_json::from_slice(&line).context("the shared store's handshake ack is not JSON")
 }
 
-/// Wait for a retiring daemon to unlink its socket, then a beat longer for
-/// its store lock to release with its process — the fresh daemon this
-/// session is about to start needs both gone.
+/// The pid on the store lock, worded to drop into a message — with the
+/// command to run, because a session that has to kill a daemon by hand
+/// should not also have to work out how.
+fn holder_hint(cfg: &Config) -> String {
+    match lock::owner(&cfg.data_dir) {
+        Some(pid) => format!(" (pid {pid} by its lock file: `kill {pid}`)"),
+        None => String::new(),
+    }
+}
+
+/// Wait for a retiring daemon to unlink its socket. Its store lock goes
+/// with its process, a little later; [`start_one`] waits for that.
 async fn wait_for_retirement(path: &Path) {
     let deadline = Instant::now() + RETIRE_DEADLINE;
     while Instant::now() < deadline && path.exists() {
         tokio::time::sleep(POLL).await;
     }
-    tokio::time::sleep(Duration::from_millis(200)).await;
+}
+
+/// Wait for the store lock to be free, so the daemon about to be started
+/// does not die on it.
+///
+/// A retiring daemon drains its sessions for a moment after it unlinks the
+/// socket; the lock is what says its process is actually gone (issue #112 —
+/// before this, a fixed sleep guessed, and a guess too short cost the
+/// session the whole `READY_DEADLINE` before it learned anything). A lock
+/// still held past the deadline is a process that is not going anywhere: a
+/// `--no-daemon` session, or a daemon that stopped answering.
+///
+/// # Errors
+/// When the lock is still held after `RETIRE_DEADLINE`.
+async fn wait_for_store_lock(cfg: &Config) -> anyhow::Result<()> {
+    let deadline = Instant::now() + RETIRE_DEADLINE;
+    loop {
+        if lock::probe(&cfg.data_dir)? {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!(
+                "another agmem process{} still owns the store in {} after {RETIRE_DEADLINE:?}, \
+                 and no daemon is answering on its socket. It is a --no-daemon session or a \
+                 daemon that stopped serving; stop it, or pass --no-daemon here.",
+                holder_hint(cfg),
+                cfg.data_dir.display()
+            );
+        }
+        tokio::time::sleep(POLL).await;
+    }
 }
 
 /// Where the daemon this configuration would start writes its log.
@@ -176,7 +262,7 @@ async fn connect(path: &Path) -> Option<UnixStream> {
 }
 
 /// Take the spawn lock, start a daemon, and wait for it to accept.
-async fn start_one(cfg: &Config, path: &Path) -> anyhow::Result<UnixStream> {
+async fn start_one(cfg: &Config, path: &Path, takeover: Takeover) -> anyhow::Result<UnixStream> {
     std::fs::create_dir_all(&cfg.data_dir)
         .with_context(|| format!("cannot create data dir {}", cfg.data_dir.display()))?;
     let _guard = queue_to_spawn(&spawn_lock_path(&cfg.data_dir)).await?;
@@ -192,8 +278,13 @@ async fn start_one(cfg: &Config, path: &Path) -> anyhow::Result<UnixStream> {
         std::fs::remove_file(path)
             .with_context(|| format!("cannot clear the stale socket {}", path.display()))?;
     }
+    // Nothing answers on the socket, but the store may still be held — by
+    // the daemon that just retired and is draining, most often. A daemon
+    // started now would exit on the lock, and this session would learn that
+    // only from the ready timeout.
+    wait_for_store_lock(cfg).await?;
 
-    spawn(cfg)?;
+    spawn(cfg, takeover)?;
     wait_until_ready(cfg, path).await
 }
 
@@ -231,7 +322,7 @@ async fn queue_to_spawn(path: &Path) -> anyhow::Result<File> {
 }
 
 /// Start a detached daemon from this same binary.
-fn spawn(cfg: &Config) -> anyhow::Result<()> {
+fn spawn(cfg: &Config, takeover: Takeover) -> anyhow::Result<()> {
     let exe = std::env::current_exe()
         .context("cannot find this binary to start the shared store from")?;
     let log_file = log_path(cfg);
@@ -256,6 +347,9 @@ fn spawn(cfg: &Config) -> anyhow::Result<()> {
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+    if takeover == Takeover::FromRetired {
+        command.arg("--took-over");
+    }
 
     // Its own process group. The daemon has to outlive the session that
     // happened to start it, including a Ctrl-C in the terminal that owns it.
@@ -271,7 +365,7 @@ fn spawn(cfg: &Config) -> anyhow::Result<()> {
             log_file.display()
         )
     })?;
-    tracing::info!(log = %log_file.display(), "started the shared store");
+    tracing::info!(log = %log_file.display(), ?takeover, "started the shared store");
     Ok(())
 }
 
@@ -312,4 +406,76 @@ async fn pump(stream: UnixStream) -> anyhow::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(data: &Path) -> Config {
+        use clap::Parser as _;
+        crate::config::Cli::try_parse_from([
+            "agmem",
+            "--embedder",
+            "none",
+            "--data",
+            &data.display().to_string(),
+        ])
+        .expect("parse")
+        .resolve()
+        .expect("resolve")
+    }
+
+    #[tokio::test]
+    async fn a_daemon_that_accepts_and_says_nothing_is_reported_not_waited_on() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = config(dir.path());
+        let path = socket_path(dir.path()).expect("socket path");
+        let listener = tokio::net::UnixListener::bind(&path).expect("bind");
+        // Accept and hold: what a daemon wedged between accept and ack does.
+        let wedged = tokio::spawn(async move {
+            let (held, _) = listener.accept().await.expect("accept");
+            std::future::pending::<()>().await;
+            drop(held);
+        });
+
+        let mut stream = UnixStream::connect(&path).await.expect("connect");
+        let error = read_ack(&mut stream, &cfg, Duration::from_millis(100))
+            .await
+            .expect_err("no ack within the deadline is an error");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("did not answer the handshake"),
+            "the message says what happened: {message}"
+        );
+        assert!(
+            message.contains(&cfg.data_dir.join(DAEMON_LOG_FILE).display().to_string()),
+            "and where to look: {message}"
+        );
+        wedged.abort();
+    }
+
+    #[tokio::test]
+    async fn a_close_without_an_ack_names_the_pid_on_the_lock() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = config(dir.path());
+        let path = socket_path(dir.path()).expect("socket path");
+        let listener = tokio::net::UnixListener::bind(&path).expect("bind");
+        // What a pre-v3 daemon does with a handshake it refuses: close.
+        tokio::spawn(async move {
+            let (accepted, _) = listener.accept().await.expect("accept");
+            drop(accepted);
+        });
+        std::fs::write(dir.path().join(lock::LOCK_FILE), "4242\n").expect("a lock file");
+
+        let mut stream = UnixStream::connect(&path).await.expect("connect");
+        let error = read_ack(&mut stream, &cfg, ACK_DEADLINE)
+            .await
+            .expect_err("a close is not an ack");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("kill 4242"),
+            "the way out is a command, not a hunt: {message}"
+        );
+    }
 }

--- a/crates/agmem-server/src/daemon/mod.rs
+++ b/crates/agmem-server/src/daemon/mod.rs
@@ -26,6 +26,7 @@ pub mod client;
 #[cfg(unix)]
 pub mod serve;
 
+use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
 
 use agmem_core::SpaceName;
@@ -159,19 +160,49 @@ impl Handshake {
     /// disagree. The message is the session's to read, so it names both
     /// sides; `retire` says whether this daemon should hand the socket over.
     pub fn accept(&self, asked: &Self) -> Result<(), Refusal> {
-        // Release first: a version skew subsumes whatever else differs, and
-        // the newest attacher's binary is the one the user just installed —
-        // the daemon defers to it rather than serving code that no longer
-        // matches what is on disk.
-        if asked.release != self.release {
-            return Err(Refusal {
-                retire: true,
-                message: format!(
-                    "the running daemon is agmem {} and this session is agmem {}; the \
-                     daemon is retiring so a fresh one can serve this release.",
-                    self.release, asked.release
-                ),
-            });
+        // Release first: a version skew subsumes whatever else differs. The
+        // *newer* binary is the one the user just installed, so the daemon
+        // defers to a newer attacher rather than serving code that no longer
+        // matches what is on disk — and keeps serving when the attacher is
+        // the older one (issue #112): two installs on PATH would otherwise
+        // retire each other's daemon in turn, cutting live sessions each time.
+        match newer(&asked.release, &self.release) {
+            Some(Ordering::Greater) => {
+                return Err(Refusal {
+                    retire: true,
+                    message: format!(
+                        "the running daemon is agmem {} and this session is agmem {}; the \
+                         daemon is retiring so a fresh one can serve this release. Sessions \
+                         still attached to it need a restart.",
+                        self.release, asked.release
+                    ),
+                });
+            }
+            Some(Ordering::Less) => {
+                return Err(Refusal {
+                    retire: false,
+                    message: format!(
+                        "the running daemon is agmem {} and this session is an older agmem \
+                         {}; the daemon keeps serving the newer release. Run this session \
+                         from the same agmem, or pass --no-daemon.",
+                        self.release, asked.release
+                    ),
+                });
+            }
+            Some(Ordering::Equal) => {}
+            None => {
+                // One side is not a version this code can read. Nothing says
+                // which is newer, so the rule from before #112 stands: the
+                // attacher's binary is the one on disk.
+                return Err(Refusal {
+                    retire: true,
+                    message: format!(
+                        "the running daemon is agmem {} and this session is agmem {}; the \
+                         daemon is retiring so a fresh one can serve this release.",
+                        self.release, asked.release
+                    ),
+                });
+            }
         }
         if asked.version != self.version {
             return Err(Refusal {
@@ -224,6 +255,33 @@ pub struct Refusal {
     pub message: String,
     /// Whether the daemon shuts down after refusing.
     pub retire: bool,
+}
+
+impl Refusal {
+    /// What a session hears when it attaches to a daemon another session
+    /// already retired (issue #112): the same "wait for the fresh one" the
+    /// first one got, so it waits instead of coming up on a socket about to
+    /// close.
+    pub fn already_retiring() -> Self {
+        Self {
+            retire: true,
+            message: format!(
+                "the running daemon (agmem {RELEASE}) is retiring for a newer release; \
+                 this session waits for the fresh one."
+            ),
+        }
+    }
+}
+
+/// Which of two releases is newer, if both are versions this code can read.
+///
+/// `Greater` means `asked` is newer than `daemon`. Both are `CARGO_PKG_VERSION`
+/// strings in practice, so the `None` branch is for a hand-built binary
+/// somebody gave a release name that is not one.
+fn newer(asked: &str, daemon: &str) -> Option<Ordering> {
+    let asked = semver::Version::parse(asked).ok()?;
+    let daemon = semver::Version::parse(daemon).ok()?;
+    Some(asked.cmp(&daemon))
 }
 
 impl std::fmt::Display for Refusal {
@@ -313,14 +371,37 @@ mod tests {
 
         for (label, broken, retires) in [
             (
-                "release",
+                "newer release",
                 Handshake {
-                    release: "0.0.0-elsewhere".to_owned(),
+                    release: "999.0.0".to_owned(),
                     ..daemon.clone()
                 },
-                // Another release means this daemon is the stale one: it
+                // A newer release means this daemon is the stale one: it
                 // steps aside rather than serving code that no longer
                 // matches the binary on disk.
+                true,
+            ),
+            (
+                "older release",
+                Handshake {
+                    release: "0.0.1".to_owned(),
+                    ..daemon.clone()
+                },
+                // An older attacher is a second install on PATH, not an
+                // upgrade (issue #112): retiring for it would let the two
+                // binaries retire each other's daemon in turn.
+                false,
+            ),
+            (
+                "unreadable release",
+                Handshake {
+                    // Not a version at all — "0.0.0-elsewhere" would be, and
+                    // would sort as older.
+                    release: "elsewhere".to_owned(),
+                    ..daemon.clone()
+                },
+                // Nothing says which side is newer; the rule from before
+                // #112 stands and the attacher's binary wins.
                 true,
             ),
             (

--- a/crates/agmem-server/src/daemon/serve.rs
+++ b/crates/agmem-server/src/daemon/serve.rs
@@ -5,6 +5,7 @@
 //! over a Unix socket. Sessions come and go; the store does not.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use agmem_embed::Embedder;
@@ -13,15 +14,25 @@ use anyhow::Context;
 use rmcp::ServiceExt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::mpsc;
+use tokio::task::JoinSet;
+use tokio::time::Instant;
 
 use crate::config::Config;
-use crate::daemon::{Ack, Handshake, socket_path};
+use crate::daemon::{Ack, Handshake, Refusal, socket_path};
 use crate::service::AgmemService;
-use crate::{embedder, lock};
+use crate::{doctor, embedder, lock};
+
+/// How long a retiring daemon keeps serving the sessions already attached
+/// before it exits (issue #112). Long enough for a tool call in flight to
+/// answer; short enough that the upgrade someone just ran does not look like
+/// a hang. The session that retired it is waiting on the store lock this
+/// process holds, so every second here is a second before the new daemon
+/// can start.
+pub const DRAIN: Duration = Duration::from_secs(2);
 
 /// Own the store and serve every session that attaches, until nothing has
-/// been attached for `idle_timeout`.
+/// been attached for `idle_timeout` — or a newer release attaches, in which
+/// case this daemon retires so that release can serve.
 ///
 /// # Errors
 /// When the lock is already held, the store will not open or migrate, the
@@ -41,6 +52,20 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
     // A daemon is where the sweep belongs: it is the process a machine starts
     // once, and the sessions attaching to it never start anything.
     let pruned = crate::startup::prune(&db).await;
+    // The checks `--doctor` cannot run while a daemon holds the store, run by
+    // the process that holds it (issue #112). They go to the log, not to the
+    // exit code: the schema and the embedder are up, so the store can serve,
+    // and a scratch write that failed is a line to read in daemon.log rather
+    // than a reason to leave every session without memory.
+    let checks = doctor::selfcheck(&db, embedder.as_ref()).await;
+    for check in &checks {
+        match &check.outcome {
+            Ok(detail) => tracing::info!(check = check.name, %detail, "selfcheck ok"),
+            Err(error) => {
+                tracing::warn!(check = check.name, %error, "selfcheck failed; serving anyway")
+            }
+        }
+    }
 
     // Bind last, and only once everything above has worked. A daemon that
     // advertises itself and then dies on migrate would invite every session
@@ -53,58 +78,125 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
         embedder = embedder.model_id(),
         dim = embedder.dim(),
         pruned,
+        checks = checks.len(),
         socket = %path.display(),
         "shared store ready"
     );
+    if cfg.took_over {
+        // The sessions that were on the old daemon are pumping a closed
+        // socket: their memory tools are gone until they start again. This
+        // is the one place that fact is written down.
+        tracing::info!(
+            release = crate::daemon::RELEASE,
+            "took over from a retired daemon; sessions still attached to the old one need a restart"
+        );
+    }
 
     let idle = Duration::from_secs(cfg.idle_timeout);
     let daemon = Arc::new(cfg);
-    let (ended, mut endings) = mpsc::unbounded_channel::<SessionEnd>();
-    let mut attached: u32 = 0;
+    // Once set, every handshake still in flight is answered "retiring" rather
+    // than "ok": a session accepted onto a daemon that is about to exit would
+    // come up with memory tools and lose them a moment later.
+    let retiring = Arc::new(AtomicBool::new(false));
+    let mut sessions = JoinSet::<SessionEnd>::new();
+    let mut listener = Some(listener);
+    let mut drain_until: Option<Instant> = None;
 
     loop {
+        // Read once per turn: the branches below hold `sessions` borrowed
+        // while they wait, so none of them can ask it again.
+        let attached = sessions.len();
         tokio::select! {
-            accepted = listener.accept() => {
+            accepted = accept_on(listener.as_ref()), if listener.is_some() => {
                 let (stream, _) = accepted.context("accepting on the agmem socket")?;
-                attached += 1;
-                let (db, embedder, daemon, ended) =
-                    (db.clone(), Arc::clone(&embedder), Arc::clone(&daemon), ended.clone());
-                tokio::spawn(async move {
-                    let end = match session(stream, db, embedder, &daemon).await {
+                let (db, embedder, daemon, retiring) =
+                    (db.clone(), Arc::clone(&embedder), Arc::clone(&daemon), Arc::clone(&retiring));
+                sessions.spawn(async move {
+                    match session(stream, db, embedder, &daemon, &retiring).await {
                         Ok(end) => end,
                         Err(error) => {
                             tracing::warn!(error = %format!("{error:#}"), "session ended badly");
                             SessionEnd::Detached
                         }
-                    };
-                    // The receiver lives as long as the loop, so this only
-                    // fails once we are already shutting down.
-                    let _ = ended.send(end);
+                    }
                 });
             }
-            Some(end) = endings.recv() => {
-                attached = attached.saturating_sub(1);
-                if matches!(end, SessionEnd::Retiring) {
-                    // Sessions may still be attached, but they are attached
-                    // to code from a release that is no longer on disk;
-                    // cutting them loose is the fix, not the damage
-                    // (issue #60 — a stale daemon otherwise serves old
-                    // schema and scoring until its idle timeout).
-                    tracing::info!(attached, "another release attached; retiring so its binary can serve");
-                    break;
+            Some(ended) = sessions.join_next(), if attached > 0 => {
+                let end = ended.unwrap_or_else(|error| {
+                    tracing::warn!(%error, "a session task did not finish");
+                    SessionEnd::Detached
+                });
+                let attached = attached.saturating_sub(1);
+                match end {
+                    SessionEnd::Retiring if drain_until.is_none() => {
+                        // Sessions may still be attached, but they are attached
+                        // to code from a release that is no longer on disk;
+                        // cutting them loose is the fix, not the damage
+                        // (issue #60 — a stale daemon otherwise serves old
+                        // schema and scoring until its idle timeout). They get
+                        // `DRAIN` to answer whatever is in flight, no more.
+                        retiring.store(true, Ordering::SeqCst);
+                        listener = None;
+                        // Unlink now, not at exit: the refused session is
+                        // waiting for exactly this before it starts a daemon
+                        // from its binary, and every second of the drain
+                        // would otherwise be added to its wait.
+                        let _ = std::fs::remove_file(&path);
+                        drain_until = Some(Instant::now() + DRAIN);
+                        tracing::warn!(
+                            attached,
+                            drain = ?DRAIN,
+                            "a newer release attached; retiring so its binary can serve — \
+                             sessions still attached need a restart"
+                        );
+                        if attached == 0 {
+                            break;
+                        }
+                    }
+                    SessionEnd::Retiring | SessionEnd::Detached if drain_until.is_some() => {
+                        if attached == 0 {
+                            tracing::info!("every session detached; retiring now");
+                            break;
+                        }
+                    }
+                    SessionEnd::Retiring | SessionEnd::Detached => {
+                        tracing::debug!(attached, "session detached");
+                    }
                 }
-                tracing::debug!(attached, "session detached");
             }
-            () = idle_elapsed(idle, attached == 0) => {
+            () = tokio::time::sleep_until(drain_until.unwrap_or_else(Instant::now)), if drain_until.is_some() => {
+                tracing::warn!(attached, "drain window over; cutting the remaining sessions loose");
+                break;
+            }
+            () = idle_elapsed(idle, attached == 0), if drain_until.is_none() => {
                 tracing::info!(?idle, "nothing attached; shutting down");
                 break;
             }
         }
     }
 
+    // In the binary the process exit does this; in a test the daemon is a
+    // task, and its sessions must not outlive it.
+    sessions.abort_all();
     drop(listener);
-    let _ = std::fs::remove_file(&path);
+    if drain_until.is_none() {
+        // A retiring daemon unlinked its socket when it stopped accepting,
+        // and the path may already belong to the daemon that replaced it.
+        let _ = std::fs::remove_file(&path);
+    }
     Ok(())
+}
+
+/// The next connection on `listener`; parks when there is no listener. The
+/// `select!` guard keeps this from being polled in that state, but a branch
+/// still has to be a future.
+async fn accept_on(
+    listener: Option<&UnixListener>,
+) -> std::io::Result<(UnixStream, tokio::net::unix::SocketAddr)> {
+    match listener {
+        Some(listener) => listener.accept().await,
+        None => std::future::pending().await,
+    }
 }
 
 /// Completes once `idle` has passed with nothing attached.
@@ -123,8 +215,8 @@ async fn idle_elapsed(idle: Duration, nothing_attached: bool) {
 enum SessionEnd {
     /// The ordinary way: the client went away, the daemon keeps serving.
     Detached,
-    /// The session ran a different release; the daemon refused it and now
-    /// shuts down so that session can start a daemon from its own binary.
+    /// The session ran a newer release; the daemon refused it and now shuts
+    /// down so that session can start a daemon from its own binary.
     Retiring,
 }
 
@@ -135,6 +227,7 @@ async fn session(
     db: Db,
     embedder: Arc<dyn Embedder>,
     daemon: &Config,
+    retiring: &AtomicBool,
 ) -> anyhow::Result<SessionEnd> {
     let (read, mut write) = stream.into_split();
     let mut read = BufReader::new(read);
@@ -154,7 +247,14 @@ async fn session(
     // The ack goes over the socket either way (issue #60): a refusal that
     // only lands in daemon.log is one the session pumps through as EOF and
     // exits 0 on — no memory tools, no explanation.
-    let decision = Handshake::new(daemon).accept(&asked);
+    let decision = if retiring.load(Ordering::SeqCst) {
+        // Accepted after another session retired this daemon: the answer is
+        // the same "wait for the fresh one" that session got, not an `ok`
+        // on a socket about to close (issue #112).
+        Err(Refusal::already_retiring())
+    } else {
+        Handshake::new(daemon).accept(&asked)
+    };
     let ack = match &decision {
         Ok(()) => Ack::accepted(),
         Err(refusal) => Ack::refused(refusal),
@@ -167,7 +267,7 @@ async fn session(
         .context("writing the handshake ack")?;
     if let Err(refusal) = decision {
         if refusal.retire {
-            tracing::warn!(%refusal, "refused a session from another release");
+            tracing::warn!(%refusal, release = %asked.release, "refused a session; retiring");
             return Ok(SessionEnd::Retiring);
         }
         return Err(refusal.into());

--- a/crates/agmem-server/src/doctor.rs
+++ b/crates/agmem-server/src/doctor.rs
@@ -8,6 +8,9 @@
 
 use std::path::Path;
 
+use agmem_embed::Embedder;
+use agmem_store::db::Db;
+
 use crate::config::Config;
 
 /// Run all checks; error (→ exit 1) when any failed.
@@ -44,7 +47,10 @@ pub async fn run(cfg: &Config) -> anyhow::Result<()> {
         if let Some(socket) = live_daemon(cfg).await {
             eprintln!("  ok    shared daemon        serving {socket}");
             eprintln!("  skip  single-writer lock    the daemon holds it");
-            eprintln!("  skip  database + schema     the daemon checked these when it started");
+            eprintln!(
+                "  skip  database + schema     the daemon checked these when it started; \
+                 its log has the result"
+            );
             failures += embedder_only(cfg);
             return finish(failures);
         }
@@ -143,24 +149,64 @@ async fn check_store(cfg: &Config) -> u32 {
 /// and not a log line. Rows written in BM25-only mode look identical and have
 /// the same remedy, so the message names it rather than guessing which
 /// happened.
-async fn check_vector_coverage(db: &agmem_store::db::Db) -> u32 {
-    match agmem_store::repo::reindex::pending_count(db).await {
-        Ok(0) => {
-            eprintln!("  ok    vector coverage      every row carries a vector");
+async fn check_vector_coverage(db: &Db) -> u32 {
+    match vector_coverage(db).await {
+        Ok(detail) => {
+            eprintln!("  ok    vector coverage      {detail}");
             0
-        }
-        Ok(pending) => {
-            eprintln!(
-                "  FAIL  vector coverage      {pending} row(s) carry no vector, so a vector \
-                 recall cannot reach them; run `agmem --reindex`"
-            );
-            1
         }
         Err(err) => {
             eprintln!("  FAIL  vector coverage      {err}");
             1
         }
     }
+}
+
+/// The coverage check's verdict, worded for whoever reports it.
+async fn vector_coverage(db: &Db) -> Result<String, String> {
+    match agmem_store::repo::reindex::pending_count(db).await {
+        Ok(0) => Ok("every row carries a vector".to_owned()),
+        Ok(pending) => Err(format!(
+            "{pending} row(s) carry no vector, so a vector recall cannot reach them; run \
+             `agmem --reindex`"
+        )),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
+/// One check over an open store, as the daemon logs it at start (issue #112)
+/// and `--doctor` prints it.
+#[derive(Debug)]
+pub struct Check {
+    /// What was checked, in the words the doctor report uses.
+    pub name: &'static str,
+    /// What was found: a detail worth a log line, or why it failed.
+    pub outcome: Result<String, String>,
+}
+
+/// The store checks that need the open handles: a scratch write and read,
+/// and — when there is a vector side — that every row carries one.
+///
+/// The daemon runs this over the `Db` it already holds, because a second
+/// connection to an embedded store from `--doctor` would be the second
+/// writer the daemon exists to prevent; until #112 those checks were simply
+/// skipped while a daemon was up. Nothing here decides what a failure means
+/// — the daemon logs and serves anyway, the doctor counts it.
+pub async fn selfcheck(db: &Db, embedder: &dyn Embedder) -> Vec<Check> {
+    let mut checks = vec![Check {
+        name: "write/read roundtrip",
+        outcome: roundtrip(db)
+            .await
+            .map(|()| "scratch record created and removed".to_owned())
+            .map_err(|err| err.to_string()),
+    }];
+    if embedder.dim() > 0 {
+        checks.push(Check {
+            name: "vector coverage",
+            outcome: vector_coverage(db).await,
+        });
+    }
+    checks
 }
 
 /// The embedder check on its own, for when the store belongs to the daemon.
@@ -217,13 +263,71 @@ fn check_data_dir(dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn roundtrip(db: &agmem_store::db::Db) -> Result<(), agmem_store::StoreError> {
+/// Write a scratch record, read it back, remove it.
+///
+/// `UPSERT`, not `CREATE`, because of the run before this one: a daemon
+/// killed between the write and the `DELETE` leaves the probe row behind,
+/// and a `CREATE` would then fail on "already exists" at every later start
+/// — a check that can only ever fail again is not a check. (A sweep ahead
+/// of the write would do the same, but `DELETE` on a table nothing has
+/// created yet is an error on a fresh store.)
+async fn roundtrip(db: &Db) -> Result<(), agmem_store::StoreError> {
     db.query(
-        "CREATE doctor_probe:check SET ok = true;
+        "UPSERT doctor_probe:check SET ok = true;
          SELECT VALUE ok FROM doctor_probe:check;
          DELETE doctor_probe;",
     )
     .await?
     .check()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_probe_row_left_behind_does_not_fail_the_next_roundtrip() {
+        let db = agmem_store::db::connect_with("mem://", None)
+            .await
+            .expect("an in-memory store");
+        agmem_store::migrate::ensure(&db).await.expect("migrate");
+        db.query("CREATE doctor_probe:check SET ok = false;")
+            .await
+            .expect("what an interrupted run leaves")
+            .check()
+            .expect("created");
+
+        roundtrip(&db)
+            .await
+            .expect("the roundtrip sweeps what an interrupted run left behind");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = {
+            use clap::Parser as _;
+            crate::config::Cli::try_parse_from([
+                "agmem",
+                "--embedder",
+                "none",
+                "--db",
+                "mem://",
+                "--data",
+                &dir.path().display().to_string(),
+            ])
+            .expect("parse")
+            .resolve()
+            .expect("resolve")
+        };
+        let embedder = crate::embedder::build(&cfg).expect("the none embedder");
+        let checks = selfcheck(&db, embedder.as_ref()).await;
+        assert!(
+            checks.iter().all(|check| check.outcome.is_ok()),
+            "{checks:?}"
+        );
+        assert_eq!(
+            checks.len(),
+            1,
+            "with no vector side there is no coverage to check: {checks:?}"
+        );
+    }
 }

--- a/crates/agmem-server/src/lock.rs
+++ b/crates/agmem-server/src/lock.rs
@@ -60,3 +60,72 @@ pub fn acquire(data_dir: &Path) -> anyhow::Result<DataDirLock> {
         }
     }
 }
+
+/// The pid recorded in the lock file, if a process ever took it.
+///
+/// Advisory: the number is whatever the last holder wrote, and it is only
+/// useful in a message that also says how to check it. The holder that is
+/// still alive is the interesting one, and [`probe`] answers that.
+pub fn owner(data_dir: &Path) -> Option<String> {
+    let owner = fs::read_to_string(data_dir.join(LOCK_FILE)).ok()?;
+    let owner = owner.trim();
+    (!owner.is_empty()).then(|| owner.to_owned())
+}
+
+/// Whether the data-dir lock is free right now, without keeping it.
+///
+/// A session that just watched a daemon retire uses this to know when that
+/// daemon's *process* is gone (issue #112): the socket vanishes when the
+/// daemon stops accepting, but the store lock goes only with the process,
+/// and a fresh daemon started before then fails on it.
+///
+/// # Errors
+/// When the lock file cannot be opened or locked for a reason other than
+/// another process holding it.
+pub fn probe(data_dir: &Path) -> anyhow::Result<bool> {
+    let path = data_dir.join(LOCK_FILE);
+    let file = File::options()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&path)
+        .with_context(|| format!("cannot open lock file {}", path.display()))?;
+    match file.try_lock() {
+        // Dropping `file` releases what this just took.
+        Ok(()) => Ok(true),
+        Err(TryLockError::WouldBlock) => Ok(false),
+        Err(TryLockError::Error(err)) => {
+            Err(err).with_context(|| format!("cannot lock {}", path.display()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_probe_sees_a_held_lock_and_a_released_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(
+            probe(dir.path()).expect("probe"),
+            "nobody holds a fresh dir"
+        );
+        assert_eq!(owner(dir.path()), None, "nobody has written a pid");
+
+        let held = acquire(dir.path()).expect("acquire");
+        assert!(!probe(dir.path()).expect("probe"), "held by this process");
+        assert_eq!(
+            owner(dir.path()).as_deref(),
+            Some(std::process::id().to_string().as_str()),
+            "the holder's pid is on record"
+        );
+
+        drop(held);
+        assert!(
+            probe(dir.path()).expect("probe"),
+            "the probe itself does not keep the lock, and neither does a dropped guard"
+        );
+    }
+}

--- a/crates/agmem-server/tests/daemon.rs
+++ b/crates/agmem-server/tests/daemon.rs
@@ -388,3 +388,117 @@ async fn a_probe_that_says_nothing_does_not_wedge_the_daemon() {
         "the daemon still serves after a probe came and went: {found}"
     );
 }
+
+#[tokio::test]
+async fn a_session_from_an_older_release_is_refused_and_the_daemon_stays() {
+    let shared = Shared::start().await;
+    let mut asked = Handshake::new(&config(shared.data.path(), "downgraded"));
+    asked.release = "0.0.1".to_owned();
+    let mut line = serde_json::to_vec(&asked).expect("serialize");
+    line.push(b'\n');
+
+    let (read, mut write) = shared.connect().await.into_split();
+    write.write_all(&line).await.expect("send the handshake");
+    let mut reply = String::new();
+    BufReader::new(read)
+        .read_line(&mut reply)
+        .await
+        .expect("read the ack");
+    let ack: Ack = serde_json::from_str(&reply).expect("the ack is JSON");
+    assert!(
+        !ack.ok && !ack.retiring,
+        "an older attacher is a second install on PATH, not an upgrade (issue #112); \
+         retiring for it would let two binaries retire each other in turn: {ack:?}"
+    );
+    assert!(
+        ack.error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("--no-daemon"),
+        "the refusal names a way out: {ack:?}"
+    );
+
+    // The daemon is still the newest binary on the socket, so it keeps serving.
+    let session = shared.attach("still-served").await;
+    let found = call(&session, "recall", json!({})).await;
+    assert!(
+        found["hits"].as_array().expect("hits").is_empty(),
+        "the daemon serves on after refusing an older release: {found}"
+    );
+}
+
+#[tokio::test]
+async fn a_retiring_daemon_turns_late_attachers_away_and_drains_before_exiting() {
+    let mut shared = Shared::start().await;
+    let already_here = shared.attach("already-here").await;
+    // Connected before the retirement, handshake not yet sent: the shape of
+    // a session that raced the upgrade.
+    let (late_read, mut late_write) = shared.connect().await.into_split();
+
+    let mut asked = Handshake::new(&config(shared.data.path(), "upgraded"));
+    asked.release = "999.0.0".to_owned();
+    let mut line = serde_json::to_vec(&asked).expect("serialize");
+    line.push(b'\n');
+    let (read, mut write) = shared.connect().await.into_split();
+    write.write_all(&line).await.expect("send the handshake");
+    let mut reply = String::new();
+    BufReader::new(read)
+        .read_line(&mut reply)
+        .await
+        .expect("read the ack");
+    let ack: Ack = serde_json::from_str(&reply).expect("the ack is JSON");
+    assert!(!ack.ok && ack.retiring, "{ack:?}");
+    let retired_at = std::time::Instant::now();
+
+    // The daemon unlinks its socket the moment it stops accepting; that is
+    // the observable edge of "retiring" for the late session below.
+    let socket = daemon::socket_path(shared.data.path()).expect("socket path");
+    for _ in 0..500 {
+        if !socket.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        !socket.exists(),
+        "a retiring daemon stops advertising itself at once"
+    );
+
+    late_write
+        .write_all(&shared.handshake("late"))
+        .await
+        .expect("the late handshake lands on a connection the daemon accepted");
+    let mut reply = String::new();
+    BufReader::new(late_read)
+        .read_line(&mut reply)
+        .await
+        .expect("read the late ack");
+    let ack: Ack = serde_json::from_str(&reply).expect("the late ack is JSON");
+    assert!(
+        !ack.ok && ack.retiring,
+        "a session accepted onto a retiring daemon would come up with memory tools and \
+         lose them a moment later; it hears the same 'wait' the upgrader did (issue \
+         #112): {ack:?}"
+    );
+
+    // The session that was already attached is served through the drain
+    // and cut loose at its end, not before.
+    let found = call(&already_here, "recall", json!({})).await;
+    assert!(
+        found["hits"].as_array().expect("hits").is_empty(),
+        "{found}"
+    );
+    tokio::time::timeout(Duration::from_secs(10), &mut shared.daemon)
+        .await
+        .expect("the daemon exits once the drain is over")
+        .expect("cleanly")
+        .expect("without error");
+    assert!(
+        retired_at.elapsed() >= daemon::serve::DRAIN,
+        "a session was still attached, so the daemon stayed for the drain window"
+    );
+    already_here
+        .waiting()
+        .await
+        .expect("the daemon's exit closes the session's transport");
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -680,17 +680,34 @@ main()
     a. unix + embedded + not --no-daemon → attach to the shared daemon (#37):
          connect <data_dir>/agmem.sock
          └─ nothing there → take <data_dir>/agmem.spawn.lock, clear a stale
-            socket, spawn `argv[0] --daemon-serve` in its own process group,
+            socket, wait for <data_dir>/agmem.lock to be free (a daemon
+            that just retired holds it while it drains; a --no-daemon
+            session holds it for good — after 15 s, a message naming the
+            pid), spawn `argv[0] --daemon-serve` in its own process group,
             wait for it to accept
          send one JSON handshake line
             { version, release, db_url, embedder, space, pool, max_k,
               tool_desc }
          read the one-line Ack { ok, error?, retiring } it answers with
-         (protocol v3, #60): a daemon from another release refuses with
-         retiring: true and shuts down — the client waits for the socket
-         to vanish and starts a fresh daemon from its own binary, exactly
-         once; other refusals (wrong store, wrong embedder) exit with the
-         daemon's message. The newest attacher's binary wins the socket.
+         (protocol v3, #60) — within 10 s: a daemon that accepted and says
+         nothing is wedged, and is reported rather than waited on (#112).
+         The daemon compares releases (#112). A *newer* attacher gets
+         retiring: true; the daemon stops accepting, unlinks the socket,
+         serves the sessions already attached for at most 2 s more, and
+         exits — the client waits for the socket to vanish and the lock to
+         free, then starts a fresh daemon from its own binary, passing
+         --took-over so its ready line says the old daemon's sessions need
+         a restart; exactly once. A session that attaches during the drain
+         hears retiring: true as well, never an ok on a socket about to
+         close. An *older* attacher is refused without retiring — two
+         installs on PATH must not retire each other's daemon in turn — and
+         so are the other refusals (wrong store, wrong embedder): a
+         non-zero exit carrying the daemon's message. A pre-v3 daemon
+         (≤ 0.1.3) closes without an Ack; the client reports it with the
+         pid from agmem.lock and the kill command, since nothing over the
+         wire can retire it. A dev build carries the same CARGO_PKG_VERSION
+         as the installed release and is served by the installed daemon;
+         work on the store itself runs with --no-daemon.
          then pump stdio ↔ socket, and decide nothing else
          └─ unreachable → stderr naming <data_dir>/daemon.log, exit 1. Never
             fall back to opening the store: that is the second writer.
@@ -709,6 +726,10 @@ main()
  8. repo::prune_expired() — lazy TTL close of decayed `fast` records, every
       space at once, and never fatal: the schema and the embedder are up, so a
       failed sweep is logged and the session is served anyway
+ 8a. the daemon only: the doctor's store checks over the handles it already
+      holds — a scratch write/read, and vector coverage when there is a
+      vector side — one log line each, never fatal (#112). `--doctor` skips
+      these while a daemon owns the store, so daemon.log is where they run.
  9. ensure space row; AgmemService.serve(transport); waiting()
 
  The daemon binds its socket only after 4–8 have succeeded, so one that dies


### PR DESCRIPTION
Closes #112.

PR #87 (v0.1.4) already retires a daemon on release skew and respawns from the attacher's binary; the Homebrew receipt and daemon.log show the 0.1.6 takeover on 2026-09-01 took under a minute with no silent attach. What #87 left is hardening, and this is it:

- **Compare, don't test inequality.** A newer attacher retires the daemon; an older one (a second install on PATH) is refused without retiring, so two binaries cannot retire each other's daemon in turn. Unreadable releases keep the old rule. Table test gains the older and unreadable rows.
- **Bounded ack read** (10 s): a daemon that accepted and hung is reported, naming daemon.log. Unit test against a socket that accepts and says nothing.
- **Retiring flag + drain.** After the first retirement the daemon stops accepting, unlinks its socket at once, answers in-flight handshakes with `retiring: true`, serves attached sessions for at most 2 s, then exits. Integration test: attached A is served through the drain, late C hears retiring, daemon exits after the window.
- **Lock probe instead of the 200 ms sleep.** The client waits for `agmem.lock` to be free before spawning; a lock still held after 15 s names the pid.
- **Startup selfcheck.** The doctor's roundtrip and vector-coverage checks run in the daemon over its own handles, logged per check, never fatal. The probe write is an `UPSERT` so a leftover row cannot fail every later start (unit test).
- **Takeover line.** Hidden `--took-over`, passed on respawn; the ready line and the retiring line both say sessions on the old daemon need a restart.
- **Pre-v3 daemon.** The no-ack message carries the pid from `agmem.lock` and the `kill` command.
- Design §5.1 route 3a rewritten; notes that a dev build is served by the installed daemon (same `CARGO_PKG_VERSION`) and store work runs with `--no-daemon`.

`cargo fmt --check`, `clippy -D warnings`, `cargo test --workspace`: 340 passed, 13 ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MUginUuH5hoGtnd9QEqL6
