### PR TITLE
A document is an episode with a name (#132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ agmem --doctor
   ok    shared daemon        not running; the next session starts one
   ok    single-writer lock   held by this process
   ok    database open        surrealkv://…/agmem.db
-  ok    schema               v8
+  ok    schema               v9
   ok    write/read roundtrip scratch record created and removed
   ok    embedder             bge-small-en-v1.5-q (384d)
   ok    embedder vs store    same model and width

--- a/crates/agmem-store/src/migrate.rs
+++ b/crates/agmem-store/src/migrate.rs
@@ -26,6 +26,7 @@ const MIGRATIONS: &[&str] = &[
     include_str!("migrations/v6_writer.surql"),
     include_str!("migrations/v7_novelty.surql"),
     include_str!("migrations/v8_summary_kind.surql"),
+    include_str!("migrations/v9_documents.surql"),
 ];
 
 /// The schema version this binary produces.

--- a/crates/agmem-store/src/migrations/v9_documents.surql
+++ b/crates/agmem-store/src/migrations/v9_documents.surql
@@ -1,0 +1,35 @@
+-- Schema v9 — documents: a named, typed artifact over the episode ground
+-- truth (issue #132).
+--
+-- An episode already is the immutable, content-hashed, chunked and indexed
+-- raw tier every memory system converges on; what it lacks to serve as a
+-- *document* — a plan, a review, a probe report — is a name and a type. So
+-- a document is an episode row with `doc_kind` set, not a second table: one
+-- retrieval path, one purge path, one `derived_from` target. `title` is
+-- indexed with `space` but not unique — title supersession (#134) keeps
+-- several rows per title, one of them live by convention, not by schema.
+--
+-- The citation span cannot ride `derived_from`: that field is a bare
+-- `array<record<memory | episode>>` and carries no payload. It lives in a
+-- sidecar `spans` on `memory` keyed by the episode it points into. Offsets
+-- are Unicode scalar (char) offsets into the verbatim `content`, `end`
+-- exclusive — the unit the 100k-char cap counts, never the normalized text
+-- the hash is taken over. Nothing writes it yet; it lands here because
+-- provenance is the field that can never be backfilled (the v6 lesson).
+--
+-- Deliberately **no backfill and no UPDATE**: a pre-v9 episode reads as
+-- anonymous, which is true. Every field is `option<>` because a SurrealDB
+-- UPDATE re-coerces every field (the v3 lesson), and memory rows are updated
+-- by REINFORCE, PRUNE_EXPIRED, FORGET_SOFT and SUPERSEDE.
+DEFINE FIELD IF NOT EXISTS title ON episode TYPE option<string>;
+DEFINE FIELD IF NOT EXISTS doc_kind ON episode TYPE option<string>
+    ASSERT $value IN ["plan", "review", "report", "probe", "transcript", "other"];
+DEFINE FIELD IF NOT EXISTS tags ON episode TYPE option<array<string>>;
+DEFINE FIELD IF NOT EXISTS mime ON episode TYPE option<string>;
+DEFINE INDEX IF NOT EXISTS ep_title ON episode COLUMNS space, title;
+DEFINE INDEX IF NOT EXISTS ep_tags ON episode COLUMNS tags.*;
+
+DEFINE FIELD IF NOT EXISTS spans ON memory TYPE option<array<object>>;
+DEFINE FIELD IF NOT EXISTS spans.*.ref ON memory TYPE record<episode>;
+DEFINE FIELD IF NOT EXISTS spans.*.start ON memory TYPE int;
+DEFINE FIELD IF NOT EXISTS spans.*.end ON memory TYPE int;

--- a/crates/agmem-store/tests/migrate.rs
+++ b/crates/agmem-store/tests/migrate.rs
@@ -1,7 +1,7 @@
 //! Migration gate against the real (in-memory) engine.
 
-use agmem_core::{SpaceName, Writer};
-use agmem_store::repo::{self, Lookup};
+use agmem_core::{EpisodeId, SpaceName, Writer};
+use agmem_store::repo::{self, Forget, Lookup};
 use agmem_store::{StoreError, db, migrate};
 
 #[tokio::test]
@@ -400,4 +400,217 @@ async fn a_fresh_store_adopts_the_first_embedders_width() {
         .await
         .expect_err("the baked width is now the wrong one");
     assert!(err.to_string().contains("potion-base-8M"), "{err}");
+}
+
+/// An episode written before v9 carries none of the document columns and
+/// never gains them: it reads as anonymous, which is true (issue #132). The
+/// purge path must still reach it, and the memory distilled from it — which
+/// has no `spans` sidecar either — must still read.
+#[tokio::test]
+async fn an_episode_written_before_v9_reads_as_anonymous_and_still_purges() {
+    let conn = db::connect("mem://").await.expect("connect mem://");
+    conn.query(include_str!("../src/migrations/v1_schema.surql"))
+        .await
+        .expect("v1")
+        .check()
+        .expect("v1 statements");
+    conn.query(
+        "CREATE episode:01M145SMNET1XRYA713EWAQTD5 SET space = 'test',
+             content_hash = 'v1-ep', content = 'recorded before documents existed';
+         CREATE episode_chunk:ulid() SET episode = episode:01M145SMNET1XRYA713EWAQTD5,
+             space = 'test', position = 0, text = 'recorded before documents existed';
+         CREATE memory:01M145SMNET1XRYA713EWAQTD6 SET space = 'test', kind = 'fact',
+             content_hash = 'v1-m', content = 'documents did not exist yet',
+             source = { kind: 'episode', ref: episode:01M145SMNET1XRYA713EWAQTD5 }",
+    )
+    .await
+    .expect("seed")
+    .check()
+    .expect("seed statements");
+
+    assert_eq!(
+        migrate::ensure(&conn).await.expect("upgrade"),
+        migrate::SCHEMA_VERSION
+    );
+
+    let space: SpaceName = "test".parse().expect("valid slug");
+    let episode: EpisodeId = "01M145SMNET1XRYA713EWAQTD5".parse().expect("a ULID");
+    let detail = repo::episode(&conn, &space, &episode)
+        .await
+        .expect("a pre-v9 episode still reads");
+    assert_eq!(detail.chunks.len(), 1);
+    assert_eq!(
+        detail.derived.len(),
+        1,
+        "the claim drawn from it still reads with no spans sidecar"
+    );
+
+    let forgotten = repo::forget(
+        &conn,
+        &Forget {
+            spaces: vec![space.clone()],
+            memories: vec![],
+            episodes: vec![episode.clone()],
+            purge: true,
+        },
+    )
+    .await
+    .expect("purge a pre-v9 episode");
+    assert_eq!(forgotten.episodes, vec![episode]);
+    assert_eq!(forgotten.chunks, 1);
+    let stats = repo::stats(&conn, &space).await.expect("stats");
+    assert_eq!((stats.episodes, stats.chunks, stats.memories), (0, 0, 1));
+}
+
+/// The engine's complaint about `statement`, or `None` if it was accepted.
+async fn rejection(db: &db::Db, statement: &str) -> Option<String> {
+    match db.query(statement).await.expect("query").check() {
+        Ok(_) => None,
+        Err(err) => Some(err.to_string()),
+    }
+}
+
+/// The planner's chosen plan as text — proof a query rides an index.
+async fn plan_for(db: &db::Db, query: &str) -> String {
+    let mut resp = db
+        .query(query)
+        .await
+        .expect("explain query")
+        .check()
+        .expect("explain statements");
+    let plan: Vec<serde_json::Value> = resp.take(0).expect("plan rows");
+    serde_json::Value::from(plan).to_string()
+}
+
+/// A document is an episode with a name and a kind (issue #132): the kind is
+/// an enum the schema enforces, and lookups by title or tag ride their own
+/// indexes rather than scanning the table.
+#[tokio::test]
+async fn a_document_carries_its_name_and_kind_and_the_title_index_serves_it() {
+    let conn = db::connect("mem://").await.expect("connect mem://");
+    migrate::ensure(&conn).await.expect("migrate");
+
+    assert_eq!(
+        rejection(
+            &conn,
+            "CREATE episode:ulid() SET space = 'test', content_hash = 'doc-1',
+                 content = 'the plan for the widget', title = 'widget plan',
+                 doc_kind = 'plan', tags = ['role:architect'], mime = 'text/markdown'",
+        )
+        .await,
+        None,
+        "a fully described document is accepted"
+    );
+    let err = rejection(
+        &conn,
+        "CREATE episode:ulid() SET space = 'test', content_hash = 'doc-2',
+             content = 'dear diary', title = 'diary', doc_kind = 'diary'",
+    )
+    .await
+    .expect("an unknown doc_kind must be rejected");
+    assert!(err.contains("doc_kind"), "{err}");
+
+    let mut resp = conn
+        .query(
+            "SELECT VALUE title FROM episode WHERE space = 'test' AND title = 'widget plan';
+             SELECT VALUE title FROM episode WHERE tags CONTAINS 'role:architect';",
+        )
+        .await
+        .expect("lookups")
+        .check()
+        .expect("lookup statements");
+    let by_title: Vec<String> = resp.take(0).expect("title hits");
+    let by_tag: Vec<String> = resp.take(1).expect("tag hits");
+    assert_eq!(by_title, ["widget plan"]);
+    assert_eq!(by_tag, by_title);
+
+    let plan = plan_for(
+        &conn,
+        "SELECT id FROM episode WHERE space = 'test' AND title = 'widget plan' EXPLAIN",
+    )
+    .await;
+    assert!(
+        plan.contains("ep_title"),
+        "a title lookup must ride ep_title: {plan}"
+    );
+    let plan = plan_for(
+        &conn,
+        "SELECT id FROM episode WHERE tags CONTAINS 'role:architect' EXPLAIN",
+    )
+    .await;
+    assert!(
+        plan.contains("ep_tags"),
+        "a tag lookup must ride ep_tags: {plan}"
+    );
+}
+
+/// The citation span is a typed sidecar on the memory (issue #132): each
+/// element names an episode and two char offsets, and a memory with no
+/// sidecar at all is still a memory the write path can reinforce.
+#[tokio::test]
+async fn a_span_sidecar_is_typed() {
+    let conn = db::connect("mem://").await.expect("connect mem://");
+    migrate::ensure(&conn).await.expect("migrate");
+    conn.query(
+        "CREATE episode:01M145SMNET1XRYA713EWAQTD5 SET space = 'test',
+             content_hash = 'doc-1', content = 'the user prefers Rust over Python',
+             title = 'preferences', doc_kind = 'report'",
+    )
+    .await
+    .expect("seed")
+    .check()
+    .expect("seed statement");
+
+    assert_eq!(
+        rejection(
+            &conn,
+            "CREATE memory:ulid() SET space = 'test', kind = 'fact', content_hash = 'm-1',
+                 content = 'the user prefers Rust', source = { kind: 'agent' },
+                 spans = [{ ref: episode:01M145SMNET1XRYA713EWAQTD5, start: 0, end: 21 }]",
+        )
+        .await,
+        None,
+        "a span naming an episode with two char offsets is accepted"
+    );
+    for (field, statement) in [
+        (
+            "ref",
+            "CREATE memory:ulid() SET space = 'test', kind = 'fact', content_hash = 'm-2',
+                 content = 'x', source = { kind: 'agent' },
+                 spans = [{ ref: memory:01M145SMNET1XRYA713EWAQTD5, start: 0, end: 1 }]",
+        ),
+        (
+            "start",
+            "CREATE memory:ulid() SET space = 'test', kind = 'fact', content_hash = 'm-3',
+                 content = 'x', source = { kind: 'agent' },
+                 spans = [{ ref: episode:01M145SMNET1XRYA713EWAQTD5, start: 'x', end: 1 }]",
+        ),
+    ] {
+        let err = rejection(&conn, statement)
+            .await
+            .unwrap_or_else(|| panic!("spans.*.{field} must be typed"));
+        assert!(err.contains(field), "{field}: {err}");
+    }
+
+    // A memory written with no sidecar is the common case; reinforcing it is
+    // the UPDATE that re-coerces every field, and it has to land.
+    let space: SpaceName = "test".parse().expect("valid slug");
+    let outcome = repo::insert_batch(
+        &conn,
+        repo::Batch {
+            space: space.clone(),
+            episode: None,
+            memories: vec![repo::NewMemory::new(
+                agmem_core::Kind::Fact,
+                "no sidecar here",
+            )],
+            writer: Writer::default(),
+        },
+    )
+    .await
+    .expect("write");
+    let id = outcome.memories[0].id().clone();
+    repo::reinforce(&conn, &[id])
+        .await
+        .expect("reinforcing a spanless row lands");
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -104,13 +104,15 @@ memory together) trivial.
    │ 1:n (by name)
    ▼
  episode ──1:n──▶ episode_chunk        [FT + HNSW indexes]
-   ▲   (verbatim ground truth, append-only)
+   ▲   (verbatim ground truth, append-only;
+   │    a *document* when `doc_kind` is set — v9, #132)
    │ source.ref (provenance link)
    │
  memory  (distilled: fact | lesson | instruction | summary)
    │  [FT + HNSW indexes; supersession chain within table]
    ├── supersedes / superseded_by ──▶ memory      (version chain)
    ├── derived_from: [record]      ──▶ memory | episode   (reflect citations)
+   ├── spans: [{ref,start,end}]    ──▶ episode   (citation spans, v9; sidecar to derived_from)
    ├── source: {kind, ref}          ▶ episode | external string
    ├── entities: [string]           (denormalized subject index, v1)
    └── tags: [string]
@@ -166,7 +168,16 @@ DEFINE FIELD session      ON episode TYPE option<string>;
 DEFINE FIELD created_at   ON episode TYPE datetime DEFAULT time::now();
 -- v6: which client wrote it (issue #75); sub-fields as on memory.writer
 DEFINE FIELD writer       ON episode TYPE option<object>;
+-- v9 (#132): a document is an episode with a name and a kind; the rest of
+-- the row is unchanged, so one retrieval path and one purge path serve both
+DEFINE FIELD title        ON episode TYPE option<string>;
+DEFINE FIELD doc_kind     ON episode TYPE option<string>
+    ASSERT $value IN ["plan", "review", "report", "probe", "transcript", "other"];
+DEFINE FIELD tags         ON episode TYPE option<array<string>>;
+DEFINE FIELD mime         ON episode TYPE option<string>;
 DEFINE INDEX episode_hash ON episode COLUMNS space, content_hash UNIQUE;
+DEFINE INDEX ep_title     ON episode COLUMNS space, title;   -- v9; not unique: #134 supersedes by title
+DEFINE INDEX ep_tags      ON episode COLUMNS tags.*;         -- v9
 
 DEFINE TABLE episode_chunk SCHEMAFULL;
 DEFINE FIELD episode   ON episode_chunk TYPE record<episode>;
@@ -212,6 +223,10 @@ DEFINE INDEX mem_writer_session ON memory COLUMNS writer.session;
 DEFINE FIELD novelty       ON memory TYPE option<float>;
 -- schema v2: what a `reflect` insight was drawn from; empty for every other write
 DEFINE FIELD derived_from  ON memory TYPE array<record<memory | episode>> DEFAULT [];
+-- v9 (#132): where in a document a claim came from — [{ref: record<episode>,
+-- start, end}] in char offsets of the verbatim content, end exclusive. A
+-- sidecar because `derived_from` carries no payload; NONE where unrecorded
+DEFINE FIELD spans         ON memory TYPE option<array<object>>;
 DEFINE FIELD created_at    ON memory TYPE datetime DEFAULT time::now();
 -- v5: 'live' while invalid_at is NONE, the close time once set — recomputed
 -- on every write, so a close moves the row out of the 'live' slot itself
@@ -250,12 +265,32 @@ Notes:
   MCP `initialize` handshake (never trusted from tool arguments), reads as
   absent on rows older than the field, and is the axis the per-source
   occupancy defense (issue #76) will slice on.
+- A **document** (v9, #132) is an episode with `doc_kind` set; `title` is
+  required alongside it by the write path, not the schema. Identity stays
+  `(space, content_hash)`, and the hash is taken over *normalized* content
+  (lowercased, whitespace-collapsed), so two documents that differ only in
+  case or spacing are one row carrying the first one's verbatim text and
+  title — a re-put reports the existing id and rewrites nothing, because no
+  UPDATE path on `episode` exists. The same content in a second space is a
+  second row with its own chunks: `space` is denormalised onto every chunk
+  and every retrieval arm filters on it, so a cross-space link would still
+  need per-space chunk rows and buys nothing. A `transcript` is refused in
+  the `user` space, since recall reads `user` from every project and a
+  transcript is one project's verbatim text.
+- `spans` (v9) is a sidecar rather than a payload on `derived_from` because
+  that field is a bare record array read through `array::map`. Offsets are
+  Unicode scalar (char) offsets into the verbatim `content` — the unit the
+  100k cap counts — with `end` exclusive, never positions in the normalized
+  text the hash is over. Nothing writes it in v9; it lands with the schema
+  because provenance is the one thing that cannot be backfilled (the v6
+  lesson).
 
 ### 2.3 Kinds, decay classes, and lifecycle
 
 | `kind` | Meaning | Default `decay_class` | Lifecycle |
 |---|---|---|---|
-| (episode table) | Verbatim record of what happened | — (no decay) | Append-only; never superseded; prunable only by `forget --purge` |
+| (episode table) | Verbatim record of what happened | — (no decay) | Append-only; never superseded; prunable only by `forget --purge`, and the claims drawn from it survive the purge |
+| (episode with `doc_kind`) | A named, typed document — plan, review, report, probe, transcript (#132) | — (no decay) | Append-only; a purge is refused while live memories cite it (`source.ref` or `derived_from`) unless `cascade`, which takes those memories too (#134); orphans — no live citer — are reported by `consolidate`, never removed on their own; a new version of a title supersedes the old by convention, not schema (#134) |
 | `fact` | Distilled statement about the world/user/project | `normal` | Supersedable; decays unless recalled |
 | `lesson` | Procedural insight ("X fails when Y; do Z") | `slow` | Supersedable; agent keeps these few and sharp (Reflexion evidence: bounded lessons beat accumulation) |
 | `instruction` | Standing behavioral rule | `pinned` | Active until superseded/forgotten; always in `context` output |
@@ -332,7 +367,9 @@ Input schemas (sketch; exact schemars structs are a phase-1 task):
     "valid_from": "RFC3339"                          // optional (when it became true)
   }],
   "episode": {                                       // optional verbatim ground truth
-    "content": "…", "occurred_at": "RFC3339", "session": "…"
+    "content": "…", "occurred_at": "RFC3339", "session": "…",
+    "title": "…", "doc_kind": "plan|review|report|probe|transcript|other",  // #135: a document;
+    "tags": ["…"], "mime": "text/markdown"           //   title required with doc_kind, transcript refused in `user`
   }
 }
 // → { created: [ids],                // in request order, minus the duplicates
@@ -375,7 +412,8 @@ Input schemas (sketch; exact schemars structs are a phase-1 task):
 // forget
 { "ids": ["memory:01J…", "01J…", "episode:01M…"],   // exact; no dry run needed
   "query": "alternative to ids",                     // dry_run: true required first
-  "space": "…", "purge": false, "dry_run": false }
+  "space": "…", "purge": false, "dry_run": false,
+  "cascade": false }        // #134: purge a cited document together with its citers
 // → { spaces: [searched], dry_run, purge,
 //     matched: [{ id, kind: "memory|episode", content, space,
 //                 invalid_reason?, derived? }],   // derived: claims an episode leaves behind
@@ -392,8 +430,9 @@ Input schemas (sketch; exact schemars structs are a phase-1 task):
   "space": "current|user|all|<name>" }   // default: current + user; all for stats
 // → { ref: canonical form, spaces: [searched],
 //     found: one of
-//       { kind: "memory",  memory, chain: [oldest→newest], episode? }
+//       { kind: "memory",  memory, chain: [oldest→newest], episode? }   // memory.spans? (v9)
 //       { kind: "episode", episode, chunks: [reading order], derived: [claims] }
+//                          // title/doc_kind/tags/mime when a document; #134 adds a window
 //       { kind: "entity",  entity, memories: [live and closed] }
 //       { kind: "stats",   counts: [{ space, memories, live, invalidated,
 //                                     episodes, chunks, live_by_kind }] } }
@@ -414,6 +453,7 @@ Input schemas (sketch; exact schemars structs are a phase-1 task):
 //     stale_contexts:  [{ claim: MemoryView, idle_days, expires_in_days }],
 //     over_full_tags:  [{ space, tag, live, keep,        // fullest first (#82)
 //                         members: [MemoryView] }],      // strongest first
+//     orphan_documents: [{ space, episode }],   // documents no live memory cites (#132 lifecycle)
 //     note? }                          // present only when something limited it
 // Every candidate is a whole `MemoryView`, content included: the #38 finding
 // is that an id and a number are not something an agent can decide on.
@@ -766,7 +806,8 @@ main()
 ```
 remember(params)
  1. validate: space slug, kinds, non-empty contents ≤ 10k chars each, an
-    episode ≤ 100k (#67 — a paste is refused whole, never truncated silently),
+    episode ≤ 100k (#67 — a paste is refused whole, never truncated silently;
+    a document is an episode with `doc_kind` under the same cap, #132),
     supersedes ids exist
  2. per memory: normalize content → blake3
     exact dup? (space, hash) unique index         → report as duplicate (NOOP)
@@ -982,6 +1023,8 @@ ids given   → resolve in each searched space → soft-invalidate (invalid_reas
 query given → BM25 only, memories only → dry_run required first (returns the matches)
               an identical second call with dry_run=false executes, and spends the confirmation
 purge on an episode also purges chunks; purge on a memory keeps its episode
+purge on a document (doc_kind set) is refused while live memories cite it,
+              unless cascade — then the citing memories go with it (#134)
 ```
 
 
@@ -1011,6 +1054,13 @@ asked it to":
   anyone forgets — and the claims distilled from it survive it, still naming
   the source. `inspect` therefore treats a `source` naming no episode as
   history rather than as a broken store.
+
+  That is the rule for *anonymous* episodes. A document (v9, #132) inverts
+  it: a purge is refused while any live memory cites it — through
+  `source.ref` **or** `derived_from`, both columns, where today's `derived`
+  projection reads only the first — unless `cascade` is set, in which case
+  the citing memories are purged with it (#134). A cascade that merely
+  orphaned them would be the anonymous rule under a new name.
 
 ### 5.5 Maintenance without a scheduler
 
@@ -1175,6 +1225,11 @@ Each phase is releasable; later phases only add.
 - **Phase 4 — polish:** `--reindex` (embedder migration);
   packaging (cargo-dist, Homebrew); `memory://` resources; eval harness;
   `ws://` sharing-mode hardening docs.
+- **Phase 9 — Documents (#132, #134–#137):** a named, typed artifact tier
+  over the episode table (v9 schema, span sidecar); windowed `inspect`, title
+  supersession and cascade purge; `agmem doc` CLI + `agmem://<space>/doc/{id}`
+  resource; the ctx-flow framework moves off `.claude/notes/`; recall-precision
+  eval with documents present.
 
 ## 9. Risks & open questions
 


### PR DESCRIPTION
## What

Schema v9 (`crates/agmem-store/src/migrations/v9_documents.surql`): optional `title`, `doc_kind` (enum-asserted), `tags`, `mime` on `episode`; indexes `ep_title (space, title)` and `ep_tags`; a typed `spans` sidecar on `memory` (`[{ref: record<episode>, start, end}]`, char offsets into the verbatim content). No UPDATE, no backfill.

design.md: §2.1/§2.2 schema delta with the identity and span notes, §2.3 lifecycle row for documents, §3.1 tool-contract deltas marked with their follow-ups (#134/#135), §5.2 cap note, §5.4 two-regime purge rule, §8 Phase 9.

## Decisions (issue's six points)

1. Extend `episode`, no second table.
2. Cross-space dedupe out of scope for v1: `space` is denormalised onto every chunk, so a link table buys nothing yet. Noted: the hash is over *normalized* text, so case/whitespace variants dedupe to the first document.
3. Span is a sidecar on memory, not on the link (impossible: `derived_from` carries no payload).
4. Documents refuse a purge while cited (`source.ref` or `derived_from`) unless `cascade`; anonymous episodes keep today's rule. Orphans become a `consolidate` list. Code lands in #134.
5. 100k cap stands.
6. `user` space allowed; `transcript` refused there (Rust validation, #135).

## Tests

Three new tests in `tests/migrate.rs`: pre-v9 episode still reads and purges; document enum + both indexes ride (EXPLAIN); span sidecar typing and a spanless row still reinforces. Workspace suite 356 passed, protocol snapshot unchanged.

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8VSNVwAQjNZ7EynoJVv1t