### PR TITLE
The contradictions list cannot be ranked without labels it does not have (#53)

### DIFF
--- a/docs/eval/pair-rank.md
+++ b/docs/eval/pair-rank.md
@@ -1,0 +1,198 @@
+# Ranking contradictions without a model (issue #53)
+
+Written before any number was computed. The bar below is the decision; the
+results section is filled in afterwards and does not move the bar.
+
+## What is being decided
+
+`consolidate` returns a `contradictions` list: pairs of live claims that share
+an entity and sit in the `[0.75, 0.90)` cosine band, sorted by cosine,
+capped at 20. On the dogfood store the list is full of paraphrase noise and
+holds 0 real disagreements (#54); the store's own corrected pairs score in
+the same cosine range as the noise. NLI was the one model-based lever and
+it anti-separates (AUC 0.22–0.31, `nli-gate.md`, #84). Relevance rerankers
+are out for the same reason: a contradiction is *more* relevant to its
+partner, not less.
+
+What is left is the shape of a **factual revision under high overlap**: two
+statements of the same fact where a number, date, version or identifier
+changed, from a rarely-named subject, written at different times. The
+literature agrees that this is the signal and that it is cheap:
+VitaminC's edit-distance baseline reaches AUC 71.3 on flagging factual
+revisions; numeric mismatch is 29 % and negation 17.6 % of real
+contradictions in de Marneffe 2008; Weissman 2015 finds factual drift at
+Jaccard ≥ 0.9; Yang 2017's "fact update" edit class is defined the same way.
+None of that needs a model, and the store already holds labels: every
+superseded row and its successor is a real disagreement, and the shipped
+top-20 list is a labelled negative set.
+
+## The bar
+
+The probe computes a **blend** of model-free features and reports it on two
+labelled sets:
+
+- **T54**: corrected pairs closed by the #54 instant (22) against the
+  contradictions list as of that instant (20). Same sets `nli-gate.md`
+  scored, so the numbers are comparable.
+- **Current**: every corrected pair in the dump (58 at the last count)
+  against the current list (20).
+
+The blend ships only if **all** of these hold:
+
+1. AUC ≥ 0.70 on both sets.
+2. Permutation p < 0.05 on both sets (10 000 label shuffles of the blend).
+3. Cosine, scored on the same sets as the control, stays ≤ 0.60 — the
+   number that says the separation is not something the existing order
+   already had.
+4. The **acceptance test**, which is the issue's own unpark trigger made
+   countable: reorder the live 20-pair list by the blend, hand-label the
+   new top 20, and find ≥ 4 real disagreements where cosine's order finds 0.
+
+Anything short of all four closes #53 measured-and-dropped, with this
+document as the record, and replaces the trigger with a countable one:
+real pairs in the live top 20 stay at 0 across two dumps at least 30 days
+apart once the store passes 200 live claims.
+
+## Features
+
+All computed from `content`, `entities` and `created_at` only — the probe
+asserts nothing else is read, because `invalid_reason`, `superseded_by`
+and `valid_from` are the labels.
+
+| feature | what it measures | expected direction |
+|---|---|---|
+| entity rarity | the rarest entity the two share, as log(pool / df); a hub entity (carried by ≥ 50 % of the pool, the `HUB_SHARE` rule from `tools/hop.rs`) counts 0 | real pairs share a *specific* subject |
+| age gap | log1p of \|Δ created_at\| in days | corrections come later than what they correct; paraphrases arrive in bursts |
+| slot change | count of numbers, dates, versions and `#ids` present in one side and not the other, taken only when masked-token Jaccard (slots masked out) ≥ 0.3, else 0 | the fact-update shape |
+| cue asymmetry | replacement and negation cues (`no longer`, `instead`, `now`, `turned out`, `not`, `never`, `used to`, `previously`, `rather than`, `superseded`, `stale`) present on exactly one side | corrections announce themselves |
+| cosine | the shipped order, as control | must not carry the blend |
+
+The blend is the unweighted mean of per-feature ranks (no fitted weights:
+with 22 positives any fit is the noise). Each feature's own AUC is reported
+beside it so the blend cannot hide a dead feature or a single live one.
+
+## Guards the probe runs on itself
+
+- **Time-matched negatives.** The age gap may measure the store's write
+  history rather than supersession — corrections span the store's life,
+  paraphrases were seeded in bursts. The probe re-scores age gap against
+  negatives resampled to match the positives' gap distribution; a feature
+  that survives that is measuring the pair.
+- **DF histogram.** In a single-project space nearly every row carries the
+  project entity. The probe reports the share of pairs whose only shared
+  entities are hubs; above 80 % the rarity lever is dead in that space and
+  the report says so.
+- **Slot change alone.** Noise pairs differ in "file lists, counts, dates"
+  (#54), which is what this feature counts. If it scores below 0.55 alone it
+  is dropped from the blend before the blend is scored.
+- **Eviction.** How many of cosine's current top 20 the blend's order evicts,
+  so the change in what an agent sees is a number, not an impression.
+- **Leakage.** A test asserts the feature functions read only the three
+  fields above.
+
+## Inputs
+
+A dump from a *copy* of the store (the daemon holds the live one), as
+`nli-gate-probe.py` documents, with three fields added: `created_at`,
+`tags`, `writer`.
+
+```
+cp -r "~/Library/Application Support/dev.agmem.agmem/agmem.db" /tmp/probe.db
+echo 'SELECT record::id(id) AS id, space, kind, content, entities, embedding,
+      created_at, valid_from, invalid_at, invalid_reason, superseded_by,
+      tags, writer FROM memory;' \
+  | surreal sql --endpoint surrealkv:///tmp/probe.db \
+      --ns agmem --db main --json --hide-welcome
+```
+
+`uv run scripts/pair-rank-probe.py DUMP` prints the report and writes the
+reordered live top 20 to `pair-rank-top20.json` for hand labelling.
+
+## Results
+
+Run 2026-09-02 against a copy of the dogfood store: 186 rows, 168 in space
+`agmem`, 97 live now and 47 live at the #54 instant. The store had grown
+since the doc's counts were written: 23 corrected pairs closed by #54
+(nli-gate.md counted 22 — one row's `invalid_at` sits inside the second the
+instant falls in) and 78 now, against 20 noise pairs in each list. The band
+held 647 candidate pairs at #54 and 3 382 now.
+
+| set | rarity | age gap | slot change | cue asym. | cosine (control) | blend | perm. p |
+|---|---|---|---|---|---|---|---|
+| T54, 23 vs 20 | 0.543 | 0.817 | 0.703 | 0.490 | **0.943** | 0.870 (age gap + slot change) | 0.0001 |
+| current, 78 vs 20 | 0.486 | 0.303 | 0.622 | 0.300 | **0.707** | 0.622 (slot change alone) | 0.011 |
+
+Ungated slot change (no overlap floor) reads 0.276 / 0.193 — backwards, as
+#54 predicted: the noise pairs differ in exactly the counts and dates it
+counts.
+
+**Verdict: not cleared.** Three of the four bars fail:
+
+1. AUC ≥ 0.70 on both sets — fails on the current set (0.622).
+2. Permutation p < 0.05 — passes on both.
+3. Cosine control ≤ 0.60 — **fails on both** (0.943, 0.707), and this is the
+   finding. The store's corrected pairs are not what an undetected
+   disagreement looks like: a correction here is typically a near-duplicate
+   with one detail changed, and it sits *above* the paraphrase noise on
+   cosine. The shipped order separates these labelled sets already; what it
+   cannot do is find a disagreement the store has not yet corrected, and
+   that class has no labels. The measurement the bar needed does not exist
+   in this store.
+4. Hand-labelled acceptance — not run; moot with 1 and 3 failed.
+
+The guards fired as designed:
+
+- **Age gap is write history.** 0.817 at #54 collapses to 0.303 now, and
+  against 78 time-matched negatives from the wide band it reads 0.386. The
+  corrections that were open at #54 were simply older than the noise seeded
+  around it.
+- **Rarity is dead in this space.** 96 % of candidate pairs share only hub
+  entities; `agmem` sits on 144 of 168 rows, and the next entity down
+  (`surrealdb`) on 14.
+- **Cue asymmetry** never rose above chance: agmem corrections restate the
+  fact rather than announce a change.
+- With a single surviving feature the blend evicts 19 of cosine's top 20,
+  which is a reorder by slot count, not a ranking.
+
+Per-feature scores: `pair-rank-scores.json` beside the probe's output (not
+committed; regenerate with the script).
+
+## Consequences
+
+- #53 closes measured-and-dropped, joining #80, #81 and #84. The
+  model-free lever was the last constraint-compatible candidate, and the
+  store cannot currently label the thing that lever would have to rank.
+- The unpark trigger becomes countable: a dump in which a hand-labelled
+  real disagreement sits inside the band but below the cap — crowded out,
+  the harm the issue names — or a labelled set that the shipped cosine
+  order does not already separate (bar 3 passing), which would mean the
+  store has accumulated corrections that are not near-duplicates. Until
+  either happens there is nothing to rank against, and the check is cheap:
+  re-run the probe on a dump at least 30 days on once the store passes 200
+  live claims.
+- The entity-normalisation fix (`ctx-flow` versus `context-flow`) stands on
+  its own and does not wait on this.
+
+## If it ships
+
+`agmem-core/src/dedup.rs` gains a pure `disagreement_score` with the feature
+functions and unit tests; `tools/consolidate.rs` computes entity document
+frequency over the pool once, adds a `signals` object to each
+`Contradiction` beside the unchanged `similarity`, and sorts by the score.
+One protocol test: a rare-entity, time-separated, numeric-conflict pair
+outranks a same-burst hub paraphrase. `docs/design.md`'s consolidate
+section is updated, and because the `Contradiction` shape changes, the
+consolidate scenario pair in `scripts/desc-eval.nu` runs first.
+
+Separately, and regardless of the verdict: `shared_entities` should
+normalise entity names (case and `[-_ ]`), since `ctx-flow` and
+`context-flow` failing to match is a recall bug, not a ranking one (#54).
+
+## Sources
+
+- VitaminC (Schuster et al. 2021): https://ar5iv.labs.arxiv.org/html/2103.08541
+- de Marneffe, Rafferty, Manning 2008, *Finding contradictions in text*: https://aclanthology.org/P08-1118.pdf
+- Weissman et al. 2015, factual drift in Wikipedia: https://ar5iv.labs.arxiv.org/html/1406.1143
+- Yang et al. 2017, edit intentions incl. "fact update": https://aclanthology.org/D17-1213/
+- NevIR reranker results on contrastive pairs: https://arxiv.org/html/2502.13506v2
+- Small-n classifier cautions: Beleites 2013, Vabalas 2019, Ojala 2010 (permutation tests)

--- a/scripts/pair-rank-probe.py
+++ b/scripts/pair-rank-probe.py
@@ -1,0 +1,360 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["numpy"]
+# ///
+"""Issue #53's probe: can model-free features rank the store's real corrected
+pairs above the paraphrase noise that fills `consolidate`'s contradictions
+list? The bar was written before this ran: docs/eval/pair-rank.md.
+
+    uv run scripts/pair-rank-probe.py DUMP
+
+DUMP is a JSON array of memory rows from a *copy* of the store, as the doc
+shows (the same dump nli-gate-probe.py takes, plus created_at, tags and
+writer). numpy only: the point of the probe is that no model is involved.
+
+Every feature reads three fields — content, entities, created_at — through
+`View`, which refuses anything else. The labels (invalid_reason,
+superseded_by, valid_from) are what is being predicted, and a probe that can
+see them by accident measures nothing.
+"""
+
+import json
+import math
+import random
+import re
+import sys
+from datetime import datetime, timezone
+
+import numpy as np
+
+# The #54 measurement instant, so the first set is the one nli-gate.md scored.
+T54 = datetime(2026, 8, 30, 19, 42, 18, tzinfo=timezone.utc)
+NOISE_SPACE = "agmem"
+COS_FLOOR = 0.75
+LIST_CAP = 20
+# tools/hop.rs: an entity on at least this share of the pool names the topic
+# everything is already about, and says nothing about a pair.
+HUB_SHARE = 0.5
+# Slot changes only count between texts that otherwise say the same thing.
+OVERLAP_FLOOR = 0.3
+# A feature this weak on its own is dropped before the blend is scored.
+FEATURE_FLOOR = 0.55
+PERMUTATIONS = 10_000
+CUES = (
+    "no longer", "instead", "now", "turned out", "not", "never", "used to",
+    "previously", "rather than", "superseded", "stale", "was", "were",
+)
+# Numbers, dates, versions, issue/PR ids — the slots a fact update changes.
+SLOT = re.compile(r"#\d+|v?\d+(?:\.\d+)+|\d{4}-\d{2}-\d{2}(?:T[\d:.]+Z?)?|\d+")
+WORD = re.compile(r"[a-z][a-z0-9_'-]*")
+ALLOWED = frozenset({"content", "entities", "created_at"})
+
+
+class View:
+    """A row as a feature is allowed to see it."""
+
+    def __init__(self, row):
+        self._row = row
+
+    def __getitem__(self, key):
+        if key not in ALLOWED:
+            raise KeyError(f"feature read a label field: {key}")
+        return self._row[key]
+
+
+def parse_when(value):
+    return datetime.fromisoformat(value.replace("Z", "+00:00")) if value else None
+
+
+def link_id(value):
+    """'memory:⟨01ABC⟩' or 'memory:01ABC' -> '01ABC'."""
+    return value.split(":", 1)[1].strip("⟨⟩") if value else None
+
+
+# --- labelled sets (these read the labels; the features do not) -------------
+
+
+def corrected_pairs(rows, by_id):
+    """(old_row, successor_row, closed_at) for every superseded row."""
+    pairs = []
+    for row in rows:
+        if row.get("invalid_reason") != "superseded":
+            continue
+        successor = by_id.get(link_id(row.get("superseded_by")))
+        if successor:
+            pairs.append((row, successor, parse_when(row["invalid_at"])))
+    return pairs
+
+
+def candidate_pairs(rows, space, t):
+    """Every pair the shipped list could hold at `t`: live, same space, a
+    shared entity, over the cosine floor, not supersedes-linked — with its
+    cosine. The list itself is the top LIST_CAP of these by cosine."""
+
+    def live_at(row):
+        vf, ia = parse_when(row.get("valid_from")), parse_when(row.get("invalid_at"))
+        return vf is not None and vf <= t and (ia is None or ia > t)
+
+    def linked(a, b):
+        return link_id(a.get("superseded_by")) == b["id"] or link_id(b.get("superseded_by")) == a["id"]
+
+    pool = [r for r in rows if r["space"] == space and live_at(r) and r.get("embedding")]
+    vectors = np.array([r["embedding"] for r in pool])
+    vectors = vectors / np.linalg.norm(vectors, axis=1, keepdims=True)
+    similarity = vectors @ vectors.T
+    pairs = []
+    for i in range(len(pool)):
+        for j in range(i + 1, len(pool)):
+            a, b = pool[i], pool[j]
+            shared = {e.lower() for e in a["entities"]} & {e.lower() for e in b["entities"]}
+            if not shared or similarity[i, j] < COS_FLOOR or linked(a, b):
+                continue
+            pairs.append((a, b, float(similarity[i, j])))
+    pairs.sort(key=lambda p: -p[2])
+    return pairs, pool
+
+
+def cosine(a, b):
+    va, vb = np.array(a["embedding"]), np.array(b["embedding"])
+    return float(va @ vb / (np.linalg.norm(va) * np.linalg.norm(vb)))
+
+
+# --- features ---------------------------------------------------------------
+
+
+def document_frequency(pool):
+    df = {}
+    for row in pool:
+        for entity in {e.lower() for e in row["entities"]}:
+            df[entity] = df.get(entity, 0) + 1
+    return df
+
+
+def entity_rarity(a: View, b: View, df, pool_size):
+    """The rarest subject the two share, as log(pool / df); hubs count 0."""
+    shared = {e.lower() for e in a["entities"]} & {e.lower() for e in b["entities"]}
+    best = 0.0
+    for entity in shared:
+        freq = df.get(entity, 1)
+        if freq >= HUB_SHARE * pool_size:
+            continue
+        best = max(best, math.log(pool_size / freq))
+    return best
+
+
+def only_hubs(a: View, b: View, df, pool_size):
+    shared = {e.lower() for e in a["entities"]} & {e.lower() for e in b["entities"]}
+    return all(df.get(e, 1) >= HUB_SHARE * pool_size for e in shared)
+
+
+def age_gap(a: View, b: View):
+    ta, tb = parse_when(a["created_at"]), parse_when(b["created_at"])
+    return math.log1p(abs((ta - tb).total_seconds()) / 86400)
+
+
+def slots_and_tokens(text):
+    slots = set(SLOT.findall(text))
+    masked = SLOT.sub(" ", text.lower())
+    return slots, set(WORD.findall(masked))
+
+
+def masked_jaccard(a: View, b: View):
+    _, ta = slots_and_tokens(a["content"])
+    _, tb = slots_and_tokens(b["content"])
+    return len(ta & tb) / len(ta | tb) if ta | tb else 0.0
+
+
+def slot_change(a: View, b: View, gated=True):
+    sa, ta = slots_and_tokens(a["content"])
+    sb, tb = slots_and_tokens(b["content"])
+    overlap = len(ta & tb) / len(ta | tb) if ta | tb else 0.0
+    if gated and overlap < OVERLAP_FLOOR:
+        return 0.0
+    return float(len(sa ^ sb))
+
+
+def cue_asymmetry(a: View, b: View):
+    la, lb = a["content"].lower(), b["content"].lower()
+    return float(sum((cue in la) != (cue in lb) for cue in CUES))
+
+
+# --- scoring ----------------------------------------------------------------
+
+
+def auc(pos, neg):
+    pos, neg = np.asarray(pos), np.asarray(neg)
+    wins = (pos[:, None] > neg[None, :]).sum() + 0.5 * (pos[:, None] == neg[None, :]).sum()
+    return float(wins / (len(pos) * len(neg)))
+
+
+def ranks(values):
+    """Average ranks, 1-based, ties shared."""
+    values = np.asarray(values)
+    order = values.argsort()
+    r = np.empty(len(values))
+    i = 0
+    while i < len(values):
+        j = i
+        while j + 1 < len(values) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        r[order[i : j + 1]] = (i + j) / 2 + 1
+        i = j + 1
+    return r
+
+
+def blend(feature_columns):
+    """Unweighted mean of per-feature ranks over the rows given."""
+    return np.mean([ranks(col) for col in feature_columns], axis=0)
+
+
+def permutation_p(pos_scores, neg_scores, observed, rng):
+    scores = np.concatenate([pos_scores, neg_scores])
+    n_pos = len(pos_scores)
+    hits = 0
+    for _ in range(PERMUTATIONS):
+        rng.shuffle(scores)
+        if auc(scores[:n_pos], scores[n_pos:]) >= observed:
+            hits += 1
+    return (hits + 1) / (PERMUTATIONS + 1)
+
+
+def features_for(pairs, df, pool_size):
+    """Feature columns for (a, b) pairs, plus cosine as the control."""
+    cols = {"rarity": [], "age_gap": [], "slot_change": [], "slot_change_raw": [], "cue_asym": []}
+    control = []
+    for a, b in pairs:
+        va, vb = View(a), View(b)
+        cols["rarity"].append(entity_rarity(va, vb, df, pool_size))
+        cols["age_gap"].append(age_gap(va, vb))
+        cols["slot_change"].append(slot_change(va, vb))
+        cols["slot_change_raw"].append(slot_change(va, vb, gated=False))
+        cols["cue_asym"].append(cue_asymmetry(va, vb))
+        control.append(cosine(a, b))
+    return {k: np.array(v) for k, v in cols.items()}, np.array(control)
+
+
+def score_set(name, pos, neg, df, pool_size, rng, report):
+    print(f"\n== {name}: {len(pos)} corrected vs {len(neg)} noise ==")
+    fpos, cpos = features_for(pos, df, pool_size)
+    fneg, cneg = features_for(neg, df, pool_size)
+    entry = {"name": name, "n_pos": len(pos), "n_neg": len(neg), "feature_auc": {}, "blend": {}}
+
+    kept = []
+    for feature in ("rarity", "age_gap", "slot_change", "slot_change_raw", "cue_asym"):
+        a = auc(fpos[feature], fneg[feature])
+        entry["feature_auc"][feature] = a
+        verdict = ""
+        if feature in ("rarity", "age_gap", "slot_change", "cue_asym"):
+            if a >= FEATURE_FLOOR:
+                kept.append(feature)
+            else:
+                verdict = "  (dropped from the blend: below the feature floor)"
+        print(f"  {feature:16s} AUC={a:.3f}{verdict}")
+    control_auc = auc(cpos, cneg)
+    entry["feature_auc"]["cosine (control)"] = control_auc
+    print(f"  {'cosine (control)':16s} AUC={control_auc:.3f}")
+
+    if kept:
+        n_pos = len(pos)
+        combined = blend([np.concatenate([fpos[f], fneg[f]]) for f in kept])
+        blend_auc = auc(combined[:n_pos], combined[n_pos:])
+        p = permutation_p(combined[:n_pos].copy(), combined[n_pos:].copy(), blend_auc, rng)
+        entry["blend"] = {"features": kept, "auc": blend_auc, "permutation_p": p}
+        print(f"  blend({', '.join(kept)}) AUC={blend_auc:.3f}  permutation p={p:.4f}")
+    else:
+        print("  no feature cleared the floor; there is no blend to score")
+
+    report["sets"].append(entry)
+    return entry
+
+
+def time_matched(pos, wide_neg, rng):
+    """Negatives resampled from the wide candidate pool to match the
+    positives' age-gap distribution, bin by bin."""
+    gaps_pos = [age_gap(View(a), View(b)) for a, b in pos]
+    gaps_neg = [age_gap(View(a), View(b)) for a, b, _ in wide_neg]
+    edges = np.histogram_bin_edges(gaps_pos, bins=6)
+    matched = []
+    for lo, hi in zip(edges[:-1], edges[1:]):
+        want = sum(lo <= g <= hi for g in gaps_pos)
+        have = [p for p, g in zip(wide_neg, gaps_neg) if lo <= g <= hi]
+        if have and want:
+            picks = rng.choice(len(have), size=want, replace=True)
+            matched.extend(have[i] for i in picks)
+    return [(a, b) for a, b, _ in matched]
+
+
+def main():
+    rows = json.load(open(sys.argv[1]))
+    by_id = {r["id"]: r for r in rows}
+    now = datetime.now(timezone.utc)
+    rng = np.random.default_rng(53)
+
+    # The leakage guard, run before anything else reads a row.
+    try:
+        View(rows[0])["invalid_reason"]
+    except KeyError:
+        pass
+    else:
+        sys.exit("View let a feature read a label field; the probe is not trustworthy")
+
+    corrected = corrected_pairs(rows, by_id)
+    pos_t54 = [(a, b) for a, b, closed in corrected if closed and closed <= T54]
+    pos_all = [(a, b) for a, b, _ in corrected]
+    cands_t54, pool_t54 = candidate_pairs(rows, NOISE_SPACE, T54)
+    cands_now, pool_now = candidate_pairs(rows, NOISE_SPACE, now)
+    neg_t54 = [(a, b) for a, b, _ in cands_t54[:LIST_CAP]]
+    neg_now = [(a, b) for a, b, _ in cands_now[:LIST_CAP]]
+
+    # Document frequency over the whole space in the dump, live or not: the
+    # positives include closed rows, and one pool for both sides keeps the
+    # rarity of an entity from depending on which set a pair came from.
+    space_rows = [r for r in rows if r["space"] == NOISE_SPACE]
+    df = document_frequency(space_rows)
+    pool_size = len(space_rows)
+    hub_share_now = float(np.mean([only_hubs(View(a), View(b), df, pool_size) for a, b, _ in cands_now])) if cands_now else 1.0
+
+    print(f"rows {len(rows)}; space {NOISE_SPACE}: {pool_size} rows, {len(pool_now)} live now, {len(pool_t54)} live at #54")
+    print(f"corrected pairs: {len(pos_t54)} closed by #54, {len(pos_all)} now")
+    print(f"candidate pairs in band: {len(cands_t54)} at #54, {len(cands_now)} now (list cap {LIST_CAP})")
+    print(f"candidate pairs sharing only hub entities: {hub_share_now:.0%}"
+          + ("  (>80%: the rarity lever is dead in this space)" if hub_share_now > 0.8 else ""))
+    top_df = sorted(df.items(), key=lambda kv: -kv[1])[:5]
+    print("entity DF, top 5: " + ", ".join(f"{e}={n}" for e, n in top_df))
+
+    report = {"run_at": now.isoformat(), "as_of": T54.isoformat(), "hub_only_share": hub_share_now, "sets": []}
+    score_set("T54", pos_t54, neg_t54, df, pool_size, rng, report)
+    current = score_set("current", pos_all, neg_now, df, pool_size, rng, report)
+
+    # Age gap against time-matched negatives from the wide band.
+    matched = time_matched(pos_all, cands_now, rng)
+    if matched:
+        a = auc([age_gap(View(x), View(y)) for x, y in pos_all], [age_gap(View(x), View(y)) for x, y in matched])
+        report["age_gap_time_matched_auc"] = a
+        print(f"\nage_gap against {len(matched)} time-matched negatives: AUC={a:.3f}"
+              + ("  (the feature was measuring write history, not the pair)" if a < FEATURE_FLOOR else ""))
+
+    # Reorder the live list by the blend and count what it evicts.
+    kept = current["blend"].get("features", [])
+    if kept and cands_now:
+        fall, _ = features_for([(a, b) for a, b, _ in cands_now], df, pool_size)
+        order = np.argsort(-blend([fall[f] for f in kept]))
+        new_top = [cands_now[i] for i in order[:LIST_CAP]]
+        old_ids = {(a["id"], b["id"]) for a, b, _ in cands_now[:LIST_CAP]}
+        evicted = sum((a["id"], b["id"]) not in old_ids for a, b, _ in new_top)
+        report["evicted_from_cosine_top20"] = evicted
+        print(f"\nblend order evicts {evicted} of cosine's top {LIST_CAP}")
+        with open("pair-rank-top20.json", "w") as out:
+            json.dump(
+                [{"a": a["content"], "b": b["content"], "cosine": s, "label": None} for a, b, s in new_top],
+                out, indent=1, ensure_ascii=False,
+            )
+        print("reordered top 20 written to pair-rank-top20.json — hand-label `label` as true/false")
+
+    with open("pair-rank-scores.json", "w") as out:
+        json.dump(report, out, indent=1)
+    print("report written to pair-rank-scores.json")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Unparks #53 as a probe, not a feature, and closes it measured-and-dropped.

`docs/eval/pair-rank.md` fixes the bar before any number (AUC ≥ 0.70 on both labelled sets, permutation p < 0.05, cosine control ≤ 0.60, ≥ 4 real disagreements in a hand-labelled reordered top 20). `scripts/pair-rank-probe.py` (numpy only, `uv run`) scores entity rarity with a hub discount, age gap, slot changes gated on masked-token overlap, and cue asymmetry, with cosine as the control, plus the guards the doc names: time-matched negatives for age, the hub-only share, a per-feature floor, an eviction count, and a leakage guard on the fields features may read.

Result on a 2026-09-02 copy of the dogfood store (23/78 corrected pairs vs 20 noise):

| set | blend | cosine control |
|---|---|---|
| T54 | 0.870 | 0.943 |
| current | 0.622 | 0.707 |

The control fails on both sets, which is the finding: the store's corrections are near-duplicates with one detail changed, so cosine already ranks them above the noise, and the class the list exists for has no labels in this store. Age gap collapses to 0.386 against time-matched negatives; 96 % of candidate pairs share only the `agmem` hub entity; cues sit at chance.

The doc replaces the unpark trigger with a countable one and keeps the entity-name normalisation fix (`ctx-flow` vs `context-flow`) as its own small change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MUginUuH5hoGtnd9QEqL6
