### PR TITLE
The plugin manifests follow the binary, and the framework audit after the move

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
   "owner": { "name": "Mate Alfoldi" },
   "metadata": {
     "description": "agmem — persistent memory for coding agents over MCP",
-    "version": "1.0.0"
+    "version": "0.1.10"
   },
   "plugins": [
     {

--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,6 +1,3 @@
-# machine-local: libraryPath is an absolute path into ~/.cache/ctx-flow
-sgconfig.yml
-
 # a machine-local skill that is not part of the framework
 skills/rust-expert-developer/
 

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -75,9 +75,12 @@ there is also no space derivation, so every project silently reads and
 writes one shared `default` space. `agmem --doctor` prints the space it
 derives for the current directory, and `/ctx-flow-doctor` flags an old,
 stale or duplicated binary and a missing plugin. If you had registered
-agmem by hand before (`claude mcp add --scope user agmem`), leave it or
-remove it: Claude Code connects only one, yours winning, and the only
-difference is the tool names (`mcp__agmem__*` vs `mcp__plugin_agmem_agmem__*`). The store is one directory
+agmem by hand before (`claude mcp add --scope user agmem`), remove it
+(`claude mcp remove agmem -s user`): Claude Code connects only one, yours
+winning, and that changes the tool names to `mcp__agmem__*` — this
+framework's agents name the plugin's (`mcp__plugin_agmem_agmem__*`), so under
+a by-hand registration they start without memory. `/agmem:doctor` flags the
+duplicate. The store is one directory
 (`~/Library/Application Support/dev.agmem.agmem` on macOS,
 `~/.local/share/agmem` on Linux) — back it up or delete it as a unit. There is
 no server-side LLM: the session distils, the store never rewrites what it
@@ -106,7 +109,7 @@ type), the routing table, payload discipline, the memory loop, and the answer
 shape — output led by the next action, numbered steps, restated state, no
 preamble, questions asked through `AskUserQuestion` rather than prose.
 
-### Five agents
+### Six agents
 
 | Agent | Model / effort | Absorbs |
 |---|---|---|
@@ -115,6 +118,7 @@ preamble, questions asked through `AskUserQuestion` rather than prose.
 | `architect` | opus / high | design of a non-trivial change — read-only, never edits |
 | `browser` | sonnet / medium | `playwright-cli` sessions — snapshots stop here |
 | `tracker` | haiku / low | Jira/GitHub via `gh`/`acli` — never raw records |
+| `scout` | haiku / low | where a symbol lives, which files match a shape — paths and line refs, never bodies |
 
 Every one ends with a **mandatory return contract**: fixed keys, hard caps, and
 an explicit forbidden list. An unschematized subagent writes an essay; a
@@ -122,18 +126,19 @@ schematized one writes 200 tokens. Tiers are picked by *consequence of being
 wrong*, not output size — `runner` misses cost one re-dispatch; a bad
 `architect` plan is discovered late, after the code exists.
 
-Codebase search is **not** here: Claude Code ships `Explore`, which already
-does it. Route search there.
+Broad codebase exploration stays with Claude Code's built-in `Explore`;
+`scout` is the cheaper cousin for a question with an enumerable answer —
+where is X, which files do Y — that should come back as refs, not prose.
 
-### Four commands
+### Five commands
 
 - **`/checkpoint`** — runs the agmem plugin's checkpoint ritual (recall
   first, so corrections land as `supersedes`; `reflect` with `derived_from`
   for conclusions) so you can `/clear` instead of letting auto-compaction
   fire, then applies the gate that accepts or drops agents' proposed
   learnings — the one step that is this framework's own.
-- **`/agmem import`** — moves a pre-agmem `LEDGER.md`, branch state, and
-  playbooks into the store, once. Showing and tidying the store are the
+- **`/agmem-import`** — moves a pre-agmem `LEDGER.md` and branch state files
+  into the store, once. Showing and tidying the store are the
   plugin's `/agmem:memory show` and `/agmem:memory tidy`.
 - **`/ctx-flow-doctor`** — checks every dependency above, the hooks, both MCP
   registrations, and whether ast-grep actually parses this project's
