### PR TITLE
The architect thinks on fable at xhigh

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,8 +1,8 @@
 ---
 name: architect
 description: Designs the approach for a non-trivial change — reads the existing code, weighs options, returns a concrete build sequence with files and risks. Read-only; never edits. Use before writing code for anything spanning more than two files.
-model: opus
-effort: high
+model: fable
+effort: xhigh
 tools: Read, Glob, Grep, Bash, mcp__plugin_agmem_agmem__recall, mcp__plugin_agmem_agmem__context
 mcpServers:
   - plugin:agmem:agmem


### PR DESCRIPTION
The architect agent moves from opus/high to fable/xhigh: the design pass is where a stronger model compounds, since the main thread executes the plan it returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8VSNVwAQjNZ7EynoJVv1t