### PR TITLE
A retiring daemon lets go of the store before its lock, and a dead one says why (#124)

### DIFF
--- a/crates/agmem-server/src/daemon/client.rs
+++ b/crates/agmem-server/src/daemon/client.rs
@@ -8,7 +8,7 @@
 
 use std::fs::{File, TryLockError};
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, bail};
@@ -226,6 +226,10 @@ async fn wait_for_retirement(path: &Path) {
 /// still held past the deadline is a process that is not going anywhere: a
 /// `--no-daemon` session, or a daemon that stopped answering.
 ///
+/// A daemon from before issue #124 released this lock a few milliseconds
+/// before it let go of the store itself; [`start_one`] allows one more start
+/// for that gap.
+///
 /// # Errors
 /// When the lock is still held after `RETIRE_DEADLINE`.
 async fn wait_for_store_lock(cfg: &Config) -> anyhow::Result<()> {
@@ -284,8 +288,57 @@ async fn start_one(cfg: &Config, path: &Path, takeover: Takeover) -> anyhow::Res
     // only from the ready timeout.
     wait_for_store_lock(cfg).await?;
 
-    spawn(cfg, takeover)?;
-    wait_until_ready(cfg, path).await
+    // A daemon that retired from a release before issue #124 released the
+    // data-dir lock a moment before the store's own lock, and a daemon
+    // started in that gap dies on the store. One more start, once the gap
+    // has closed, is the whole allowance: a second death is a real error.
+    let mut starts_left = match takeover {
+        Takeover::No => 1,
+        Takeover::FromRetired => 2,
+    };
+    loop {
+        let mut child = spawn(cfg, takeover)?;
+        match wait_until_ready(cfg, path, &mut child).await? {
+            Ready::Serving(stream) => {
+                reap_in_background(child);
+                return Ok(stream);
+            }
+            Ready::Died(status) => {
+                starts_left -= 1;
+                if starts_left == 0 {
+                    bail!(
+                        "the shared store exited ({status}) before it accepted a session. \
+                         Its log is {}; --no-daemon opens the store in this process instead.",
+                        log_path(cfg).display()
+                    );
+                }
+                tracing::info!(
+                    %status,
+                    "the shared store died at startup right after a retirement; starting it once more"
+                );
+                wait_for_store_lock(cfg).await?;
+            }
+        }
+    }
+}
+
+/// What became of a daemon this session started.
+enum Ready {
+    /// It accepted; the stream is the session's.
+    Serving(UnixStream),
+    /// It exited before it accepted. Its reason is in its log, not here: its
+    /// stderr was closed at spawn.
+    Died(ExitStatus),
+}
+
+/// Collect the daemon's exit status when it comes, so the process does not
+/// linger as a zombie for as long as this session lives (issue #124). The
+/// daemon is in its own process group and outlives this session as a rule;
+/// then the thread simply ends with the session.
+fn reap_in_background(mut child: Child) {
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
 }
 
 /// Wait for the right to start a daemon.
@@ -322,7 +375,7 @@ async fn queue_to_spawn(path: &Path) -> anyhow::Result<File> {
 }
 
 /// Start a detached daemon from this same binary.
-fn spawn(cfg: &Config, takeover: Takeover) -> anyhow::Result<()> {
+fn spawn(cfg: &Config, takeover: Takeover) -> anyhow::Result<Child> {
     let exe = std::env::current_exe()
         .context("cannot find this binary to start the shared store from")?;
     let log_file = log_path(cfg);
@@ -359,22 +412,37 @@ fn spawn(cfg: &Config, takeover: Takeover) -> anyhow::Result<()> {
         command.process_group(0);
     }
 
-    command.spawn().with_context(|| {
+    let child = command.spawn().with_context(|| {
         format!(
             "cannot start the shared store; its log is {}",
             log_file.display()
         )
     })?;
     tracing::info!(log = %log_file.display(), ?takeover, "started the shared store");
-    Ok(())
+    Ok(child)
 }
 
-/// Poll the socket until the daemon we started accepts, or time runs out.
-async fn wait_until_ready(cfg: &Config, path: &Path) -> anyhow::Result<UnixStream> {
+/// Poll the socket until the daemon we started accepts, exits, or time runs
+/// out.
+///
+/// The exit is checked on every turn (issue #124): a daemon that died at
+/// startup — on the store's lock, most often — used to cost the session the
+/// whole `READY_DEADLINE`, with nothing to read at the end of it.
+///
+/// # Errors
+/// When the deadline passes with the daemon alive and silent, or the child
+/// cannot be checked on.
+async fn wait_until_ready(cfg: &Config, path: &Path, child: &mut Child) -> anyhow::Result<Ready> {
     let deadline = Instant::now() + READY_DEADLINE;
     while Instant::now() < deadline {
         if let Some(stream) = connect(path).await {
-            return Ok(stream);
+            return Ok(Ready::Serving(stream));
+        }
+        if let Some(status) = child
+            .try_wait()
+            .context("checking whether the shared store is still starting")?
+        {
+            return Ok(Ready::Died(status));
         }
         tokio::time::sleep(POLL).await;
     }
@@ -476,6 +544,35 @@ mod tests {
         assert!(
             message.contains("kill 4242"),
             "the way out is a command, not a hunt: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_daemon_that_exits_at_startup_is_reported_at_once_with_its_log() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cfg = config(dir.path());
+        let path = socket_path(dir.path()).expect("socket path");
+
+        // `spawn` starts this same binary — here the test executable, which
+        // does not know `--daemon-serve` and exits at once: exactly a daemon
+        // that died at startup (issue #124).
+        let started = Instant::now();
+        let error = start_one(&cfg, &path, Takeover::No)
+            .await
+            .expect_err("a child that exited never accepts");
+        let message = format!("{error:#}");
+        assert!(
+            started.elapsed() < READY_DEADLINE / 4,
+            "the exit is seen when it happens, not at the ready deadline: {:?}",
+            started.elapsed()
+        );
+        assert!(
+            message.contains("exited"),
+            "the message says what happened: {message}"
+        );
+        assert!(
+            message.contains(&log_path(&cfg).display().to_string()),
+            "and where the daemon wrote why: {message}"
         );
     }
 }

--- a/crates/agmem-server/src/daemon/serve.rs
+++ b/crates/agmem-server/src/daemon/serve.rs
@@ -30,14 +30,33 @@ use crate::{doctor, embedder, lock};
 /// can start.
 pub const DRAIN: Duration = Duration::from_secs(2);
 
+/// How long a daemon on its way out waits for the engine to close the store
+/// and release the store's own file lock, before it gives up its data-dir
+/// lock regardless (issue #124).
+const STORE_RELEASE_DEADLINE: Duration = Duration::from_secs(10);
+
 /// Own the store and serve every session that attaches, until nothing has
 /// been attached for `idle_timeout` — or a newer release attaches, in which
 /// case this daemon retires so that release can serve.
 ///
+/// On the way out it waits for the engine to let go of the store before it
+/// releases the data-dir lock (issue #124): the session that retired it is
+/// polling that lock, and starts a daemon the moment it is free.
+///
 /// # Errors
 /// When the lock is already held, the store will not open or migrate, the
-/// embedder will not load, or the socket cannot be bound.
+/// embedder will not load, or the socket cannot be bound. The `--daemon-serve`
+/// process writes the error to its log as well as returning it: its stderr
+/// is closed, and the log is the only place a detached process has.
 pub async fn run(cfg: Config) -> anyhow::Result<()> {
+    let outcome = serve(cfg).await;
+    if let Err(error) = &outcome {
+        tracing::error!(error = %format!("{error:#}"), "the shared store stopped with an error");
+    }
+    outcome
+}
+
+async fn serve(cfg: Config) -> anyhow::Result<()> {
     let path = socket_path(&cfg.data_dir)?;
     // The lock is what makes "one owner" true; the socket only advertises it.
     // Holding it here is also what makes the unlink below safe — no other
@@ -176,15 +195,75 @@ pub async fn run(cfg: Config) -> anyhow::Result<()> {
     }
 
     // In the binary the process exit does this; in a test the daemon is a
-    // task, and its sessions must not outlive it.
+    // task, and its sessions must not outlive it. Aborting is a request: the
+    // tasks, and the store handles they hold, go when the runtime gets to
+    // them, and the handle dropped below has to be the last one.
     sessions.abort_all();
+    while sessions.join_next().await.is_some() {}
     drop(listener);
     if drain_until.is_none() {
         // A retiring daemon unlinked its socket when it stopped accepting,
         // and the path may already belong to the daemon that replaced it.
         let _ = std::fs::remove_file(&path);
     }
+    // With the last handle gone the engine shuts the store down on a task of
+    // its own, and the store's file lock is released at the end of that —
+    // some milliseconds from now, while the data-dir lock `_lock` above is
+    // released the moment this returns. A session polling the data-dir lock
+    // would start a daemon in that gap, and that daemon would die on the
+    // store (issue #124). So: wait for the store to let go first.
+    drop(db);
+    wait_for_store_release(&daemon.db_url).await;
     Ok(())
+}
+
+/// Wait until the engine has released the store's own file lock, or
+/// [`STORE_RELEASE_DEADLINE`] has passed.
+///
+/// The probe is a second descriptor on the lock file: `flock` conflicts
+/// between descriptors of one process too, so it succeeds exactly when the
+/// engine's descriptor has gone. Engines that keep no lock file this process
+/// can see — `mem://`, a remote server — have nothing to wait for.
+async fn wait_for_store_release(db_url: &str) {
+    let Some(path) = store_lock_path(db_url) else {
+        return;
+    };
+    let started = Instant::now();
+    loop {
+        let probe = std::fs::File::options()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map(|file| file.try_lock().map(|()| drop(file)));
+        match probe {
+            // No lock file: the engine never took one, or the store is gone.
+            Err(_) | Ok(Ok(())) => {
+                tracing::info!(elapsed = ?started.elapsed(), "the store let go");
+                return;
+            }
+            Ok(Err(std::fs::TryLockError::WouldBlock)) => {}
+            Ok(Err(std::fs::TryLockError::Error(error))) => {
+                tracing::warn!(%error, path = %path.display(), "cannot probe the store's lock; exiting anyway");
+                return;
+            }
+        }
+        if started.elapsed() >= STORE_RELEASE_DEADLINE {
+            tracing::warn!(
+                deadline = ?STORE_RELEASE_DEADLINE,
+                "the store did not let go in time; exiting anyway"
+            );
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+/// The lock file an embedded surrealkv store keeps at its root, for the
+/// engines that keep one.
+fn store_lock_path(db_url: &str) -> Option<std::path::PathBuf> {
+    db_url
+        .strip_prefix("surrealkv://")
+        .map(|root| std::path::Path::new(root).join("LOCK"))
 }
 
 /// The next connection on `listener`; parks when there is no listener. The

--- a/crates/agmem-server/tests/takeover.rs
+++ b/crates/agmem-server/tests/takeover.rs
@@ -1,0 +1,168 @@
+//! The daemon as a process, seen from the session that replaces it (issue
+//! #124).
+//!
+//! `tests/daemon.rs` runs the daemon as a task, which cannot show the order
+//! in which a *process* lets go of its two locks — the data-dir lock agmem
+//! takes and the file lock the embedded store takes for itself. These start
+//! the real binary and watch the edge a retiring daemon exposes to the
+//! session waiting on it.
+
+#![cfg(unix)]
+
+use std::fs::{File, TryLockError};
+use std::io::{BufRead as _, BufReader, Write as _};
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use agmem_server::config::{Cli, Config};
+use agmem_server::daemon::{self, Ack, Handshake};
+use agmem_server::lock;
+use clap::Parser as _;
+
+/// The session's view of a data dir: same derivation the daemon uses, so
+/// the handshake names the store the daemon opened.
+fn config(data: &Path) -> Config {
+    Cli::try_parse_from([
+        "agmem",
+        "--data",
+        &data.display().to_string(),
+        "--embedder",
+        "none",
+        "--idle-timeout",
+        "0",
+    ])
+    .expect("parse")
+    .resolve()
+    .expect("resolve")
+}
+
+/// The real binary, serving `data` the way a session would have started it:
+/// detached streams, its log in the data dir.
+fn start_daemon(data: &Path) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_agmem"))
+        .args([
+            "--daemon-serve",
+            "--data",
+            &data.display().to_string(),
+            "--embedder",
+            "none",
+            "--idle-timeout",
+            "0",
+            "--log-file",
+            &data.join(daemon::DAEMON_LOG_FILE).display().to_string(),
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("start the daemon")
+}
+
+fn wait_for_socket(socket: &Path) {
+    for _ in 0..600 {
+        if UnixStream::connect(socket).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!("the daemon never bound {}", socket.display());
+}
+
+/// A handshake from a release that does not exist: the daemon retires.
+fn retire(socket: &Path, cfg: &Config) {
+    let mut asked = Handshake::new(cfg);
+    asked.release = "999.0.0".to_owned();
+    let mut line = serde_json::to_vec(&asked).expect("serialize");
+    line.push(b'\n');
+
+    let mut stream = UnixStream::connect(socket).expect("connect");
+    stream.write_all(&line).expect("send the handshake");
+    let mut reply = String::new();
+    BufReader::new(&stream)
+        .read_line(&mut reply)
+        .expect("read the ack");
+    let ack: Ack = serde_json::from_str(&reply).expect("the ack is JSON");
+    assert!(!ack.ok && ack.retiring, "{ack:?}");
+}
+
+#[test]
+fn a_retiring_daemon_lets_go_of_the_store_before_the_data_dir_lock() {
+    let data = tempfile::tempdir().expect("tempdir");
+    let cfg = config(data.path());
+    let socket = daemon::socket_path(data.path()).expect("socket path");
+    let mut daemon = start_daemon(data.path());
+    wait_for_socket(&socket);
+
+    // The embedded store's own lock file, held by the daemon's process
+    // while the store is open. Its existence is asserted so a renamed file
+    // cannot turn the check below into a lock on nothing.
+    let store_lock = data.path().join("agmem.db").join("LOCK");
+    assert!(
+        store_lock.exists(),
+        "the store keeps its lock at {}",
+        store_lock.display()
+    );
+
+    retire(&socket, &cfg);
+
+    // The data-dir lock is what a session polls for before it starts the
+    // next daemon (`wait_for_store_lock`). The first instant it is free,
+    // the store must be free too — or the daemon that session starts dies
+    // on it, which is what happened on every other upgrade before #124.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !lock::probe(data.path()).expect("probe the data-dir lock") {
+        assert!(
+            Instant::now() < deadline,
+            "the retiring daemon never released the data-dir lock"
+        );
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    let store = File::options()
+        .read(true)
+        .write(true)
+        .open(&store_lock)
+        .expect("open the store's lock file");
+    match store.try_lock() {
+        Ok(()) => {}
+        Err(TryLockError::WouldBlock) => panic!(
+            "the data-dir lock was released while the store was still locked: a daemon \
+             started on that signal dies on the store (issue #124)"
+        ),
+        Err(TryLockError::Error(error)) => panic!("locking the store's lock file: {error}"),
+    }
+
+    let status = daemon.wait().expect("wait for the daemon");
+    assert!(status.success(), "the retiring daemon exits cleanly: {status}");
+}
+
+#[test]
+fn a_daemon_that_cannot_take_the_store_says_so_in_its_log() {
+    let data = tempfile::tempdir().expect("tempdir");
+    let socket = daemon::socket_path(data.path()).expect("socket path");
+    let mut owner = start_daemon(data.path());
+    wait_for_socket(&socket);
+
+    // A second daemon on the same data dir: what a session starts when it
+    // misjudges the first one's exit. Its stderr is closed, like every
+    // daemon's; the log is the only place its reason can go.
+    let status = start_daemon(data.path())
+        .wait()
+        .expect("wait for the second daemon");
+    assert!(!status.success(), "a daemon without the store exits non-zero");
+
+    let log = std::fs::read_to_string(data.path().join(daemon::DAEMON_LOG_FILE))
+        .expect("read the daemon log");
+    assert!(
+        log.contains("already owns the data dir"),
+        "the log names the refusal, not just 'agmem starting': {log}"
+    );
+    assert!(
+        log.contains("stopped with an error"),
+        "and marks it as the reason the daemon is gone: {log}"
+    );
+
+    owner.kill().expect("stop the owner");
+    let _ = owner.wait();
+}

--- a/crates/agmem-server/tests/takeover.rs
+++ b/crates/agmem-server/tests/takeover.rs
@@ -134,7 +134,10 @@ fn a_retiring_daemon_lets_go_of_the_store_before_the_data_dir_lock() {
     }
 
     let status = daemon.wait().expect("wait for the daemon");
-    assert!(status.success(), "the retiring daemon exits cleanly: {status}");
+    assert!(
+        status.success(),
+        "the retiring daemon exits cleanly: {status}"
+    );
 }
 
 #[test]
@@ -150,7 +153,10 @@ fn a_daemon_that_cannot_take_the_store_says_so_in_its_log() {
     let status = start_daemon(data.path())
         .wait()
         .expect("wait for the second daemon");
-    assert!(!status.success(), "a daemon without the store exits non-zero");
+    assert!(
+        !status.success(),
+        "a daemon without the store exits non-zero"
+    );
 
     let log = std::fs::read_to_string(data.path().join(daemon::DAEMON_LOG_FILE))
         .expect("read the daemon log");

--- a/docs/design.md
+++ b/docs/design.md
@@ -684,7 +684,12 @@ main()
             that just retired holds it while it drains; a --no-daemon
             session holds it for good — after 15 s, a message naming the
             pid), spawn `argv[0] --daemon-serve` in its own process group,
-            wait for it to accept
+            wait for it to accept — watching the child as it waits, so a
+            daemon that exits at startup is reported at once with its log
+            path, not after the 120 s ready deadline (#124). After a
+            retirement the client starts it once more if it died: a daemon
+            from before #124 released agmem.lock a few ms before the store's
+            own file lock, and a daemon started in that gap dies on the store
          send one JSON handshake line
             { version, release, db_url, embedder, space, pool, max_k,
               tool_desc }
@@ -718,6 +723,15 @@ main()
  4. acquire exclusive lock file <data_dir>/agmem.lock (embedded engines only)
       └─ held by another pid → exit with MCP-friendly stderr message
          ("that pid is usually the daemon; drop --no-daemon, or use ws://")
+      On its way out the daemon drops its last store handle — the engine
+      then closes the store on a task of its own and releases the store's
+      file lock (agmem.db/LOCK) at the end of that — and waits for that lock
+      to be free (10 s at most) before it returns and agmem.lock goes with
+      it. So agmem.lock being free means the process has let go of the store
+      (#124); before this, the two were a few ms apart, and a session
+      polling agmem.lock started a daemon that died on the store's lock.
+      Every daemon failure is also written to daemon.log: its stderr is
+      closed, and the log is the only place a detached process has.
  5. any::connect(db_url); USE NS agmem DB main
  6. migrate::ensure()     — idempotent DEFINEs, meta.schema_version gate
  7. embedder init (async — model may download on very first run)


### PR DESCRIPTION
Closes #124.

## What was wrong

Two locks, released a few milliseconds apart. `agmem.lock` went the moment the daemon's loop returned; the engine released `agmem.db/LOCK` later, on its own shutdown task. The client polls `agmem.lock` at 50 ms as its "process is gone" signal, spawned a daemon in the gap, and that daemon died on the store's lock. Its stderr is closed, so `daemon.log` showed only `agmem starting`, and the client waited the full 120 s ready deadline. Reproduced with the v0.1.7 release binary; details and timings on the issue.

## What changes

- **serve.rs** — on exit: drain the aborted sessions, drop the last store handle, and wait (10 s cap) for the store's lock file to be free before returning. `agmem.lock` is now released strictly after the store. Also logs the run's error before returning it, since a `--daemon-serve` process has no stderr.
- **client.rs** — `wait_until_ready` keeps the spawned `Child` and `try_wait`s it on every poll; a daemon that exits at startup is reported at once with its log path. After a retirement the client starts it once more, because a daemon from before this change still opens the gap (the 0.1.8 → 0.1.9 upgrade goes through this path). The daemon is reaped in a thread rather than left a zombie.
- **tests/takeover.rs** — drives the real binary: a retire must leave the store's lock free the first instant `agmem.lock` is (10/10 on this branch, 9/10 failing on main), and a second daemon on a held store must leave its reason in the log.
- **docs/design.md** — the two facts above in the startup flow.

## Tried and dropped

Holding `agmem.lock` outside the tokio runtime, so it outlives the runtime's teardown. It does not help: surrealkv's `Tree::drop` spawns its `close()` onto the *current* runtime handle, which is the one shutting down, so the close never runs and the store's lock lives until process exit. The daemon has to drop its handle while the runtime is alive and wait.

## Cost

The store lets go about 140 ms after the last handle drops on an idle exit; that is the added daemon exit time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HguvV4brZfcP667ZGFN6T