@@ -147,6 +152,10 @@ does it. Route search there.
   `~/.cache/ctx-flow/grammars` (shared by every project on the machine),
   registers it in the project's `sgconfig.yml`, and verifies it against real
   files. `sgconfig.yml` is machine-local — gitignore it.
+- **`/bare-worktree`** — `init`, `add`, `remove`, `apply`, `discard`, `which`
+  for the bare-repo + sibling-worktrees layout; the only sanctioned way to
+  make a worktree here, since raw `git worktree add` skips the profile files
+  and the root-`.claude` symlink (a hook denies it).
 
 ### The hooks
 
@@ -346,16 +355,19 @@ compacts; the token saving is a side effect of the quality win.
 ## Layout
 
 ```
-context-flow/               mounted as your project's .claude
+.claude/                    this folder, copied into your project
 ├── CLAUDE.md               the routing discipline — loads every session
 ├── settings.json           hook registration
-├── agents/                 runner, verifier, architect, browser, tracker
-├── commands/               checkpoint (wraps the plugin's), agmem import, ctx-flow-doctor, ast-grep-it, bare-worktree
+├── .gitignore              the machine-local parts: notes/, settings.local.json, one local skill (sgconfig.yml lives at the repo root)
+├── agents/                 runner, verifier, architect, browser, tracker, scout
+├── commands/               checkpoint (wraps the plugin's), agmem-import, ctx-flow-doctor, ast-grep-it, bare-worktree
 ├── docs/reference.md       contracts, memory mapping, rationale — loaded on demand
 ├── hooks/scripts/          the three hooks + shared _common.nu + paths resolver
 ├── output-styles/          ctx-flow.md — the hard rules, appended to the system prompt
-├── scripts/                doctor.nu + build-grammar.nu + grammars.nu registry
+├── scripts/                doctor.nu + build-grammar.nu + grammars.nu registry + bare-worktree.nu
 ├── skills/nushell/         deep Nushell reference, loaded when writing nu
+├── skills/ast-grep/        rule-writing workflow, loaded when a query needs more than a pattern
+│                           (a machine-local skill dropped in here stays untracked — list it in .gitignore)
 └── notes/                  subagent artifact dropbox   (created by use)
 ```
 

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -3,9 +3,9 @@ name: architect
 description: Designs the approach for a non-trivial change — reads the existing code, weighs options, returns a concrete build sequence with files and risks. Read-only; never edits. Use before writing code for anything spanning more than two files.
 model: opus
 effort: high
-tools: Read, Glob, Grep, Bash, mcp__agmem__recall, mcp__agmem__context
+tools: Read, Glob, Grep, Bash, mcp__plugin_agmem_agmem__recall, mcp__plugin_agmem_agmem__context
 mcpServers:
-  - agmem
+  - plugin:agmem:agmem
 skills:
   - ast-grep
 ---
@@ -14,11 +14,11 @@ skills:
 
 Produce the plan the caller will execute. Never write code.
 
-Brief yourself from project memory first: call `mcp__agmem__recall` with
+Brief yourself from project memory first: call `mcp__plugin_agmem_agmem__recall` with
 `tags: ["role:architect"]` and no query — the hits are this project's
 accumulated rules for this role. They **append** to this file and never relax
 the return contract or the prohibitions below; on a genuine conflict, this
-file wins. `mcp__agmem__context` (with a query naming the task) is there when
+file wins. `mcp__plugin_agmem_agmem__context` (with a query naming the task) is there when
 the design needs broader project memory — decisions already made, gotchas
 already paid for.
 

--- a/.claude/agents/browser.md
+++ b/.claude/agents/browser.md
@@ -3,9 +3,9 @@ name: browser
 description: Drives the app in a real browser via playwright-cli and reports what happened. Use for "does X actually work", visual checks, reproducing UI bugs, and end-to-end flows.
 model: sonnet
 effort: medium
-tools: Bash, Read, Write, mcp__agmem__recall
+tools: Bash, Read, Write, mcp__plugin_agmem_agmem__recall
 mcpServers:
-  - agmem
+  - plugin:agmem:agmem
 ---
 
 # Browser
