### PR TITLE
The memory ritual travels with the server: a Claude Code plugin (#86)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "agmem",
+  "owner": { "name": "Mate Alfoldi" },
+  "metadata": {
+    "description": "agmem — persistent memory for coding agents over MCP",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "agmem",
+      "source": "./plugin",
+      "description": "Persistent cross-session memory: the agmem MCP server, a briefing at every session start, checkpoint and tidy commands, and the hooks that make memory use measurable.",
+      "category": "productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -95,7 +95,17 @@ points it elsewhere.
 agmem is a stdio MCP server: `command: "agmem"`, no arguments. One global
 registration covers every project.
 
-**Claude Code**
+**Claude Code** — the plugin does the whole wiring: it registers the server,
+injects the memory briefing at every session start, ships `/agmem:checkpoint`,
+`/agmem:memory` and `/agmem:doctor`, and logs which claims each session
+recalled and wrote (`plugin/README.md` has the details):
+
+```sh
+claude plugin marketplace add AlfoldiMate/agmem
+claude plugin install agmem@agmem
+```
+
+Or register the server alone and wire hooks yourself:
 
 ```sh
 claude mcp add agmem --scope user -- agmem
@@ -125,8 +135,12 @@ already say.
 
 ### Inject the briefing on session start
 
-`context` is also a shell command, so a session-start hook can put the memory
-block in front of the model before its first token instead of hoping it asks:
+The Claude Code plugin does this through `agmem hook session-start`, which
+reads the hook payload on stdin and prints the briefing as hook context — the
+same binary answers every plugin hook, so nothing else needs installing. For
+any other client, `context` is also a shell command, so a session-start hook
+can put the memory block in front of the model before its first token instead
+of hoping it asks:
 
 ```sh
 agmem context --query "release work" --budget-chars 4000

--- a/crates/agmem-server/src/config.rs
+++ b/crates/agmem-server/src/config.rs
@@ -132,6 +132,17 @@ pub enum CliCommand {
     /// can inject the briefing into a session instead of hoping the model
     /// asks for it.
     Context(ContextArgs),
+
+    /// Answer a Claude Code hook event: read the payload on stdin, print the
+    /// reply, exit 0. The shell side of the agmem plugin (`plugin/`).
+    Hook(HookArgs),
+}
+
+/// Which event `agmem hook` is answering.
+#[derive(Debug, Clone, PartialEq, Eq, Args)]
+pub struct HookArgs {
+    #[command(subcommand)]
+    pub event: crate::hook::HookEvent,
 }
 
 /// What `agmem context` passes through to the `context` tool, one flag per

--- a/crates/agmem-server/src/hook.rs
+++ b/crates/agmem-server/src/hook.rs
@@ -1,0 +1,700 @@
+//! `agmem hook <event>` — the shell side of the Claude Code plugin.
+//!
+//! A plugin's hooks are shell commands fed a JSON payload on stdin. Writing
+//! them as scripts would make the plugin depend on a scripting runtime the
+//! user has to install; the one binary every agmem user already has is this
+//! one, so the hooks are subcommands of it. Each reads the payload, answers
+//! on stdout in the shape the hook reference specifies, and exits 0 — a hook
+//! must never break a session, so every failure here degrades to silence and
+//! a log line, never to a non-zero exit.
+//!
+//! Three events carry memory behaviour:
+//!
+//! - `session-start` injects the briefing (`agmem context`, the same block
+//!   the MCP tool assembles) before the first token, names the branch tag,
+//!   and after a compaction lists what the session had recalled so the
+//!   checkpoint that follows can cite it.
+//! - `post-tool-use` keeps the per-session log — which claims `recall`
+//!   returned, which `remember`/`reflect` wrote and cited — and nudges at
+//!   two seams: a successful `git push`, and an answered `AskUserQuestion`.
+//! - `stop` nudges once, when a session recalled memory and wrote none.
+//!
+//! The log is the one thing the store cannot keep (issue #86): `REINFORCE`
+//! overwrites `last_accessed`, so "which rows did this session see" is
+//! unanswerable server-side, and the citation step needs exactly that list.
+//! It lives under the data dir as `hooks/<session_id>.jsonl`, one JSON
+//! object per line, and is pruned at session start.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use clap::Subcommand;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::config::{Config, ContextArgs};
+use crate::oneshot;
+
+/// Which hook event the payload on stdin belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Subcommand)]
+pub enum HookEvent {
+    /// SessionStart: print the memory briefing as `additionalContext`.
+    SessionStart,
+    /// PostToolUse: log recalls and writes; nudge at seams.
+    PostToolUse,
+    /// Stop: nudge once if the session recalled memory and wrote none.
+    Stop,
+}
+
+/// Days a session log outlives its last write before session start removes it.
+///
+/// A week covers a resumed session; anything older belongs to a session no
+/// hook will hear from again.
+const LOG_RETENTION_DAYS: i64 = 7;
+
+/// How many recalled ids a post-compaction briefing lists, newest first.
+///
+/// Enough to cover a working session's recalls; a cap because a session that
+/// recalled hundreds of claims needs the recent ones, not all of them.
+const COMPACT_RECALLED_CAP: usize = 40;
+
+const HEADER: &str = "Durable project memory lives in agmem, not in this window. Before the first \
+move, call the agmem `context` tool with a short query naming the work at hand, and treat \
+the briefing as established fact — do not re-derive what it records; verify a specific \
+claim only before acting on it. The `recall` tool reaches what the briefing omits; ask \
+in words, not keywords. A claim that turns out to be stale is corrected with `remember` + \
+`supersedes` (its id ends its line), never worked around. /agmem:checkpoint stores this \
+session's durable state back.";
+
+const FOOTER: &str = "The block above is this project's memory briefing (agmem). Treat it as \
+established fact — do not re-derive what it records; verify a specific claim only \
+before acting on it. The `recall` tool reaches what it omits; ask in words, not \
+keywords. A claim that turns out to be stale is corrected with `remember` + `supersedes` \
+(its id ends its line), never worked around. /agmem:checkpoint stores this session's \
+durable state back.";
+
+const COMPACTED: &str = "NOTE: context was compacted immediately before this. Anything not in agmem \
+or on disk is gone — re-read files before assuming their contents, and do not trust \
+remembered line numbers. A checkpoint now (/agmem:checkpoint) stores what the summary \
+dropped while the reasons are still recoverable.";
+
+const PUSH_NUDGE: &str = "git push succeeded — that is a checkpoint seam. Store the session's \
+durable state in agmem now, as /agmem:checkpoint would: decisions with their reasons, \
+corrected assumptions, branch state as fast-decay claims tagged branch:<slug>. Recall \
+each topic before writing so corrections land as supersedes. Then continue, or suggest \
+/clear if the task is finished.";
+
+const DECISION_NUDGE: &str = "The answer above is a decision the user just made. Once its reason is \
+clear, it is worth one claim in agmem: a `fact` with the decision and the reason, with \
+`supersedes` set if it overturns a claim in the briefing. Not every answer needs storing; \
+a routine choice does not, and one a future session would otherwise re-ask does.";
+
+const STOP_NUDGE: &str = "This session recalled memory and has written none back. If it \
+established anything durable — a decision with its reason, a corrected assumption, a \
+gotcha that cost time — /agmem:checkpoint stores it; if it established nothing, nothing \
+is the right amount to store.";
+
+/// One line of the session log.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct Entry {
+    /// When it happened, RFC 3339.
+    at: String,
+    /// `recall`, `write`, or `nudge`.
+    kind: String,
+    /// The tool (for `recall`/`write`) or the nudge id (for `nudge`).
+    name: String,
+    /// Ids returned (`recall`) or created (`write`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    ids: Vec<String>,
+    /// Ids cited in `derived_from` (`write` from `reflect`).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    cites: Vec<String>,
+}
+
+/// Read the payload from stdin, answer the event, print the answer, exit 0.
+///
+/// stdout is the hook's reply here, not the MCP wire; like `oneshot`, this
+/// is a place the crate-wide print deny is lifted on purpose.
+///
+/// # Errors
+/// Never in practice: every failure is logged and swallowed so the hook exits
+/// 0. The signature keeps `main`'s dispatch uniform.
+#[allow(clippy::print_stdout)]
+pub async fn run(cfg: Config, event: HookEvent) -> anyhow::Result<()> {
+    let raw = std::io::read_to_string(std::io::stdin()).unwrap_or_default();
+    let payload: Value = serde_json::from_str(&raw).unwrap_or(Value::Null);
+    if let Some(reply) = respond(&cfg, event, &payload).await {
+        println!("{reply}");
+    }
+    Ok(())
+}
+
+/// The JSON reply for `event`, or `None` when the hook has nothing to say.
+///
+/// Separated from [`run`] so tests can feed a payload without a stdin.
+pub async fn respond(cfg: &Config, event: HookEvent, payload: &Value) -> Option<String> {
+    let session = Session::from_payload(&cfg.data_dir, payload);
+    let text = match event {
+        HookEvent::SessionStart => session_start(cfg, &session, payload).await,
+        HookEvent::PostToolUse => post_tool_use(&session, payload),
+        HookEvent::Stop => stop(&session, payload),
+    }?;
+    let event_name = match event {
+        HookEvent::SessionStart => "SessionStart",
+        HookEvent::PostToolUse => "PostToolUse",
+        HookEvent::Stop => "Stop",
+    };
+    Some(
+        json!({
+            "hookSpecificOutput": {
+                "hookEventName": event_name,
+                "additionalContext": text,
+            }
+        })
+        .to_string(),
+    )
+}
+
+// --- session log ----------------------------------------------------------
+
+/// The per-session log and the directory it lives in.
+#[derive(Debug, Clone)]
+struct Session {
+    dir: PathBuf,
+    file: PathBuf,
+}
+
+impl Session {
+    fn from_payload(data_dir: &Path, payload: &Value) -> Self {
+        let id = payload
+            .get("session_id")
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+            .unwrap_or("nosession");
+        let dir = data_dir.join("hooks");
+        let file = dir.join(format!("{}.jsonl", safe_name(id)));
+        Self { dir, file }
+    }
+
+    fn append(&self, kind: &str, name: &str, ids: Vec<String>, cites: Vec<String>) {
+        let entry = Entry {
+            at: jiff::Timestamp::now().to_string(),
+            kind: kind.to_owned(),
+            name: name.to_owned(),
+            ids,
+            cites,
+        };
+        let written = fs::create_dir_all(&self.dir).and_then(|()| {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&self.file)?;
+            let mut line = serde_json::to_string(&entry).unwrap_or_default();
+            line.push('\n');
+            file.write_all(line.as_bytes())
+        });
+        if let Err(error) = written {
+            tracing::warn!(%error, path = %self.file.display(), "hook log not written");
+        }
+    }
+
+    fn entries(&self) -> Vec<Entry> {
+        fs::read_to_string(&self.file)
+            .unwrap_or_default()
+            .lines()
+            .filter_map(|line| serde_json::from_str(line).ok())
+            .collect()
+    }
+
+    /// True the first time `id` is asked about this session, false after.
+    fn first_time(&self, id: &str) -> bool {
+        let seen = self
+            .entries()
+            .iter()
+            .any(|e| e.kind == "nudge" && e.name == id);
+        if !seen {
+            self.append("nudge", id, Vec::new(), Vec::new());
+        }
+        !seen
+    }
+
+    /// Distinct recalled ids, newest first.
+    fn recalled(&self) -> Vec<String> {
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::new();
+        for entry in self.entries().iter().rev().filter(|e| e.kind == "recall") {
+            for id in &entry.ids {
+                if seen.insert(id.clone()) {
+                    out.push(id.clone());
+                }
+            }
+        }
+        out
+    }
+
+    fn wrote(&self) -> bool {
+        self.entries().iter().any(|e| e.kind == "write")
+    }
+
+    /// Remove logs untouched for [`LOG_RETENTION_DAYS`].
+    fn prune(&self) {
+        let Ok(entries) = fs::read_dir(&self.dir) else {
+            return;
+        };
+        let horizon = std::time::SystemTime::now()
+            - std::time::Duration::from_secs(60 * 60 * 24 * LOG_RETENTION_DAYS.unsigned_abs());
+        for entry in entries.flatten() {
+            let stale = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .map(|modified| modified < horizon)
+                .unwrap_or(false);
+            if stale {
+                let _ = fs::remove_file(entry.path());
+            }
+        }
+    }
+}
+
+/// A session id reduced to a filename: anything outside `[A-Za-z0-9._-]`
+/// becomes `-`, so a hostile payload cannot name a path.
+fn safe_name(id: &str) -> String {
+    let mut out: String = id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    out.truncate(80);
+    if out.is_empty() || out.chars().all(|c| c == '.') {
+        out = "nosession".to_owned();
+    }
+    out
+}
+
+// --- events ---------------------------------------------------------------
+
+async fn session_start(cfg: &Config, session: &Session, payload: &Value) -> Option<String> {
+    session.prune();
+    let cwd = payload
+        .get("cwd")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+    let compacted = payload.get("source").and_then(Value::as_str) == Some("compact");
+
+    let mut parts: Vec<String> = Vec::new();
+    if compacted {
+        let mut note = COMPACTED.to_owned();
+        let recalled = session.recalled();
+        if !recalled.is_empty() {
+            let listed: Vec<&str> = recalled
+                .iter()
+                .take(COMPACT_RECALLED_CAP)
+                .map(String::as_str)
+                .collect();
+            note.push_str(
+                "\n\nClaims this session recalled before the compaction, newest first — the \
+                 checkpoint can cite them in `derived_from` without a second recall: ",
+            );
+            note.push_str(&listed.join(", "));
+        }
+        parts.push(note);
+    }
+
+    let briefing = oneshot::fetch(cfg, ContextArgs::default()).await;
+    let memory = match briefing {
+        Ok(block) if !block.trim().is_empty() => format!("{}\n\n{FOOTER}", block.trim()),
+        Ok(_) => HEADER.to_owned(),
+        Err(error) => {
+            tracing::warn!(%error, "briefing unavailable; falling back to the pull nudge");
+            HEADER.to_owned()
+        }
+    };
+    let branch_note = branch_of(&cwd)
+        .map(|b| {
+            format!(
+                " In-flight state for the current branch ({b}) carries the tag branch:{} — \
+                 recall with that tag when resuming work here.",
+                slug(&b)
+            )
+        })
+        .unwrap_or_default();
+    parts.push(format!("{memory}{branch_note}"));
+    Some(parts.join("\n\n"))
+}
+
+fn post_tool_use(session: &Session, payload: &Value) -> Option<String> {
+    let tool = payload.get("tool_name").and_then(Value::as_str)?;
+    let input = payload.get("tool_input").unwrap_or(&Value::Null);
+    let response = payload.get("tool_response").unwrap_or(&Value::Null);
+
+    match tool {
+        "Bash" => {
+            let command = input.get("command").and_then(Value::as_str).unwrap_or("");
+            let ok = response
+                .get("exit_code")
+                .and_then(Value::as_i64)
+                .unwrap_or(0)
+                == 0;
+            (ok && is_push(command) && session.first_time("push")).then(|| PUSH_NUDGE.to_owned())
+        }
+        "AskUserQuestion" => Some(DECISION_NUDGE.to_owned()),
+        _ => {
+            let (server, verb) = mcp_parts(tool)?;
+            if !server.contains("agmem") {
+                return None;
+            }
+            let body = response_body(response);
+            match verb {
+                "recall" => {
+                    let ids = strings_at(&body, &["hits"], "id");
+                    if !ids.is_empty() {
+                        session.append("recall", verb, ids, Vec::new());
+                    }
+                }
+                "remember" => {
+                    let ids = body
+                        .get("created")
+                        .and_then(Value::as_array)
+                        .map(|created| {
+                            created
+                                .iter()
+                                .filter_map(|c| c.as_str().or_else(|| c.get("id")?.as_str()))
+                                .map(str::to_owned)
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    session.append("write", verb, ids, Vec::new());
+                }
+                "reflect" => {
+                    let ids = body
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .map(|id| vec![id.to_owned()])
+                        .unwrap_or_default();
+                    let cites = input
+                        .get("derived_from")
+                        .and_then(Value::as_array)
+                        .map(|list| {
+                            list.iter()
+                                .filter_map(Value::as_str)
+                                .map(str::to_owned)
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    session.append("write", verb, ids, cites);
+                }
+                _ => {}
+            }
+            None
+        }
+    }
+}
+
+fn stop(session: &Session, payload: &Value) -> Option<String> {
+    let already = payload
+        .get("stop_hook_active")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if already || session.wrote() || session.recalled().is_empty() {
+        return None;
+    }
+    session.first_time("stop").then(|| STOP_NUDGE.to_owned())
+}
+
+// --- payload shapes -------------------------------------------------------
+
+/// `(server, tool)` out of an MCP tool name, plugin-scoped or not.
+///
+/// `mcp__agmem__recall` and `mcp__plugin_agmem_agmem__recall` both name the
+/// same tool; a plugin-bundled server gets the longer prefix.
+fn mcp_parts(tool: &str) -> Option<(&str, &str)> {
+    let rest = tool.strip_prefix("mcp__")?;
+    rest.rsplit_once("__")
+}
+
+/// The tool's structured answer, whatever wrapping the payload gave it.
+///
+/// Claude Code hands PostToolUse the result as the tool emitted it, which for
+/// an MCP tool may be the JSON object itself, the text rendering of it, or
+/// the content-block array carrying that text. All three are tried.
+fn response_body(response: &Value) -> Value {
+    match response {
+        Value::Object(_) => response
+            .get("content")
+            .and_then(parse_blocks)
+            .unwrap_or_else(|| response.clone()),
+        Value::String(text) => serde_json::from_str(text).unwrap_or(Value::Null),
+        Value::Array(_) => parse_blocks(response).unwrap_or(Value::Null),
+        _ => Value::Null,
+    }
+}
+
+fn parse_blocks(content: &Value) -> Option<Value> {
+    content.as_array()?.iter().find_map(|block| {
+        let text = block.get("text")?.as_str()?;
+        serde_json::from_str(text).ok()
+    })
+}
+
+/// The string field `key` of every object in the array at `path`.
+fn strings_at(body: &Value, path: &[&str], key: &str) -> Vec<String> {
+    let mut node = body;
+    for step in path {
+        node = match node.get(step) {
+            Some(next) => next,
+            None => return Vec::new(),
+        };
+    }
+    node.as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item.get(key)?.as_str())
+                .map(str::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// A real `git push`, not the word inside a commit message or an echo.
+fn is_push(command: &str) -> bool {
+    let stripped = strip_quoted(command);
+    stripped.split(['|', ';', '&', '\n']).any(|segment| {
+        let mut words = segment.split_whitespace().skip_while(|w| *w == "(");
+        let is_git = words
+            .next()
+            .is_some_and(|w| w == "git" || w.ends_with("/git"));
+        if !is_git {
+            return false;
+        }
+        // The subcommand is the first word that is not a global option;
+        // `-C <dir>` and `-c <k=v>` take a value, the rest are flags.
+        let mut words = words.peekable();
+        while let Some(word) = words.peek() {
+            if *word == "-C" || *word == "-c" {
+                words.next();
+                words.next();
+            } else if word.starts_with('-') {
+                words.next();
+            } else {
+                break;
+            }
+        }
+        words.next() == Some("push")
+    })
+}
+
+fn strip_quoted(command: &str) -> String {
+    let mut out = String::with_capacity(command.len());
+    let mut quote: Option<char> = None;
+    for c in command.chars() {
+        match quote {
+            Some(q) if c == q => quote = None,
+            Some(_) => {}
+            None if c == '"' || c == '\'' => quote = Some(c),
+            None => out.push(c),
+        }
+    }
+    out
+}
+
+// --- git ------------------------------------------------------------------
+
+/// The current branch, or `None` when detached, unborn, or outside a repo.
+fn branch_of(cwd: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(["branch", "--show-current"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    (!branch.is_empty() && branch != "HEAD").then_some(branch)
+}
+
+/// A branch name as the tag carries it — the rule context-flow's hooks and
+/// `/checkpoint` share, so the two sides of the tag cannot drift.
+fn slug(branch: &str) -> String {
+    let mut out = String::with_capacity(branch.len());
+    let mut dash = false;
+    for c in branch.chars() {
+        if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+            out.push(c);
+            dash = false;
+        } else if !dash {
+            out.push('-');
+            dash = true;
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    let mut short: String = trimmed.chars().take(80).collect();
+    if short.is_empty() {
+        short = "detached".to_owned();
+    }
+    short
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_push_is_recognised_and_a_mention_is_not() {
+        assert!(is_push("git push"));
+        assert!(is_push("git push -u origin main"));
+        assert!(is_push("cargo test && git push"));
+        assert!(is_push("/usr/bin/git push"));
+        assert!(is_push("git -C /repo push --force-with-lease"));
+        assert!(!is_push("git commit -m 'push it'"));
+        assert!(!is_push("echo \"git push\""));
+        assert!(!is_push("grep push src/"));
+        assert!(!is_push("git log --grep push"));
+    }
+
+    #[test]
+    fn plugin_scoped_and_bare_tool_names_split_alike() {
+        assert_eq!(mcp_parts("mcp__agmem__recall"), Some(("agmem", "recall")));
+        assert_eq!(
+            mcp_parts("mcp__plugin_agmem_agmem__reflect"),
+            Some(("plugin_agmem_agmem", "reflect"))
+        );
+        assert_eq!(mcp_parts("Bash"), None);
+    }
+
+    #[test]
+    fn a_response_is_read_through_any_of_its_wrappings() {
+        let object = json!({"hits": [{"id": "A"}, {"id": "B"}]});
+        let text = Value::String(object.to_string());
+        let blocks = json!([{"type": "text", "text": object.to_string()}]);
+        let wrapped = json!({"content": [{"type": "text", "text": object.to_string()}]});
+        for shape in [&object, &text, &blocks, &wrapped] {
+            assert_eq!(
+                strings_at(&response_body(shape), &["hits"], "id"),
+                vec!["A", "B"],
+                "{shape}"
+            );
+        }
+    }
+
+    #[test]
+    fn slugs_match_the_hook_scripts_rule() {
+        assert_eq!(slug("fix/takeover-lock-order"), "fix-takeover-lock-order");
+        assert_eq!(slug("release/v1.2.3+build"), "release-v1.2.3-build");
+        assert_eq!(slug("///"), "detached");
+        assert_eq!(slug("a b  c"), "a-b-c");
+    }
+
+    #[test]
+    fn a_session_id_cannot_name_a_path() {
+        assert_eq!(safe_name("../../etc/passwd"), "..-..-etc-passwd");
+        assert!(!safe_name("a/b\\c").contains(['/', '\\']));
+        assert_eq!(safe_name(".."), "nosession");
+        assert_eq!(safe_name(""), "nosession");
+    }
+
+    #[test]
+    fn the_log_round_trips_and_nudges_once() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let session = Session::from_payload(dir.path(), &json!({"session_id": "s1"}));
+        assert!(session.recalled().is_empty());
+        session.append("recall", "recall", vec!["A".into(), "B".into()], vec![]);
+        session.append("recall", "recall", vec!["B".into(), "C".into()], vec![]);
+        assert_eq!(session.recalled(), vec!["B", "C", "A"]);
+        assert!(!session.wrote());
+        assert!(session.first_time("push"));
+        assert!(!session.first_time("push"));
+        session.append("write", "reflect", vec!["D".into()], vec!["A".into()]);
+        assert!(session.wrote());
+    }
+
+    #[test]
+    fn stop_nudges_only_a_session_that_recalled_and_never_wrote() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let payload = json!({"session_id": "s2", "stop_hook_active": false});
+        let session = Session::from_payload(dir.path(), &payload);
+        assert_eq!(stop(&session, &payload), None, "nothing recalled");
+        session.append("recall", "recall", vec!["A".into()], vec![]);
+        assert!(stop(&session, &payload).is_some(), "recalled, not written");
+        assert_eq!(stop(&session, &payload), None, "once per session");
+
+        let fresh = Session::from_payload(dir.path(), &json!({"session_id": "s3"}));
+        fresh.append("recall", "recall", vec!["A".into()], vec![]);
+        fresh.append("write", "remember", vec!["B".into()], vec![]);
+        assert_eq!(stop(&fresh, &json!({"session_id": "s3"})), None, "wrote");
+
+        let looping = json!({"session_id": "s2", "stop_hook_active": true});
+        assert_eq!(stop(&session, &looping), None, "already continuing");
+    }
+
+    #[test]
+    fn post_tool_use_logs_recalls_and_writes_and_nudges_seams() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let base = json!({"session_id": "s4"});
+        let session = Session::from_payload(dir.path(), &base);
+
+        let recall = json!({
+            "session_id": "s4",
+            "tool_name": "mcp__plugin_agmem_agmem__recall",
+            "tool_input": {"query": "q"},
+            "tool_response": {"hits": [{"id": "A"}, {"id": "B"}]}
+        });
+        assert_eq!(post_tool_use(&session, &recall), None);
+        assert_eq!(session.recalled(), vec!["A", "B"]);
+
+        let reflect = json!({
+            "session_id": "s4",
+            "tool_name": "mcp__agmem__reflect",
+            "tool_input": {"insight": "x", "derived_from": ["A"]},
+            "tool_response": {"id": "C", "created": true}
+        });
+        assert_eq!(post_tool_use(&session, &reflect), None);
+        let writes: Vec<Entry> = session
+            .entries()
+            .into_iter()
+            .filter(|e| e.kind == "write")
+            .collect();
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].ids, vec!["C"]);
+        assert_eq!(writes[0].cites, vec!["A"]);
+
+        let other_server = json!({
+            "session_id": "s4",
+            "tool_name": "mcp__memory__recall",
+            "tool_response": {"hits": [{"id": "Z"}]}
+        });
+        assert_eq!(post_tool_use(&session, &other_server), None);
+        assert!(!session.recalled().contains(&"Z".to_owned()));
+
+        let push = json!({
+            "session_id": "s4",
+            "tool_name": "Bash",
+            "tool_input": {"command": "git push origin HEAD"},
+            "tool_response": {"exit_code": 0}
+        });
+        assert!(post_tool_use(&session, &push).is_some());
+        assert_eq!(post_tool_use(&session, &push), None, "once per session");
+
+        let failed_push = json!({
+            "session_id": "s5",
+            "tool_name": "Bash",
+            "tool_input": {"command": "git push"},
+            "tool_response": {"exit_code": 1}
+        });
+        let s5 = Session::from_payload(dir.path(), &failed_push);
+        assert_eq!(post_tool_use(&s5, &failed_push), None);
+
+        let decision = json!({"session_id": "s4", "tool_name": "AskUserQuestion"});
+        assert!(post_tool_use(&session, &decision).is_some());
+    }
+}

--- a/crates/agmem-server/src/lib.rs
+++ b/crates/agmem-server/src/lib.rs
@@ -8,6 +8,7 @@ pub mod config;
 pub mod daemon;
 pub mod doctor;
 pub mod embedder;
+pub mod hook;
 pub mod lock;
 pub mod oneshot;
 pub mod prompts;

--- a/crates/agmem-server/src/main.rs
+++ b/crates/agmem-server/src/main.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 #[cfg(unix)]
 use agmem_server::daemon;
 use agmem_server::service::{self, AgmemService};
-use agmem_server::{config, doctor, embedder, lock, oneshot, reindex, startup, telemetry};
+use agmem_server::{config, doctor, embedder, hook, lock, oneshot, reindex, startup, telemetry};
 use clap::Parser;
 
 #[tokio::main]
@@ -46,8 +46,10 @@ async fn main() -> anyhow::Result<()> {
     // One-shot subcommands print their answer and exit. They route through
     // the daemon the way a session would (or open the store where a session
     // would), so they never contend with a running daemon for the store.
-    if let Some(config::CliCommand::Context(args)) = cfg.command.clone() {
-        return oneshot::context(cfg, args).await;
+    match cfg.command.clone() {
+        Some(config::CliCommand::Context(args)) => return oneshot::context(cfg, args).await,
+        Some(config::CliCommand::Hook(args)) => return hook::run(cfg, args.event).await,
+        None => {}
     }
 
     // A failure on the shared path exits non-zero rather than falling back to

--- a/crates/agmem-server/src/prompts.rs
+++ b/crates/agmem-server/src/prompts.rs
@@ -249,3 +249,37 @@ mod tests {
         );
     }
 }
+
+/// The plugin's checkpoint command carries the same citation step as the
+/// server prompt — the step measured at 3/3 cited versus 0/3 from the
+/// `reflect` description alone (`docs/eval/ritual-reflect-note`). Two copies
+/// of one measured wording drift silently; this makes drift a failing test.
+#[cfg(test)]
+mod plugin_drift {
+    use super::*;
+
+    const PLUGIN_CHECKPOINT: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../plugin/commands/checkpoint.md"
+    ));
+
+    /// Whitespace-insensitive form, so hard-wrapped markdown compares equal
+    /// to the single-line prompt paragraph.
+    fn squash(text: &str) -> String {
+        text.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    #[test]
+    fn the_plugin_checkpoint_carries_the_prompts_citation_step_verbatim() {
+        let prompt = checkpoint(&Focus::default());
+        let step_4 = prompt
+            .split("\n\n")
+            .find(|paragraph| paragraph.trim_start().starts_with("4. "))
+            .expect("the checkpoint prompt has a step 4");
+        assert!(
+            squash(PLUGIN_CHECKPOINT).contains(&squash(step_4)),
+            "plugin/commands/checkpoint.md no longer carries step 4 of prompts::checkpoint \
+             word for word:\n{step_4}"
+        );
+    }
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -624,6 +624,9 @@ agmem/
 │       │   ├── doctor.rs         # --doctor self-check
 │       │   ├── reindex.rs        # --reindex re-embedding pass
 │       │   ├── oneshot.rs        # `agmem context`: one briefing, no server
+│       │   ├── hook.rs           # `agmem hook <event>`: the plugin's hooks —
+│       │   │                     #   briefing injection, per-session recall
+│       │   │                     #   log, seam nudges
 │       │   ├── embedder.rs       # backend selection from Config
 │       │   ├── service.rs        # AgmemService { repo, embedder, cfg,
 │       │   │                     #   tool_router, prompt_router }
@@ -635,6 +638,9 @@ agmem/
 │       │   ├── prompts.rs        # checkpoint / recall_first rituals
 │       │   └── telemetry.rs      # tracing → stderr (or AGMEM_LOG_FILE)
 │       └── tests/                # protocol, eval, harness, daemon, knn_probe
+├── plugin/                       # the Claude Code plugin: .mcp.json, hooks
+│                                 #   (all `agmem hook …`), commands, skill
+├── .claude-plugin/marketplace.json # lets `claude plugin marketplace add` find it
 ├── docs/                         # idea.md, design.md, eval batches
 └── scripts/                      # desc-eval.nu (LLM-driven description eval)
 ```

--- a/docs/eval/outcome-counters.md
+++ b/docs/eval/outcome-counters.md
@@ -74,3 +74,66 @@ plus an index-only migration, ~half a day and a baseline re-record), and a
 `session` field on the eval `Seed` with a scripted recall-before-reflect
 step — in a new scenario, since seeding recalls reinforce and would shift an
 existing scenario's strengths.
+
+## Amended 2026-09-02 — two corrections and the decision rule
+
+Written before the 2026-09-16 probe reads a number, so the rule is not fitted
+to the result.
+
+### Corrections to the record
+
+- **The monotonic recall count already exists.** `queries::read::REINFORCE`
+  does `access_count += 1, last_accessed = time::now()` on every live recall,
+  and `MemoryRecord` has carried `access_count` since v0.1.0. The earlier
+  sizing ("a `recall_count` incremented by REINFORCE — the one piece of new
+  state") was wrong: the *denominator* has been accumulating all along. Only
+  the numerator (recalled-then-cited) is missing, and it is derivable at
+  read time from `derived_from`.
+- **The exposure count is clean in one way and dirty in another.** The
+  recall tool reinforces only `Liveness::Live` pages, only rows that survived
+  the #76 occupancy cap and the #77 abstention cut, and `context` never
+  reinforces — so trimmed rows are not exposures, which is right. But it also
+  counts a **filters-only listing** (no query, nothing scored) and an
+  **entity-hop promotion** as exposures, and neither is a relevance event.
+  When the gate clears, the denominator must be narrowed to *scored*
+  exposures. Do **not** narrow `REINFORCE` itself — `strength` and
+  `last_accessed` must keep moving on every live recall or a listing stops
+  keeping rows alive and the prune horizon shifts. Add a separate
+  `search_hits` counter bumped by a second, narrower UPDATE from the facts
+  the recall handler already holds (`is_search`, `by_score`, `hopped`).
+
+### Why citations are zero, and what changed
+
+Live sessions run a client-side `/checkpoint` command that, until
+2026-09-02, lacked the reflect step the server-side checkpoint prompt carries
+(`prompts.rs`, step 4). The description eval put that step at 3/3 cited
+versus 0/3 from the `reflect` description alone, so the sessions never
+reflected and there was nothing to count. The step now ships in the ritual;
+the clock starts 2026-09-02. Re-probe on **2026-09-16** and **2026-10-01**
+with `nu scripts/outcome-probe.nu`.
+
+The *recalled-then-* qualifier stays un-backfillable server-side
+(`REINFORCE` overwrites `last_accessed`; parallel sessions share one slot).
+The planned agmem plugin keeps that log on the client instead: a hook on
+each `recall` records the returned ids per session, and the checkpoint
+ritual hands the list back to the model to mark what it drew on. That makes
+both arms of #86 a by-product of the ritual already measured at 3/3.
+
+### Decision rule for 2026-10-01
+
+1. **Gate unchanged: ≥ 20 live rows carrying `derived_from`.** Under 20 on
+   2026-10-01 with the ritual fixed for four weeks closes #86 as "it measured
+   `reflect` adoption, not memory worth".
+2. **If the gate clears, measure before building.** Cited live rows must
+   rank-separate from uncited ones on the free #54-style measurement: AUC
+   ≥ 0.65 of `cited` against recall rank on the live store. Below that, the
+   citation is not a rank signal here and #86 closes measured-and-dropped
+   with this number in the record.
+3. **If it separates, the feature is a ratio, not a count.** `cited_by`
+   (read-time, one grouped `derived_from CONTAINSANY` plus an index-only
+   migration) over `search_hits` (new, scored-only, above), with an evidence
+   floor of 10 scored exposures before any weight, a cap like the hop arm,
+   and `WEIGHT_CITED = 0.0` report-only first — the #83 precedent. The
+   negative arm is dropped as filed; its only live form, a per-writer
+   aggregate over rows corrected soon after being recalled, waits for writer
+   data and its own gate.

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "agmem",
+  "displayName": "agmem memory",
+  "description": "Persistent cross-session memory for Claude Code: the agmem MCP server, a briefing injected at every session start, checkpoint and tidy commands, and hooks that log what memory was used so the store can learn what helped.",
+  "version": "0.1.0",
+  "author": { "name": "Mate Alfoldi" },
+  "homepage": "https://github.com/AlfoldiMate/agmem",
+  "repository": "https://github.com/AlfoldiMate/agmem",
+  "license": "MIT",
+  "keywords": ["memory", "mcp", "context", "checkpoint"]
+}

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "agmem": {
+      "command": "agmem"
+    }
+  }
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,56 @@
+# agmem plugin for Claude Code
+
+Persistent memory wired into every session, with nothing to bootstrap by hand:
+the plugin registers the agmem MCP server, injects the memory briefing at
+session start, ships the checkpoint and tidy commands, and logs which claims
+each session recalled and wrote so the store can learn what helped.
+
+Every hook is a subcommand of the `agmem` binary (`agmem hook <event>`), so
+the plugin needs nothing beyond agmem itself — no scripting runtime, no `jq`.
+
+## Install
+
+Requires `agmem` 0.1.9 or newer on `PATH` (`cargo install agmem`, or the
+Homebrew tap — see the repository README).
+
+```
+claude plugin marketplace add AlfoldiMate/agmem
+claude plugin install agmem@agmem
+```
+
+To try it from a checkout without installing: `claude --plugin-dir ./plugin`.
+
+## What it adds
+
+| Piece | What it does |
+|---|---|
+| `.mcp.json` | Registers `agmem` over stdio. The space derives from the repo, so every branch and worktree of a project reads one store. |
+| `SessionStart` hook | Injects the briefing (`agmem context`) before the first token, names the branch tag, and after a compaction lists the claims the session had recalled so the next checkpoint can cite them. |
+| `PostToolUse` hook | Logs the ids each `recall` returned and each `remember`/`reflect` wrote or cited, under `<data dir>/hooks/<session>.jsonl`. Nudges once after a successful `git push`, and after every answered `AskUserQuestion` — both are decision seams. |
+| `Stop` hook | Nudges once per session when memory was recalled and nothing was written back. |
+| `/agmem:checkpoint` | The distil → recall → remember → reflect ritual. Step 4 (cite with `derived_from`) is byte-identical to the server's own checkpoint prompt; a test in the server crate fails if they drift. |
+| `/agmem:memory show\|tidy` | Show the store and judge the briefing; consolidate duplicates, contradictions and stale claims. |
+| `/agmem:doctor` | Self-check plus duplicate-registration check. |
+| `agmem` skill | The judgement: what is worth storing, correct-never-contradict, kinds, seams. |
+
+## Coexistence
+
+**Already registered agmem yourself** (`claude mcp add agmem --scope user`)?
+Both stay configured; Claude Code connects the higher-precedence one (local >
+project > user > plugin), so nothing runs twice. It only changes the tool
+names — `mcp__agmem__*` for your registration, `mcp__plugin_agmem_agmem__*`
+for the plugin's. The plugin's hooks and commands accept both.
+
+**Using context-flow** (or any project hooks that already inject `agmem
+context`)? Plugin hooks and project hooks both run, so the briefing would
+appear twice. Remove the project's SessionStart memory hook and keep the
+plugin's.
+
+## The session log
+
+`agmem hook post-tool-use` appends one JSON line per recall and per write to
+`<data dir>/hooks/<session_id>.jsonl` (`agmem --doctor` prints the data dir).
+Logs untouched for seven days are removed at the next session start. The log
+is what makes "recalled-then-cited" countable client-side — the store cannot
+keep it, because reinforcing a claim overwrites its last-accessed stamp — and
+it is what the post-compaction briefing reads.

--- a/plugin/commands/checkpoint.md
+++ b/plugin/commands/checkpoint.md
@@ -1,0 +1,94 @@
+---
+description: Store the session's durable state in agmem so you can safely /clear instead of letting /compact fire.
+argument-hint: "[optional: what to emphasise]"
+allowed-tools: Read, Bash(git branch:*), mcp__agmem__recall, mcp__agmem__remember, mcp__agmem__reflect, mcp__agmem__inspect, mcp__plugin_agmem_agmem__recall, mcp__plugin_agmem_agmem__remember, mcp__plugin_agmem_agmem__reflect, mcp__plugin_agmem_agmem__inspect
+---
+
+# Checkpoint
+
+Store memory so that a fresh session — with none of this context — could pick
+the work up without asking a single question. Memory lives in **agmem**: the
+space derives from the repo's shared git dir, so every branch and worktree
+writes to one store and there are no paths to resolve. You do the distilling;
+agmem stores what you send and never rewrites it.
+
+The branch tag for branch-scoped claims was announced at session start
+(`branch:<slug>`). If it is no longer in context, the current branch is:
+
+```
+!`git branch --show-current 2>/dev/null`
+```
+
+and the tag is `branch:` followed by the branch name with every run of
+characters outside `A-Za-z0-9._-` replaced by one `-`, leading and trailing
+`-` trimmed. Empty (detached HEAD) means there is no branch tag — then
+everything is durable or nothing.
+
+## The ritual, in order
+
+1. **Distil.** List what this session established that is durable and
+   **non-obvious**: decisions *and their reasons* (the reason is the valuable
+   half — "used a channel because the mutex version deadlocked under the retry
+   path", never just "used a channel"); corrected assumptions (the
+   highest-value entry type — a fresh session will make the same wrong
+   assumption); map facts for files whose purpose their path does not state;
+   gotchas that cost real time and would again. One atomic, self-contained
+   claim per entry, third person, meaningful with no conversation around it.
+
+2. **Recall before writing.** For each topic you are about to store, `recall`
+   it first. This step gets skipped under momentum — measured, not
+   hypothetical — and skipping it stores contradictions instead of
+   corrections. A claim that updates an earlier one is sent with `supersedes:
+   [<old id>]`, which closes the old claim but keeps it readable and dated.
+
+3. **Store with the right kind** (table below), batched into as few `remember`
+   calls as the content allows. Then **read the reply**: `duplicates` were
+   *not* written and `related` sit alongside what was — if either contains a
+   claim yours contradicts, re-send with `supersedes` set to its id, or the
+   live claim is still the wrong one.
+
+4. **A conclusion you worked out goes through `reflect` instead.** If one of
+   your candidates is something you concluded *from* what step 2 returned —
+   the cause behind three separate failures, what a preference and a
+   constraint mean taken together — store that one with `reflect`: the
+   insight, and `derived_from` set to the ids you drew it from. Same write,
+   with the evidence attached, so a later session can check the conclusion
+   rather than take it on faith. Something you were simply told is not this;
+   it belongs in the batch above.
+
+5. **Branch state.** What is done *and verified*, the immediate next action,
+   what is blocked on what — as `fact`s with `decay_class: fast` and the
+   branch tag. They fade in days and are pruned automatically, which is the
+   point: branch state should die with the branch.
+
+If `$ARGUMENTS` is non-empty, make sure that topic is covered explicitly.
+
+## What kind
+
+| What | kind | decay | tags / entities |
+|---|---|---|---|
+| Decision + reason, corrected assumption, map fact | `fact` | default | entities: the subsystem or file |
+| Gotcha, hard-won how-to | `lesson` | default (slow) | — |
+| Standing rule for every future session | `instruction` | pinned — lands in every briefing, so be sparing | — |
+| Branch state (Done/Next/Blocked) | `fact` | `fast` | the branch tag |
+| A conclusion drawn *from stored memories* | use `reflect` with `derived_from` | — | — |
+
+Verbatim text worth keeping as ground truth — an error transcript, a user
+requirement stated exactly — goes in the same `remember` call as `episode`;
+every claim in that call is provenanced to it. Sparingly: episodes are for
+text whose exact wording matters, not a session diary.
+
+## What to leave out
+
+Anything git records. Anything the code says plainly. Anything true only for
+the current turn. Narrative of what happened — memory holds state, not logs.
+Long tool output is not memory at all: it goes to a file with a one-line
+pointer claim if it needs finding again.
+
+## Then
+
+Report in three lines: how many claims stored by kind, how many superseded,
+and what you deliberately left out. Then tell the user they can safely
+`/clear` — and that this is better than letting auto-compaction fire, because
+the memory is now in the store and the next session starts with it in front
+of it.

--- a/plugin/commands/doctor.md
+++ b/plugin/commands/doctor.md
@@ -1,0 +1,34 @@
+---
+description: Check that agmem memory is wired into this session — binary, store, model, MCP registration — and print the fix for anything that is not.
+allowed-tools: Bash(agmem --doctor:*), Bash(agmem --version:*), Bash(claude mcp list:*), Bash(which agmem:*)
+---
+
+# agmem doctor
+
+Installation self-check, from the binary:
+
+```
+!`agmem --doctor 2>&1 || echo "agmem --doctor exited $?"`
+```
+
+MCP servers this session can see:
+
+```
+!`claude mcp list 2>&1`
+```
+
+Read both and report in at most six lines:
+
+1. Whether the binary is on PATH and its version (the plugin needs 0.1.9 or
+   newer for `agmem hook`; older binaries serve MCP fine but the hooks print
+   nothing).
+2. Whether the self-check passed; for each failing line, its printed fix.
+3. Whether the `agmem` server is registered **twice** — once by this plugin
+   and once at user or project scope. Claude Code connects only the
+   higher-precedence one (local > project > user > plugin), so this is
+   harmless, but it decides the tool names: `mcp__agmem__*` when your own
+   registration wins, `mcp__plugin_agmem_agmem__*` when the plugin's does.
+   Permission rules and hooks in this plugin accept both.
+4. If no agmem tools are in this session at all, the likely cause: the
+   plugin's server is disabled in `/mcp`, or the binary failed to start —
+   `agmem --doctor` says which.

--- a/plugin/commands/memory.md
+++ b/plugin/commands/memory.md
@@ -1,0 +1,43 @@
+---
+description: Inspect or tidy this project's agmem memory — show what the store holds and whether the briefing is still right, or consolidate duplicates, contradictions and stale claims.
+argument-hint: "[show | tidy]"
+allowed-tools: Read, mcp__agmem__context, mcp__agmem__recall, mcp__agmem__inspect, mcp__agmem__consolidate, mcp__agmem__remember, mcp__agmem__reflect, mcp__agmem__forget, mcp__plugin_agmem_agmem__context, mcp__plugin_agmem_agmem__recall, mcp__plugin_agmem_agmem__inspect, mcp__plugin_agmem_agmem__consolidate, mcp__plugin_agmem_agmem__remember, mcp__plugin_agmem_agmem__reflect, mcp__plugin_agmem_agmem__forget
+---
+
+# agmem memory
+
+Operate on this project's memory store according to `$ARGUMENTS` (default:
+`show`). The space derives from the repo automatically; you never name it
+except where noted.
+
+## show
+
+`inspect` with `ref: "stats"` for the counts, then `context` with no query for
+the general briefing. Report: live claims by kind for this project's space and
+`user`, the briefing itself, and one line of assessment — is anything in it
+stale, wrong, or contradicted by what the repo says right now? A claim worth
+doubting gets `inspect` on its id (provenance and correction history), not a
+hedge.
+
+## tidy
+
+Run `consolidate`, then judge each list — it decides nothing itself, and empty
+lists are the healthy outcome, not a failure:
+
+- **near_duplicates** — merge a group with one `remember`: the wording worth
+  keeping, `supersedes` set to every other member's id. Check
+  `min_similarity` first: it is the weakest pair anywhere in the group, so a
+  low value means the cluster chained through a middle claim and may be two
+  claims, not one. Never `forget` a duplicate — that deletes the history the
+  merge exists to keep.
+- **contradictions** — read both; nothing has judged that they disagree. When
+  one is wrong, send the right one with the wrong one's id in `supersedes`.
+  When both are right (scope differs), leave them.
+- **stale_contexts** — a `fast` claim recall kept alive: if it proved durable,
+  re-store it with a slower `decay_class` (superseding the fast one); if it
+  was scaffolding, `forget` it.
+
+Report what you merged, corrected, and expired, in at most five lines.
+
+Never `forget` with `purge` during any of these modes without the user
+confirming first.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,0 +1,28 @@
+{
+  "description": "agmem memory: inject the briefing at session start, log which claims were recalled and written, nudge at checkpoint seams. Every hook is `agmem hook <event>`, so nothing beyond the agmem binary is needed.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact|fork",
+        "hooks": [
+          { "type": "command", "command": "agmem hook session-start", "timeout": 15 }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(Bash|AskUserQuestion|mcp__(plugin_agmem_)?agmem__(recall|remember|reflect))$",
+        "hooks": [
+          { "type": "command", "command": "agmem hook post-tool-use", "timeout": 5 }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "agmem hook stop", "timeout": 5 }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin/skills/agmem/SKILL.md
+++ b/plugin/skills/agmem/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: agmem
+description: Judgement for persistent memory — when a moment is worth storing in agmem, when a briefing claim should be corrected rather than worked around, what to leave out, and which seams call for a checkpoint. Use when deciding whether something is worth remembering, when memory and the repo disagree, or at a seam (a push, a decision the user just made, a compaction, a finished task).
+---
+
+# Memory judgement
+
+agmem stores what you send and never rewrites it, so the quality of the store
+is the quality of your judgement at write time. These are the tests.
+
+## Is it worth storing?
+
+All four, or it is not:
+
+1. **Durable** — true of this project or this person, not of this task.
+2. **Non-obvious** — not something the repo, a type, a test, or git history
+   already says. Memory is for what a future session would have to *work out
+   again*.
+3. **Earned** — seen more than once, or once at real cost. A single cheap
+   surprise is an anecdote.
+4. **Actionable** — it changes what a future session would *do*. "The parser
+   is complex" changes nothing; "the parser re-reads the file on every token,
+   so batch calls" does.
+
+The reason is the valuable half of a decision. "Used a channel" is worth
+little; "used a channel because the mutex version deadlocked under the retry
+path" saves the next session from the same detour.
+
+## Correct, never contradict
+
+A briefing claim that turns out wrong is corrected with `remember` and
+`supersedes` set to its id — the id ends every briefing line. The old claim
+stays readable and dated; only one is live. Storing the new truth *beside*
+the old one leaves two live claims that disagree, and the next session picks
+one at random.
+
+Before any write, `recall` the topic in the words you would store it in. A
+live claim that already says it means nothing to store; one that says
+something different means this is a correction and you need its id.
+
+## What kind
+
+| What | kind | decay |
+|---|---|---|
+| Decision + reason, corrected assumption, map fact | `fact` | default |
+| Gotcha, hard-won how-to | `lesson` | slow |
+| Standing rule for every future session | `instruction` | pinned — be sparing |
+| Branch state (done, next, blocked) | `fact`, `decay_class: fast`, tagged `branch:<slug>` | days |
+| A conclusion drawn from stored claims | `reflect`, with `derived_from` set to the claims it rests on | default |
+
+Cite what you drew on. When a conclusion rests on claims that memory put in
+front of you — in the briefing or in a `recall` result — `reflect` with those
+ids in `derived_from` is the same write with its evidence attached, and it is
+how the store learns which of its claims actually help.
+
+## Leave out
+
+Anything git records. Anything the code says plainly. Anything true only for
+the current turn. Narrative — memory holds state, not logs. Long output goes
+to a file with a one-line pointer claim.
+
+## Seams
+
+A seam is where the reasons are still in context and about to stop being:
+
+- a successful `git push` — work shipped, reasons fresh;
+- an answer to a question you asked the user — a decision was just made;
+- a compaction — the summary keeps outcomes and drops reasons;
+- a finished task, before starting the next.
+
+At a seam, `/agmem:checkpoint`. Saving nothing is the right outcome for a
+session that established nothing durable; saving its scratch work is not.


### PR DESCRIPTION
## Why

#86 sat at 0/20 cited rows for a month because the client-side `/checkpoint` sessions actually ran lacked one step of the server's checkpoint prompt — invisible from the server, found only by probing the store. A plugin makes the ritual travel with agmem instead of with one repo, and makes the 2026-10-01 measurement a fact about agmem rather than about one laptop.

## What

- **`agmem hook <event>`** (`crates/agmem-server/src/hook.rs`): SessionStart, PostToolUse and Stop answered from the stdin payload. The plugin depends on nothing but the binary — no scripting runtime, no jq. Injects the briefing (`agmem context`), names the branch tag, keeps `<data>/hooks/<session>.jsonl` (recall ids, write ids, `derived_from` cites), lists recalled ids after a compaction, nudges at a successful push, an answered `AskUserQuestion`, and once per session at Stop when memory was recalled and nothing written.
- **`plugin/`**: `.mcp.json`, `hooks/hooks.json`, `/agmem:checkpoint`, `/agmem:memory show|tidy`, `/agmem:doctor`, the `agmem` judgement skill, README. **`.claude-plugin/marketplace.json`** at the root so `claude plugin marketplace add AlfoldiMate/agmem` works.
- **Drift test**: `prompts::plugin_drift` fails if the plugin checkpoint's citation step stops matching `prompts::checkpoint` word for word — that step is the one measured at 3/3 cited vs 0/3.
- **`docs/eval/outcome-counters.md`**: `access_count` already is the monotonic denominator (REINFORCE has bumped it since 0.1.0); exposures currently count filters-only listings and hop promotions and need a scored-only `search_hits` when the gate clears; the 2026-10-01 decision rule, written before any number.
- README and design.md updated.

## Verified

- `cargo fmt`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`: 352 passed, 13 ignored.
- `claude plugin validate` on both manifests.
- Headless `claude --plugin-dir ./plugin` in a scratch repo: real briefing injected, branch tag named, all commands and the skill visible.
- Probed the real PostToolUse payload headless: `tool_response` for MCP tools is a JSON string; the matcher regex fires for `mcp__agmem__recall`.

## Facts from the Claude Code docs that shaped this

- Plugin hooks merge with project hooks (double-firing is real; plugin README says what to remove).
- Plugin-bundled MCP tools are `mcp__plugin_agmem_agmem__*`; a user-scope `agmem` entry takes precedence and Claude Code connects only one. Matchers and `allowed-tools` accept both names.
- PreCompact cannot add model-visible context; the post-compaction list rides `SessionStart` with `source: compact`.
- Elicitation exists but asks the *user* via a dialog, not the model — closes the #86 "MCP feedback loop" question without building anything.

## Deliberately not in this PR

- A "here is what you recalled" step inside the checkpoint ritual: unmeasured wording, and `desc-eval.nu` cannot drive the plugin command yet. Bar recorded in `.claude/notes/plan-86-round2-2026-09-02.md`.
- `search_hits` exposure narrowing: waits for the citation gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Second commit: the framework lives here

`.claude` was a gitignored symlink to a separate context-flow checkout; it is now a tracked folder in this repo, tuned to run on the plugin. The SessionStart hook keeps only the worktree layout check, the push nudge left the Bash hook, `/checkpoint` invokes the plugin's `agmem:checkpoint` skill and adds only the gate on agents' proposed learnings, `/agmem` keeps `import` (show/tidy are `/agmem:memory`), and the doctor reports a binary without `agmem hook` and a missing plugin with the install commands. Machine-local parts (`notes/`, `settings.local.json`, `sgconfig.yml`, a local skill) stay untracked via `.claude/.gitignore`. Every session in this repo now gets its memory the way an installed user does, so a plugin change is dogfooded on the next session.