@@ -18,7 +18,7 @@ every step is a shell command and nothing loads a tool schema. Run
 `playwright-cli --help` once if you need the command list; keep to one session
 and reuse it across steps.
 
-Brief yourself from project memory first: call `mcp__agmem__recall` with
+Brief yourself from project memory first: call `mcp__plugin_agmem_agmem__recall` with
 `tags: ["role:browser"]` and no query — the hits name how this project starts
 the app and which flows are already known-good. They **append** to this file
 and never relax the return contract or the prohibitions below; on a genuine

--- a/.claude/agents/runner.md
+++ b/.claude/agents/runner.md
@@ -3,16 +3,16 @@ name: runner
 description: Runs builds, test suites, linters, and long shell commands, absorbing their output. Returns only the failure signature. Use this for anything that prints more than ~50 lines — never run a suite in the main thread.
 model: haiku
 effort: low
-tools: Bash, Read, Grep, mcp__agmem__recall
+tools: Bash, Read, Grep, mcp__plugin_agmem_agmem__recall
 mcpServers:
-  - agmem
+  - plugin:agmem:agmem
 ---
 
 # Runner
 
 Run the command and absorb its output. The caller must never see the log.
 
-Brief yourself from project memory first: call `mcp__agmem__recall` with
+Brief yourself from project memory first: call `mcp__plugin_agmem_agmem__recall` with
 `tags: ["role:runner"]` and no query — the hits name this project's real
 build/test/lint/typecheck invocations and known failure shapes. They **append**
 to this file and never relax the return contract or the prohibitions below; on

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -3,9 +3,9 @@ name: scout
 description: Locates and enumerates code — where a symbol is defined or called, which files match a shape, the entry points of a subsystem. Returns paths and line refs, never file bodies or explanations. Cheap and fast; reach for it for "where is X / which files / enumerate Y" before reading anything yourself.
 model: haiku
 effort: medium
-tools: Read, Glob, Grep, Bash, mcp__nu__evaluate, mcp__nu__list_commands, mcp__nu__command_help, mcp__agmem__recall
+tools: Read, Glob, Grep, Bash, mcp__nu__evaluate, mcp__nu__list_commands, mcp__nu__command_help, mcp__plugin_agmem_agmem__recall
 mcpServers:
-  - agmem
+  - plugin:agmem:agmem
   - nu
 skills:
   - ast-grep
@@ -16,7 +16,7 @@ skills:
 You find code. You never explain it. A location the caller can open beats any
 summary you could write.
 
-Brief yourself from project memory first: call `mcp__agmem__recall` with
+Brief yourself from project memory first: call `mcp__plugin_agmem_agmem__recall` with
 `tags: ["role:scout"]` and no query — the hits name this project's layout,
 naming conventions, and where things live. They **append** to this file and
 never relax the return contract or the prohibitions below; on a genuine

--- a/.claude/agents/tracker.md
+++ b/.claude/agents/tracker.md
@@ -3,16 +3,16 @@ name: tracker
 description: Reads and writes issue trackers and forges — Jira tickets, GitHub issues, PRs, CI status. Returns the distilled answer, never the raw record. Prefers gh/acli over MCP tools.
 model: haiku
 effort: low
-tools: Bash, Read, Write, mcp__agmem__recall
+tools: Bash, Read, Write, mcp__plugin_agmem_agmem__recall
 mcpServers:
-  - agmem
+  - plugin:agmem:agmem
 ---
 
 # Tracker
 
 Answer questions about tickets and PRs. Return conclusions, never records.
 
-Brief yourself from project memory first: call `mcp__agmem__recall` with
+Brief yourself from project memory first: call `mcp__plugin_agmem_agmem__recall` with
 `tags: ["role:tracker"]` and no query — the hits are this project's
 accumulated rules for this role. They **append** to this file and never relax
 the return contract or the prohibitions below; on a genuine conflict, this

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -3,9 +3,9 @@ name: verifier
 description: Adversarially checks one specific claim, finding, or assumption against the actual code. Defaults to refuting. Use before acting on anything expensive or hard to reverse.
 model: sonnet
 effort: high
-tools: Read, Glob, Grep, Bash, mcp__agmem__recall
+tools: Read, Glob, Grep, Bash, mcp__plugin_agmem_agmem__recall
 mcpServers:
-  - agmem
+  - plugin:agmem:agmem
 skills:
   - ast-grep
 ---
@@ -14,7 +14,7 @@ skills:
 
 You are given one claim. Try to destroy it. If it survives, it is probably true.
 
-Brief yourself from project memory first: call `mcp__agmem__recall` with
+Brief yourself from project memory first: call `mcp__plugin_agmem_agmem__recall` with
 `tags: ["role:verifier"]` and no query — the hits are this project's
 accumulated rules for this role. They **append** to this file and never relax
 the return contract or the prohibitions below; on a genuine conflict, this

--- a/.claude/commands/agmem-import.md
+++ b/.claude/commands/agmem-import.md
@@ -1,15 +1,15 @@
 ---
-description: Migrate a pre-agmem checkout's file memory — LEDGER.md, branch state files, playbooks — into the agmem store, once. Showing and tidying the store are the plugin's /agmem:memory.
-argument-hint: "import"
+description: Migrate a pre-agmem checkout's file memory — LEDGER.md and branch state files — into the agmem store, once. Showing and tidying the store are the plugin's /agmem:memory.
 allowed-tools: Read, Bash, Glob, mcp__agmem__recall, mcp__agmem__remember, mcp__plugin_agmem_agmem__recall, mcp__plugin_agmem_agmem__remember
 ---
 
-# agmem import
+# agmem-import
 
-`show` and `tidy` live in the agmem plugin as `/agmem:memory show` and
-`/agmem:memory tidy`; if `$ARGUMENTS` asks for either, say so and stop. What
-this framework still owns is the one-time migration of the file memory it
-used before agmem existed.
+Showing and tidying the store are the plugin's `/agmem:memory show` and
+`/agmem:memory tidy`. What this framework still owns is the one-time
+migration of the file memory it used before agmem existed; in a checkout
+that has already run it (the files carry an `.imported` suffix) this is a
+no-op.
 
 Resolve the legacy paths:
 
@@ -17,13 +17,13 @@ Resolve the legacy paths:
 nu "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/scripts/ctx-flow-paths.nu"
 ```
 
-Then, for whichever of these exist — `LEDGER=`, every file under
-`.claude/notes/state/`, and every `.claude/playbooks/<role>.md`:
+Then, for whichever of these exist — `LEDGER=` and every file under
+`.claude/notes/state/`:
 
 1. Read the file. Distil each entry into one atomic, third-person claim —
    ledger decisions and map entries → `fact` (set `valid_from` from the
-   entry's date where it carries one), gotchas → `lesson`, playbook rules →
-   `lesson` tagged `role:<role>`, branch state → `fact` with `decay_class:
+   entry's date where it carries one), gotchas → `lesson`, branch state →
+   `fact` with `decay_class:
    fast` tagged with that branch's `branch:<slug>` tag (`TAG=` for the
    current branch; the same slug rule for others). A rule the ledger states
    as binding every session → `instruction`, sparingly.

--- a/.claude/commands/checkpoint.md
+++ b/.claude/commands/checkpoint.md
@@ -56,7 +56,7 @@ how many you saw and how many you kept, and move on.
 ## 3. Legacy files
 
 If `.claude/notes/LEDGER.md` exists, this checkout predates agmem — run
-`/agmem import` once to move its contents into the store.
+`/agmem-import` once to move its contents into the store.
 
 ## Then
 

--- a/.claude/docs/reference.md
+++ b/.claude/docs/reference.md
@@ -83,7 +83,7 @@ The lifetime split the two files used to carry maps onto kinds and decay:
 The slug in `branch:<slug>` is computed inside the agmem binary — its
 SessionStart hook announces it and its checkpoint writes it, one rule for
 both sides. `hooks/scripts/ctx-flow-paths.nu` (`TAG=`) carries the same rule
-for `/agmem import`, and is the one place here that must keep matching it.
+for `/agmem-import`, and is the one place here that must keep matching it.
 
 Writing well is `/checkpoint`'s job, and its order matters: distil → `recall`
 the topic → `remember`, with `supersedes` carrying the id of anything now

--- a/.claude/hooks/scripts/_common.nu
+++ b/.claude/hooks/scripts/_common.nu
@@ -74,7 +74,7 @@ export def slug [b: string]: nothing -> string {
 # {root, ledger, branch, state, tag} — root and tag serve the live flow (the
 # .claude/notes artifact dropbox and the agmem branch tag, one slug rule for
 # the hook that announces it and the /checkpoint that writes it); ledger and
-# state are the LEGACY file locations, still resolved so /agmem import can find
+# state are the LEGACY file locations, still resolved so /agmem-import can find
 # what a pre-agmem checkout wrote. `state` and `tag` are null on a detached
 # HEAD.
 export def paths [p: record]: nothing -> record {

--- a/.claude/hooks/scripts/ctx-flow-paths.nu
+++ b/.claude/hooks/scripts/ctx-flow-paths.nu
@@ -11,7 +11,7 @@
 # permits but a slug should not carry — `+ # ( ) % &`, non-ASCII, over 80
 # characters — diverges the same way. One resolver, called by both sides, is
 # the only version of this that stays correct. LEDGER/STATE are the legacy
-# file locations, kept so /agmem import can find a pre-agmem checkout's notes.
+# file locations, kept so /agmem-import can find a pre-agmem checkout's notes.
 #
 # Usage, from anywhere inside the repo:
 #     nu ctx-flow-paths.nu            # KEY=VALUE lines, shell-friendly

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -60,8 +60,34 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: release-plz/action@v0.5
+        id: release-pr
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      # release-plz bumps Cargo.toml alone. The plugin manifests carry the
+      # same version — the plugin is only ever as new as the binary, since its
+      # hooks are `agmem hook` — and a test in agmem-server fails when they
+      # lag, so the release PR has to carry them too. Re-applied on every
+      # update of the PR: release-plz rewrites its branch each time.
+      - name: Pin the plugin manifests to the proposed version
+        if: steps.release-pr.outputs.prs != '' && steps.release-pr.outputs.prs != '[]'
+        env:
+          PRS: ${{ steps.release-pr.outputs.prs }}
+        run: |
+          set -eu
+          branch=$(printf '%s' "$PRS" | jq -r '.[0].head_branch')
+          git fetch origin "$branch"
+          git checkout "$branch"
+          version=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "agmem-server") | .version')
+          for f in plugin/.claude-plugin/plugin.json .claude-plugin/marketplace.json; do
+            sed -i -E "s/\"version\": \"[0-9][0-9.]*\"/\"version\": \"$version\"/" "$f"
+            grep -q "\"version\": \"$version\"" "$f"
+          done
+          git diff --quiet && exit 0
+          git config user.name "release-plz"
+          git config user.email "release-plz@users.noreply.github.com"
+          git commit -am "The plugin manifests follow the binary to $version"
+          git push origin "$branch"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .DS_Store
 
+# ast-grep custom-language registry; libraryPath is an absolute path into
+# ~/.cache/ctx-flow, so it is machine-local (/ast-grep-it writes it)
+sgconfig.yml
+
 # .claude is this repo's own Claude Code framework (ctx-flow, tuned to the
 # agmem plugin) and is tracked; its machine-local parts are listed in
 # .claude/.gitignore

--- a/README.md
+++ b/README.md
@@ -342,11 +342,12 @@ BGE vectors (`tests/fixtures/`), and tests that need the live model are
 `#[ignore]`d.
 
 The repo's own `.claude/` is the ctx-flow framework — routing discipline,
-agents, hooks, commands — tuned to run on the plugin under `plugin/`: every
-session here gets its memory the way an installed user does, so a plugin
-change is dogfooded on the next session. `claude --plugin-dir ./plugin` loads
-the working-tree plugin without installing it; `claude plugin marketplace add
-/path/to/agmem` installs it from a checkout.
+agents, hooks, commands — tuned to run on the plugin under `plugin/`. Nothing
+in the repo enables the plugin; sessions here use it the way any user does,
+installed from the marketplace at user scope, so a plugin change is dogfooded
+once it is released. `claude --plugin-dir ./plugin` loads the working-tree
+plugin without installing it; `claude plugin marketplace add /path/to/agmem`
+installs it from a checkout.
 
 Retrieval quality is measured, not asserted. An offline, deterministic eval
 rides `cargo test` against a recorded baseline in

--- a/crates/agmem-server/src/hook.rs
+++ b/crates/agmem-server/src/hook.rs
@@ -523,7 +523,7 @@ fn branch_of(cwd: &Path) -> Option<String> {
     (!branch.is_empty() && branch != "HEAD").then_some(branch)
 }
 
-/// A branch name as the tag carries it — the rule context-flow's hooks and
+/// A branch name as the tag carries it — the rule the ctx-flow hooks and
 /// `/checkpoint` share, so the two sides of the tag cannot drift.
 fn slug(branch: &str) -> String {
     let mut out = String::with_capacity(branch.len());

--- a/crates/agmem-server/src/prompts.rs
+++ b/crates/agmem-server/src/prompts.rs
@@ -282,4 +282,32 @@ mod plugin_drift {
              word for word:\n{step_4}"
         );
     }
+
+    const PLUGIN_MANIFEST: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../plugin/.claude-plugin/plugin.json"
+    ));
+    const MARKETPLACE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../.claude-plugin/marketplace.json"
+    ));
+
+    /// The plugin's hooks are `agmem hook …`, so the plugin is only ever as
+    /// new as the binary: both manifests carry the crate version. release-plz
+    /// bumps Cargo.toml alone and the release-pr workflow re-pins these two
+    /// after it; this is what notices a bump that skipped them.
+    #[test]
+    fn the_plugin_manifests_carry_the_crate_version() {
+        let want = format!("\"version\": \"{}\"", env!("CARGO_PKG_VERSION"));
+        for (path, text) in [
+            ("plugin/.claude-plugin/plugin.json", PLUGIN_MANIFEST),
+            (".claude-plugin/marketplace.json", MARKETPLACE),
+        ] {
+            assert!(
+                text.contains(&want),
+                "{path} does not carry the crate version {}",
+                env!("CARGO_PKG_VERSION")
+            );
+        }
+    }
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -29,12 +29,12 @@ descriptions, and task breakdowns.
 ┌─────────────────────────┐ ┌─────────────────────────┐
 │ agmem process (per      │ │ agmem process           │
 │ client)                 │ │                         │
-│ ┌─────────────────────┐ │ │   Default mode: each    │
-│ │ rmcp server         │ │ │   process owns its OWN  │
-│ │  tools: remember,   │ │ │   embedded DB file      │
-│ │  recall, context,   │ │ │   (one process per      │
-│ │  forget, inspect    │ │ │   data dir, enforced    │
-│ │  prompts: rituals   │ │ │   by a lock file).      │
+│ ┌─────────────────────┐ │ │   Default mode: the     │
+│ │ rmcp server, rituals│ │ │   first agmem to start  │
+│ │  tools: remember,   │ │ │   becomes a daemon that │
+│ │  recall, context,   │ │ │   owns the DB file;     │
+│ │  reflect, forget,   │ │ │   later sessions talk   │
+│ │ consolidate, inspect│ │ │   to it (#37).          │
 │ └────────┬────────────┘ │ │                         │
 │ ┌────────▼────────────┐ │ │   Sharing mode: both    │
 │ │ core (domain)       │ │ │   processes point       │
@@ -57,9 +57,10 @@ descriptions, and task breakdowns.
 
 Key properties:
 
-- **One process, one binary, no daemon, no ports** in the default mode. The
-  MCP client spawns `agmem` over stdio; the DB is a file in the platform data
-  dir. Everything Spectron does with api/worker/scheduler/management processes,
+- **One binary, no ports.** The MCP client spawns `agmem` over stdio; on Unix
+  the first one to start becomes a shared daemon that owns the DB file in the
+  platform data dir, and later sessions hand off to it over a local socket
+  (#37). `--no-daemon` keeps the one-process mode. Everything Spectron does with api/worker/scheduler/management processes,
   a job queue, and an object store, agmem does in-process or lazily (§6.5).
 - **stdout is the MCP wire.** All logging goes to stderr (or a file). This is
   a hard invariant enforced in the telemetry module; `println!` is forbidden.
@@ -76,7 +77,7 @@ Key properties:
 
 | Spectron | agmem |
 |---|---|
-| 7 verbs: remember/recall/context/reflect/forget/upload/inspect | 5 tools v1: **remember, recall, context, forget, inspect** (+ reflect as a persisting tool in phase 3, #26; upload dropped) |
+| 7 verbs: remember/recall/context/reflect/forget/upload/inspect | 7 tools: **remember, recall, context, reflect, forget, consolidate, inspect** (upload dropped) |
 | Server-side 3-stage LLM extraction pipeline | **The calling agent extracts**; tool descriptions + input schemas are the contract |
 | Reconciler (create/update/supersede/flag, confidence floor) | Caller-driven supersession (`supersedes:` param) + server-side dedup gate (exact hash + cosine ≥ 0.95 → report duplicate instead of insert) |
 | Tri-temporal (system/known/valid time) | **Bi-temporal-lite**: `created_at` (known) + `valid_from`/`invalid_at` (valid); supersede-don't-delete chains |
@@ -1109,8 +1110,12 @@ rather than details:
 | `--doctor` | — | One-shot self check: lock, DB open, migrate, embedder, sample roundtrip, vector coverage; prints report, exits |
 | `--reindex` | — | Re-embed every row under the configured backend and record its model/dim pair — the one sanctioned way to change embedders; exits |
 | `context` subcommand | — | Print one session-start briefing to stdout and exit (`--query`, `--space`, `--budget-chars`) — the shell-hook surface, no MCP served |
+| `hook <event>` subcommand | — | The Claude Code plugin's hooks, reading the hook JSON on stdin: `session-start` (briefing plus branch tag, post-compaction recall list), `post-tool-use` (recall/write log, seam nudges), `stop` (recalled-but-wrote-nothing nudge); no MCP served |
 
-Client registration (the entire install story):
+Client registration: in Claude Code the plugin does it — `claude plugin
+marketplace add AlfoldiMate/agmem`, then `claude plugin install agmem@agmem`
+— and brings the `agmem hook` hooks and the checkpoint commands with it. Any
+other MCP client registers the binary by hand:
 
 ```sh
 claude mcp add agmem --scope user -- agmem

--- a/docs/tool-descriptions.md
+++ b/docs/tool-descriptions.md
@@ -400,7 +400,7 @@ an agent can check itself against.
 ## Overriding a description
 
 `AGMEM_TOOL_DESC_<TOOL>` replaces one outright, per server, no rebuild —
-`REMEMBER`, `RECALL`, `CONTEXT`, `FORGET`, `INSPECT`. See the README for the
+`REMEMBER`, `RECALL`, `CONTEXT`, `REFLECT`, `FORGET`, `CONSOLIDATE`, `INSPECT`. See the README for the
 `.mcp.json` shape. Three things worth knowing:
 
 - It is the **whole** description, never an addition. What the agent reads is

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "agmem",
   "displayName": "agmem memory",
   "description": "Persistent cross-session memory for Claude Code: the agmem MCP server, a briefing injected at every session start, checkpoint and tidy commands, and hooks that log what memory was used so the store can learn what helped.",
-  "version": "0.1.0",
+  "version": "0.1.10",
   "author": { "name": "Mate Alfoldi" },
   "homepage": "https://github.com/AlfoldiMate/agmem",
   "repository": "https://github.com/AlfoldiMate/agmem",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -10,8 +10,9 @@ the plugin needs nothing beyond agmem itself — no scripting runtime, no `jq`.
 
 ## Install
 
-Requires `agmem` 0.1.10 or newer on `PATH` (`cargo install agmem`, or the
-Homebrew tap — see the repository README).
+Requires `agmem` 0.1.10 or newer on `PATH` — the Homebrew tap, the shell
+installer, or `cargo install --git` as the repository README's Install
+section describes (nothing is on crates.io).
 
 ```
 claude plugin marketplace add AlfoldiMate/agmem
@@ -19,6 +20,9 @@ claude plugin install agmem@agmem
 ```
 
 To try it from a checkout without installing: `claude --plugin-dir ./plugin`.
+
+The plugin's version is the binary's: every release pins both manifests to
+the crate version, since the hooks are subcommands of that binary.
 
 ## What it adds
 
@@ -41,8 +45,8 @@ project > user > plugin), so nothing runs twice. It only changes the tool
 names — `mcp__agmem__*` for your registration, `mcp__plugin_agmem_agmem__*`
 for the plugin's. The plugin's hooks and commands accept both.
 
-**Using context-flow** (or any project hooks that already inject `agmem
-context`)? Plugin hooks and project hooks both run, so the briefing would
+**A project whose own hooks already inject `agmem context`** (ctx-flow did,
+before the plugin)? Plugin hooks and project hooks both run, so the briefing would
 appear twice. Remove the project's SessionStart memory hook and keep the
 plugin's.
 

--- a/plugin/commands/doctor.md
+++ b/plugin/commands/doctor.md
@@ -11,17 +11,24 @@ Installation self-check, from the binary:
 !`agmem --doctor 2>&1 || echo "agmem --doctor exited $?"`
 ```
 
+Binary on PATH, and whether more than one copy is installed:
+
+```
+!`agmem --version 2>&1; which -a agmem`
+```
+
 MCP servers this session can see:
 
 ```
 !`claude mcp list 2>&1`
 ```
 
-Read both and report in at most six lines:
+Read all three and report in at most six lines:
 
 1. Whether the binary is on PATH and its version (the plugin needs 0.1.10 or
    newer for `agmem hook`; older binaries serve MCP fine but the hooks print
-   nothing).
+   nothing). Two paths from `which -a` means a stale copy may shadow the
+   upgraded one.
 2. Whether the self-check passed; for each failing line, its printed fix.
 3. Whether the `agmem` server is registered **twice** — once by this plugin
    and once at user or project scope. Claude Code connects only the

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -14,6 +14,13 @@
 # Narrative commit titles carry no conventional-commit markers, so the bump
 # defaults to patch; pre-1.0 that is the honest default.
 #
+# The plugin manifests (plugin/.claude-plugin/plugin.json and
+# .claude-plugin/marketplace.json) carry the same version as the crates: the
+# plugin's hooks are `agmem hook`, so it is only ever as new as the binary.
+# release-plz cannot bump them — the release-pr workflow re-pins them after
+# each run, and a test in agmem-server fails when they lag. A manual bump PR
+# has to touch them by hand.
+#
 # Change detection checks out the last tag into a temp worktree and runs
 # `cargo package --workspace` there, verify-build included and no flag to skip
 # it — so the workflow points CARGO_TARGET_DIR at the cached target dir, which


### PR DESCRIPTION
## Summary

Post-migration audit of the `.claude` framework now living in this repo (#127, #129), plus the release seam it exposed.

- **Release pinning.** release-plz bumps `Cargo.toml` alone, but the plugin manifests carry the crate version because the plugin's hooks are `agmem hook …`. The release-pr job now re-pins `plugin/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` after each release-plz run, and `prompts::plugin_drift::the_plugin_manifests_carry_the_crate_version` fails when they lag. `release-plz.toml` documents that a manual bump PR must touch both by hand.
- **`/agmem import` → `/agmem-import`**, no longer importing playbooks (retired). A no-op in this checkout; kept for projects that copy the folder.
- **Agents name only the plugin's tools** (`mcp__plugin_agmem_agmem__*`). The framework README now says to remove a by-hand `claude mcp add agmem`, since it outranks the plugin and leaves the agents without memory.
- **`/agmem:doctor`** also runs `which -a agmem`, so a stale copy shadowing an upgrade shows up.
- **`sgconfig.yml`** is ignored at the repo root, where `/ast-grep-it` writes it, instead of under `.claude/`.
- **Docs catch-up.** Root README states the no-project-enable decision; `.claude/README` lists six agents, five commands and `/bare-worktree`; plugin README covers the install paths and version coupling; `docs/design.md` describes the daemon, seven tools, `hook <event>`, and the plugin install story.

## Test plan

- [x] `cargo test -p agmem-server --lib plugin_drift` passes at 0.1.10
- [ ] Next release-plz run produces a PR whose second commit re-pins both manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016py8cQTpNeAwA3SDrhciCB
