### PR TITLE
The document tier from the shell, and as a resource (#135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,31 @@ agmem context --query "release work" --budget-chars 4000
 It attaches to the running daemon, or starts the one the session is about to
 reuse, and prints the same block the MCP tool returns.
 
+### Documents from the shell
+
+A subagent has a shell before it has MCP tools, and a plan handed around by
+id is a plan nobody has to find on disk. `agmem doc` is the document tier as
+four shell verbs, each the MCP tool it mirrors — `remember`, `inspect`,
+`forget` — with the document fields as flags:
+
+```sh
+agmem doc put --title plan-x --kind plan --tag role:architect < plan.md
+# 01K4…  memory://myproject/doc/01K4…
+agmem doc get plan-x --raw                 # the newest version, as stored
+agmem doc get 01K4… --offset 0 --limit 4000
+agmem doc list --kind plan
+agmem doc forget 01K4… --purge [--cascade]
+```
+
+`put` prints the id and the resource URI on one line — what an agent returns
+to the main thread instead of a path. A second `put` under the same title is
+a new version; `get <title>` resolves to the newest, and every version stays
+readable by id. The same document is an MCP resource at
+`memory://<space>/doc/<id>`, served as its own text under its own media type,
+so a client's `@` picker can attach it like a file; `resources/list` shows the
+newest ten per space, and a `recall` hit that slices a document carries a
+`resource_link` to it.
+
 ## The loop
 
 Seven tools. Two MCP prompts, which Claude Code shows as slash commands, ask
@@ -297,7 +322,7 @@ Every flag has an environment variable. `agmem --help` has the exact spellings.
 | `--log`, `--log-file` | `info` to stderr | Telemetry. stdout is the MCP wire and stays empty |
 | `AGMEM_TOOL_DESC_<TOOL>` | built-in wording | Replace one tool's description, per server, no rebuild |
 | `FASTEMBED_CACHE_DIR` | `<data>/models` | Where the embedding model lives |
-| `--doctor` | | Self-check, then exit |
+| `--doctor` | | Self-check, then exit. Counts documents per space |
 | `--reindex` | | Re-embed every row under the configured embedder. The one way to change models |
 
 A tool description is most of what decides whether an agent reaches for

--- a/crates/agmem-server/src/config.rs
+++ b/crates/agmem-server/src/config.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use agmem_core::SpaceName;
+use agmem_core::{DocKind, SpaceName};
 use anyhow::{Context, bail};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
@@ -136,6 +136,142 @@ pub enum CliCommand {
     /// Answer a Claude Code hook event: read the payload on stdin, print the
     /// reply, exit 0. The shell side of the agmem plugin (`plugin/`).
     Hook(HookArgs),
+
+    /// Store, read, list or forget a document — a named, typed text — from
+    /// the shell, with no MCP session.
+    Doc(DocArgs),
+}
+
+/// The `agmem doc` verbs (#135): the shell door into the document tier, for
+/// subagents that have a shell but no MCP tools, and for anything that wants
+/// to hand a plan around by id instead of by path.
+#[derive(Debug, Clone, PartialEq, Eq, Args)]
+pub struct DocArgs {
+    #[command(subcommand)]
+    pub verb: DocVerb,
+}
+
+/// One document operation. Each is the MCP tool it mirrors — `remember`,
+/// `inspect`, `forget` — with the document parameters as flags.
+#[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
+pub enum DocVerb {
+    /// Store stdin as a document. Prints `<id> <uri>` on one line — the
+    /// address to hand on instead of a file path.
+    Put(DocPutArgs),
+
+    /// Print a document: by id, or by title for the newest version under it.
+    Get(DocGetArgs),
+
+    /// List a space's documents, newest first.
+    List(DocListArgs),
+
+    /// Forget a document, or purge it and its slices outright.
+    Forget(DocForgetArgs),
+}
+
+/// What `agmem doc put` passes to `remember`'s episode arm.
+#[derive(Debug, Clone, PartialEq, Eq, Args)]
+pub struct DocPutArgs {
+    /// The document's name. A second put under the same title is a new
+    /// version; `get <title>` resolves to the newest, and every version
+    /// stays readable by id.
+    #[arg(long)]
+    pub title: String,
+
+    /// What the document is: plan, review, report, probe, transcript or other.
+    #[arg(long, value_parser = parse_doc_kind)]
+    pub kind: DocKind,
+
+    /// A label to list by. Repeatable.
+    #[arg(long = "tag", value_name = "TAG")]
+    pub tags: Vec<String>,
+
+    /// The content's media type, served as the resource's mime type.
+    #[arg(long, default_value = "text/markdown")]
+    pub mime: String,
+
+    /// Where to write: `current` (the default), `user`, or a space name.
+    #[arg(long)]
+    pub space: Option<String>,
+}
+
+/// What `agmem doc get` passes to `inspect`.
+#[derive(Debug, Clone, PartialEq, Eq, Args)]
+pub struct DocGetArgs {
+    /// A document id, or a title. An id is tried first; a title resolves
+    /// to the newest version stored under it.
+    #[arg(value_name = "ID | TITLE")]
+    pub reference: String,
+
+    /// Start of the window, in characters. 0 by default.
+    #[arg(long, value_name = "N")]
+    pub offset: Option<usize>,
+
+    /// Length of the window, in characters. The whole document by default.
+    #[arg(long, value_name = "N")]
+    pub limit: Option<usize>,
+
+    /// Print the content alone, as stored. Without this the answer is the
+    /// `inspect` JSON: the content, its versions, and what cites it.
+    #[arg(long)]
+    pub raw: bool,
+
+    /// Where to look: `current`, `user`, `all`, or a space name. Defaults
+    /// to `current` and `user` together for an id, `current` for a title.
+    #[arg(long)]
+    pub space: Option<String>,
+}
+
+/// What `agmem doc list` passes to `inspect`'s `docs:` form.
+#[derive(Debug, Clone, PartialEq, Eq, Args)]
+pub struct DocListArgs {
+    /// Keep only this kind. Repeatable.
+    #[arg(long = "kind", value_name = "KIND", value_parser = parse_doc_kind)]
+    pub kinds: Vec<DocKind>,
+
+    /// Keep only documents carrying this tag. Repeatable.
+    #[arg(long = "tag", value_name = "TAG")]
+    pub tags: Vec<String>,
+
+    /// The space to list: `current` (the default), `user`, or a name.
+    #[arg(long)]
+    pub space: Option<String>,
+
+    /// Print the `inspect` JSON instead of one line per document.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// What `agmem doc forget` passes to `forget`.
+#[derive(Debug, Clone, PartialEq, Eq, Args)]
+pub struct DocForgetArgs {
+    /// The document id.
+    pub id: String,
+
+    /// Delete outright — the text and its slices. Unrecoverable.
+    #[arg(long)]
+    pub purge: bool,
+
+    /// When purging a document live claims still cite: purge those claims
+    /// with it. Without this the purge is refused and names them.
+    #[arg(long, requires = "purge")]
+    pub cascade: bool,
+
+    /// Where to look: `current`, `user`, `all`, or a space name. Defaults
+    /// to `current` and `user` together.
+    #[arg(long)]
+    pub space: Option<String>,
+}
+
+/// `--kind` as a [`DocKind`], with the spellings that would have worked.
+fn parse_doc_kind(text: &str) -> Result<DocKind, String> {
+    text.parse().map_err(|_| {
+        let kinds: Vec<&str> = DocKind::ALL.iter().map(|kind| kind.as_str()).collect();
+        format!(
+            "`{text}` is not a document kind; one of {}",
+            kinds.join(", ")
+        )
+    })
 }
 
 /// Which event `agmem hook` is answering.

--- a/crates/agmem-server/src/doc.rs
+++ b/crates/agmem-server/src/doc.rs
@@ -1,0 +1,324 @@
+//! `agmem doc` — the document tier from the shell (#135).
+//!
+//! Subagents have a shell and not always the MCP tools, and a plan handed
+//! around by id is a plan nothing has to `cat`. So the four document verbs
+//! are one-shots on the `agmem context` pattern (`oneshot.rs`): attach to the
+//! shared daemon where a session would, else open the store here — never a
+//! second writer beside a daemon that owns the store — and call the tool a
+//! session would have called: `remember` for `put`, `inspect` for `get` and
+//! `list`, `forget` for `forget`.
+//!
+//! Every verb goes through the tool's own JSON answer, on both routes, so
+//! what the shell prints is what an MCP client would have seen: the same
+//! refusals, the same window, the same versions. The daemon route reads the
+//! tool result's structured content; the direct route serialises the typed
+//! result. The rendering is the only thing added here.
+
+use agmem_core::{EpisodeId, SpaceName, Writer};
+use anyhow::{Context as _, bail};
+use serde_json::{Value, json};
+
+use crate::config::{Config, DocArgs, DocForgetArgs, DocGetArgs, DocListArgs, DocPutArgs, DocVerb};
+use crate::resources;
+use crate::tools::remember::MAX_EPISODE_CHARS;
+
+/// Run one verb, print its answer, exit — the whole subcommand.
+///
+/// stdout is the answer here, not the MCP wire: one-shot mode is the single
+/// place outside the transport where the crate-wide deny is lifted.
+///
+/// # Errors
+/// When no route to the store works, stdin cannot be read, or the tool
+/// refuses the parameters.
+#[allow(clippy::print_stdout)]
+pub async fn run(cfg: Config, args: DocArgs) -> anyhow::Result<()> {
+    let answer = match args.verb {
+        DocVerb::Put(put) => {
+            let content = std::io::read_to_string(std::io::stdin())
+                .context("reading the document on stdin")?;
+            self::put(&cfg, put, content).await?
+        }
+        DocVerb::Get(get) => self::get(&cfg, get).await?,
+        DocVerb::List(list) => self::list(&cfg, list).await?,
+        DocVerb::Forget(forget) => self::forget(&cfg, forget).await?,
+    };
+    // The verbs end their own lines: raw content is printed as stored.
+    print!("{answer}");
+    Ok(())
+}
+
+/// Store `content` as a document; the answer is `<id> <uri>` on one line.
+///
+/// # Errors
+/// When the tool refuses — an empty or oversize document, a transcript in
+/// the `user` space — or no route to the store works.
+pub async fn put(cfg: &Config, args: DocPutArgs, content: String) -> anyhow::Result<String> {
+    let DocPutArgs {
+        title,
+        kind,
+        tags,
+        mime,
+        space,
+    } = args;
+    let arguments = json!({
+        "space": space,
+        "memories": [],
+        "episode": {
+            "content": content,
+            "title": title,
+            "doc_kind": kind,
+            "tags": tags,
+            "mime": mime,
+        }
+    });
+    let answer = call(cfg, "remember", arguments).await?;
+    let id = answer["episode"]
+        .as_str()
+        .context("remember answered without an episode id; agmem versions disagree?")?;
+    // The tool resolved the space before writing, so a name that reached
+    // here is one the store holds; `current` is this run's own.
+    let space = written_space(cfg, space.as_deref())?;
+    Ok(format!(
+        "{id} {uri}\n",
+        uri = resources::document_uri(space.as_str(), id)
+    ))
+}
+
+/// Read a document by id or title: the `inspect` JSON, or the content alone.
+///
+/// # Errors
+/// When nothing answers to the reference, it names something that is not a
+/// document (under `--raw`), or no route to the store works.
+pub async fn get(cfg: &Config, args: DocGetArgs) -> anyhow::Result<String> {
+    let DocGetArgs {
+        reference,
+        offset,
+        limit,
+        raw,
+        space,
+    } = args;
+    // An id is tried first: a title that happens to be a ULID is a title
+    // nobody would choose, and `--help` says which wins.
+    let reference = if reference.parse::<EpisodeId>().is_ok() {
+        format!("episode:{reference}")
+    } else {
+        format!(
+            "doc:{space}/{reference}",
+            space = space.as_deref().unwrap_or("current")
+        )
+    };
+    // The tool's default window on a document is one chunk — right for an
+    // agent paging, wrong for a shell that asked for the file. No limit
+    // here means the whole document, which the write cap bounds.
+    let arguments = json!({
+        "ref": reference,
+        "space": space,
+        "offset": offset,
+        "limit": limit.or(Some(MAX_EPISODE_CHARS)),
+    });
+    let answer = call(cfg, "inspect", arguments).await?;
+    if !raw {
+        return pretty(&answer);
+    }
+    let Some(content) = answer["found"]["episode"]["content"].as_str() else {
+        bail!("{reference} is not a document; `agmem doc get` without --raw shows what it is");
+    };
+    Ok(content.to_owned())
+}
+
+/// List a space's documents, newest first — one line each, or the JSON.
+///
+/// # Errors
+/// When the space is unknown or no route to the store works.
+pub async fn list(cfg: &Config, args: DocListArgs) -> anyhow::Result<String> {
+    let DocListArgs {
+        kinds,
+        tags,
+        space,
+        json: as_json,
+    } = args;
+    let arguments = json!({
+        "ref": format!("docs:{}", space.as_deref().unwrap_or("current")),
+        "doc_kinds": kinds,
+        "tags": tags,
+    });
+    let answer = call(cfg, "inspect", arguments).await?;
+    if as_json {
+        return pretty(&answer);
+    }
+    let documents = answer["found"]["documents"]
+        .as_array()
+        .context("inspect answered without a listing; agmem versions disagree?")?;
+    Ok(documents.iter().map(line).collect())
+}
+
+/// One listing line: id, kind, size, citations, date, title — the id first
+/// so a `cut -d' ' -f1` gets what `get` and `forget` take.
+fn line(document: &Value) -> String {
+    let field = |name: &str| document[name].as_str().unwrap_or("?").to_owned();
+    format!(
+        "{id}  {kind:<10}  {chars:>7} chars  cited {cited:<3}  {created}  {title}\n",
+        id = field("id"),
+        kind = field("doc_kind"),
+        chars = document["chars"].as_u64().unwrap_or(0),
+        cited = document["cited"].as_u64().unwrap_or(0),
+        created = field("created_at"),
+        title = field("title"),
+    )
+}
+
+/// Forget a document — close it, or purge it and its slices.
+///
+/// # Errors
+/// When the id names nothing, a purge is refused because live claims cite
+/// the document and `--cascade` was not given, or no route to the store
+/// works.
+pub async fn forget(cfg: &Config, args: DocForgetArgs) -> anyhow::Result<String> {
+    let DocForgetArgs {
+        id,
+        purge,
+        cascade,
+        space,
+    } = args;
+    let arguments = json!({
+        "ids": [format!("episode:{id}")],
+        "space": space,
+        "purge": purge,
+        "cascade": cascade,
+    });
+    let answer = call(cfg, "forget", arguments).await?;
+    let names = |key: &str| -> Vec<String> {
+        answer[key]
+            .as_array()
+            .map(|ids| {
+                ids.iter()
+                    .filter_map(Value::as_str)
+                    .map(str::to_owned)
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    let purged = names("purged");
+    let invalidated = names("invalidated");
+    Ok(if purge {
+        format!(
+            "purged {count} record(s), {chunks} chunk(s): {ids}\n",
+            count = purged.len(),
+            chunks = answer["chunks_purged"].as_u64().unwrap_or(0),
+            ids = purged.join(", ")
+        )
+    } else {
+        format!(
+            "forgot {count} record(s): {ids}\n",
+            count = invalidated.len(),
+            ids = invalidated.join(", ")
+        )
+    })
+}
+
+/// The space a `put` landed in, for the URI: this run's own for `current`
+/// or nothing, else the name given.
+fn written_space(cfg: &Config, space: Option<&str>) -> anyhow::Result<SpaceName> {
+    match space {
+        None | Some("current") => Ok(cfg.space.clone()),
+        Some(name) => name
+            .parse()
+            .with_context(|| format!("`{name}` is not a space name")),
+    }
+}
+
+/// The tool's JSON answer, by whichever route this configuration serves.
+async fn call(cfg: &Config, tool: &'static str, arguments: Value) -> anyhow::Result<Value> {
+    #[cfg(unix)]
+    if crate::daemon::wanted(cfg) {
+        return through_daemon(cfg, tool, arguments).await;
+    }
+    direct(cfg, tool, arguments).await
+}
+
+/// Ask a shared daemon, as a real MCP client on the session socket.
+#[cfg(unix)]
+async fn through_daemon(
+    cfg: &Config,
+    tool: &'static str,
+    arguments: Value,
+) -> anyhow::Result<Value> {
+    use rmcp::model::{CallToolRequestParams, ContentBlock};
+
+    let session = crate::oneshot::daemon_session(cfg).await?;
+    let arguments = arguments
+        .as_object()
+        .cloned()
+        .context("tool arguments are an object")?;
+    let result = session
+        .call_tool(CallToolRequestParams::new(tool).with_arguments(arguments))
+        .await
+        .map_err(|error| anyhow::anyhow!("the {tool} tool refused: {error}"))?;
+    // Detach politely so the daemon logs a session that ended, not one that
+    // broke; the answer is already in hand either way.
+    let _ = session.cancel().await;
+
+    let text = || {
+        result
+            .content
+            .iter()
+            .filter_map(|block| match block {
+                ContentBlock::Text(text) => Some(text.text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    if result.is_error == Some(true) {
+        bail!("the {tool} tool answered with an error: {}", text());
+    }
+    if let Some(value) = result.structured_content {
+        return Ok(value);
+    }
+    serde_json::from_str(&text())
+        .context("the tool answered with no JSON; agmem versions disagree?")
+}
+
+/// Open the store in this process and call the tool with no wire at all.
+async fn direct(cfg: &Config, tool: &'static str, arguments: Value) -> anyhow::Result<Value> {
+    use crate::tools::{forget, inspect, remember};
+
+    let (service, lock) = crate::oneshot::open_direct(cfg).await?;
+    let refused = |error: rmcp::ErrorData| anyhow::anyhow!("the {tool} tool refused: {error}");
+    let answer = match tool {
+        "remember" => {
+            // Who wrote it (issue #75): no MCP handshake here, so the CLI
+            // introduces itself, and the session is the one this process
+            // minted for itself.
+            let writer = Writer {
+                client: "agmem-cli".to_owned(),
+                client_version: Some(env!("CARGO_PKG_VERSION").to_owned()),
+                session: service.session().to_owned(),
+                tool: tool.to_owned(),
+            };
+            let params = serde_json::from_value(arguments)?;
+            serde_json::to_value(
+                remember::run(&service, params, writer)
+                    .await
+                    .map_err(refused)?,
+            )?
+        }
+        "inspect" => {
+            let params = serde_json::from_value(arguments)?;
+            serde_json::to_value(inspect::run(&service, params).await.map_err(refused)?)?
+        }
+        "forget" => {
+            let params = serde_json::from_value(arguments)?;
+            serde_json::to_value(forget::run(&service, params).await.map_err(refused)?)?
+        }
+        other => bail!("`agmem doc` has no direct route for the {other} tool"),
+    };
+    drop(lock);
+    Ok(answer)
+}
+
+fn pretty(answer: &Value) -> anyhow::Result<String> {
+    let mut text = serde_json::to_string_pretty(answer)?;
+    text.push('\n');
+    Ok(text)
+}

--- a/crates/agmem-server/src/doctor.rs
+++ b/crates/agmem-server/src/doctor.rs
@@ -98,6 +98,13 @@ async fn check_store(cfg: &Config) -> u32 {
                     eprintln!("  FAIL  write/read roundtrip {err}");
                 }
             }
+            match document_counts(&db).await {
+                Ok(detail) => eprintln!("  ok    documents            {detail}"),
+                Err(err) => {
+                    failures += 1;
+                    eprintln!("  FAIL  documents            {err}");
+                }
+            }
             Some(db)
         }
         Err(err) => {
@@ -174,6 +181,27 @@ async fn vector_coverage(db: &Db) -> Result<String, String> {
     }
 }
 
+/// How many documents each registered space holds (#135): the named, typed
+/// episodes `agmem doc put` writes and the `@` picker lists. A count, not a
+/// check — it cannot fail short of the store failing — but it is the one
+/// number that says whether the document tier is in use at all.
+async fn document_counts(db: &Db) -> Result<String, String> {
+    let spaces = agmem_store::repo::spaces(db)
+        .await
+        .map_err(|err| err.to_string())?;
+    let mut parts = Vec::with_capacity(spaces.len());
+    for space in &spaces {
+        let stats = agmem_store::repo::stats(db, space)
+            .await
+            .map_err(|err| err.to_string())?;
+        parts.push(format!("{space}: {}", stats.documents));
+    }
+    if parts.is_empty() {
+        return Ok("no space registered yet".to_owned());
+    }
+    Ok(parts.join(", "))
+}
+
 /// One check over an open store, as the daemon logs it at start (issue #112)
 /// and `--doctor` prints it.
 #[derive(Debug)]
@@ -206,6 +234,10 @@ pub async fn selfcheck(db: &Db, embedder: &dyn Embedder) -> Vec<Check> {
             outcome: vector_coverage(db).await,
         });
     }
+    checks.push(Check {
+        name: "documents",
+        outcome: document_counts(db).await,
+    });
     checks
 }
 
@@ -326,8 +358,13 @@ mod tests {
         );
         assert_eq!(
             checks.len(),
-            1,
+            2,
             "with no vector side there is no coverage to check: {checks:?}"
+        );
+        assert_eq!(
+            checks[1].outcome.as_deref(),
+            Ok("no space registered yet"),
+            "a store nothing registered in has nothing to count: {checks:?}"
         );
     }
 }

--- a/crates/agmem-server/src/lib.rs
+++ b/crates/agmem-server/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod config;
 pub mod daemon;
+pub mod doc;
 pub mod doctor;
 pub mod embedder;
 pub mod hook;

--- a/crates/agmem-server/src/main.rs
+++ b/crates/agmem-server/src/main.rs
@@ -10,15 +10,18 @@
 //!   pump stdio into it, so several sessions share one embedded store.
 //! - `--no-daemon`, a remote `--db`, or a non-Unix platform — open the store
 //!   in this process, which is what agmem always did.
-//! - a subcommand (`agmem context`, issue #46) — answer once on stdout and
-//!   exit, choosing between the two shapes above the same way.
+//! - a subcommand (`agmem context`, issue #46; `agmem doc`, issue #135) —
+//!   answer once on stdout and exit, choosing between the two shapes above
+//!   the same way.
 
 use std::sync::Arc;
 
 #[cfg(unix)]
 use agmem_server::daemon;
 use agmem_server::service::{self, AgmemService};
-use agmem_server::{config, doctor, embedder, hook, lock, oneshot, reindex, startup, telemetry};
+use agmem_server::{
+    config, doc, doctor, embedder, hook, lock, oneshot, reindex, startup, telemetry,
+};
 use clap::Parser;
 
 #[tokio::main]
@@ -49,6 +52,7 @@ async fn main() -> anyhow::Result<()> {
     match cfg.command.clone() {
         Some(config::CliCommand::Context(args)) => return oneshot::context(cfg, args).await,
         Some(config::CliCommand::Hook(args)) => return hook::run(cfg, args.event).await,
+        Some(config::CliCommand::Doc(args)) => return doc::run(cfg, args).await,
         None => {}
     }
 

--- a/crates/agmem-server/src/oneshot.rs
+++ b/crates/agmem-server/src/oneshot.rs
@@ -54,15 +54,57 @@ pub async fn fetch(cfg: &Config, args: ContextArgs) -> anyhow::Result<String> {
     direct(cfg, args).await
 }
 
+/// A live MCP session on the shared daemon, attached or freshly started.
+///
+/// # Errors
+/// When no daemon can be reached or started, or the handshake fails.
+#[cfg(unix)]
+pub(crate) async fn daemon_session(
+    cfg: &Config,
+) -> anyhow::Result<rmcp::service::RunningService<rmcp::RoleClient, ()>> {
+    use anyhow::Context as _;
+    use rmcp::ServiceExt as _;
+
+    let (read, write) = crate::daemon::client::attach(cfg).await?.into_split();
+    ().serve((read, write))
+        .await
+        .context("initializing MCP with the shared store")
+}
+
+/// The store, opened in this process the way `main::in_process` opens it —
+/// lock, open, migrate, embedder check, prune, register — so a one-shot
+/// sees exactly the state a served session would.
+///
+/// The lock rides along: dropping the pair releases it, and a caller that
+/// wants the store for longer keeps the pair for longer.
+///
+/// # Errors
+/// When the lock is held elsewhere, the store will not open or migrate, or
+/// the embedder disagrees with what the store was written with.
+pub(crate) async fn open_direct(
+    cfg: &Config,
+) -> anyhow::Result<(AgmemService, Option<lock::DataDirLock>)> {
+    let lock = if cfg.db_is_remote() {
+        None
+    } else {
+        Some(lock::acquire(&cfg.data_dir)?)
+    };
+    let db = agmem_store::db::connect_with(&cfg.db_url, cfg.db_credentials()).await?;
+    agmem_store::migrate::ensure(&db).await?;
+    let embedder = embedder::build(cfg)?;
+    agmem_store::migrate::ensure_embedder(&db, embedder.model_id(), embedder.dim()).await?;
+    let pruned = crate::startup::prune(&db).await;
+    agmem_store::repo::ensure_space(&db, &cfg.space).await?;
+    tracing::debug!(pruned, "store opened for a one-shot");
+    Ok((AgmemService::new(db, embedder, Arc::new(cfg.clone())), lock))
+}
+
 /// Ask a shared daemon, as a real MCP client on the session socket.
 #[cfg(unix)]
 async fn through_daemon(cfg: &Config, args: ContextArgs) -> anyhow::Result<String> {
-    use anyhow::Context as _;
-    use rmcp::ServiceExt as _;
     use rmcp::model::CallToolRequestParams;
 
-    let (read, write) = crate::daemon::client::attach(cfg).await?.into_split();
-    let session = ().serve((read, write)).await.context("initializing MCP with the shared store")?;
+    let session = daemon_session(cfg).await?;
 
     let ContextArgs {
         query,
@@ -91,25 +133,8 @@ async fn through_daemon(cfg: &Config, args: ContextArgs) -> anyhow::Result<Strin
 }
 
 /// Open the store in this process and call the tool with no wire at all.
-///
-/// The startup mirrors `main::in_process` — lock, open, migrate, embedder
-/// check, prune, register — so the block is assembled from exactly the store
-/// state a served session would see.
 async fn direct(cfg: &Config, args: ContextArgs) -> anyhow::Result<String> {
-    let lock = if cfg.db_is_remote() {
-        None
-    } else {
-        Some(lock::acquire(&cfg.data_dir)?)
-    };
-    let db = agmem_store::db::connect_with(&cfg.db_url, cfg.db_credentials()).await?;
-    agmem_store::migrate::ensure(&db).await?;
-    let embedder = embedder::build(cfg)?;
-    agmem_store::migrate::ensure_embedder(&db, embedder.model_id(), embedder.dim()).await?;
-    let pruned = crate::startup::prune(&db).await;
-    agmem_store::repo::ensure_space(&db, &cfg.space).await?;
-    tracing::debug!(pruned, "store opened for a one-shot context");
-
-    let service = AgmemService::new(db, embedder, Arc::new(cfg.clone()));
+    let (service, lock) = open_direct(cfg).await?;
     let params = ContextParams {
         query: args.query,
         space: args.space,

--- a/crates/agmem-server/src/resources.rs
+++ b/crates/agmem-server/src/resources.rs
@@ -12,18 +12,25 @@
 //! |---|---|
 //! | `memory://<space>` | the index: the space's live claims, slim, marked when cut |
 //! | `memory://<space>/<id>` | the full `inspect` answer for that id |
+//! | `memory://<space>/doc/<id>` | a document's text as stored, under its own media type (#135) |
 //!
-//! `resources/list` serves one entry per registered space; the record form is
-//! published as a *template*, because a store of a thousand claims must not
-//! push a thousand rows at every client that renders the list as a menu. The
-//! index is where the concrete URIs come from: each entry carries its own.
+//! `resources/list` serves one entry per registered space, plus the newest
+//! few documents of the spaces this session reads — enough for a client's
+//! `@` picker, which is not a file browser. The record and document forms
+//! are published as *templates*, because a store of a thousand claims must
+//! not push a thousand rows at every client that renders the list as a menu.
+//! The index is where the concrete URIs come from: each entry carries its own.
 //!
-//! Everything is `application/json`, shaped by the same serde types the tools
-//! answer with — a resource that renders differently from the tool it mirrors
-//! would be two answers to one question.
+//! Everything but a document is `application/json`, shaped by the same serde
+//! types the tools answer with — a resource that renders differently from
+//! the tool it mirrors would be two answers to one question. A document is
+//! the exception on purpose: its JSON form is still there at
+//! `memory://<space>/<id>`, and the `doc/` form exists so a plan can be
+//! attached to a conversation the way a file is.
 
-use agmem_core::SpaceName;
-use agmem_store::repo::{self, Lookup};
+use agmem_core::{Episode, EpisodeId, SpaceName};
+use agmem_store::StoreError;
+use agmem_store::repo::{self, DocumentFilter, Lookup};
 use rmcp::ErrorData;
 use rmcp::model::{
     ErrorCode, ListResourceTemplatesResult, ListResourcesResult, ReadResourceResult, Resource,
@@ -42,6 +49,22 @@ const MIME: &str = "application/json";
 /// the space never contains a slash and the id never needs escaping: spaces
 /// are validated slugs and ids are ULIDs.
 const SCHEME: &str = "memory://";
+
+/// The path segment that tells the document form from the record form.
+const DOC_SEGMENT: &str = "doc/";
+
+/// What a document reads as when it was stored without a media type.
+const DOC_MIME: &str = "text/plain";
+
+/// How many documents per space `resources/list` shows: the newest, for a
+/// picker — every document still answers at its own URI.
+const LISTED_DOCUMENTS: usize = 10;
+
+/// The `memory://<space>/doc/<id>` form of a document — what `agmem doc put`
+/// prints and what a `recall` hit's `resource_link` points at.
+pub fn document_uri(space: &str, id: &str) -> String {
+    format!("{SCHEME}{space}/{DOC_SEGMENT}{id}")
+}
 
 /// The index a `memory://<space>` read answers with.
 #[derive(Debug, Serialize)]
@@ -76,7 +99,8 @@ struct IndexEntry {
     content: String,
 }
 
-/// One resource per registered space.
+/// One resource per registered space, then the newest documents of the
+/// spaces this session reads — `current` and `user`, recall's default pair.
 ///
 /// # Errors
 /// [`ErrorData`] with `INTERNAL_ERROR` for a failing store.
@@ -84,7 +108,7 @@ pub async fn list(service: &AgmemService) -> Result<ListResourcesResult, ErrorDa
     let spaces = repo::spaces(service.db())
         .await
         .map_err(|error| store_error(&error))?;
-    let resources = spaces
+    let mut resources: Vec<Resource> = spaces
         .into_iter()
         .map(|space| {
             Resource::new(format!("{SCHEME}{space}"), space.to_string())
@@ -96,7 +120,48 @@ pub async fn list(service: &AgmemService) -> Result<ListResourcesResult, ErrorDa
                 .with_mime_type(MIME)
         })
         .collect();
+
+    let mut attached = vec![service.config().space.clone()];
+    if !attached.contains(&SpaceName::user()) {
+        attached.push(SpaceName::user());
+    }
+    let filter = DocumentFilter {
+        kinds: Vec::new(),
+        tags: Vec::new(),
+        limit: LISTED_DOCUMENTS,
+    };
+    for space in &attached {
+        let documents = repo::documents(service.db(), space, &filter)
+            .await
+            .map_err(|error| store_error(&error))?;
+        resources.extend(
+            documents
+                .into_iter()
+                .map(|summary| document_resource(space, &summary.episode)),
+        );
+    }
     Ok(ListResourcesResult::with_all_items(resources))
+}
+
+/// A document as a listed resource: named by its title, sized, typed.
+fn document_resource(space: &SpaceName, episode: &Episode) -> Resource {
+    let title = episode.title.clone().unwrap_or_default();
+    let kind = episode
+        .doc_kind
+        .map_or("document", agmem_core::DocKind::as_str);
+    let mut description = format!("A {kind} in `{space}`");
+    if !episode.tags.is_empty() {
+        description.push_str(", tagged ");
+        description.push_str(&episode.tags.join(", "));
+    }
+    Resource::new(
+        document_uri(space.as_str(), episode.id.as_str()),
+        title.clone(),
+    )
+    .with_title(title)
+    .with_description(description)
+    .with_mime_type(episode.mime.as_deref().unwrap_or(DOC_MIME))
+    .with_size(episode.content.len() as u64)
 }
 
 /// The record form, as a template rather than a listing (see the module doc).
@@ -110,6 +175,14 @@ pub fn templates() -> ListResourceTemplatesResult {
                  memory, episode, or chunk.",
             )
             .with_mime_type(MIME),
+        ResourceTemplate::new(format!("{SCHEME}{{space}}/{DOC_SEGMENT}{{id}}"), "document")
+            .with_title("One document, as text")
+            .with_description(
+                "A named, typed document's text as stored, under its own media \
+                 type — the address `agmem doc put` prints, and where a `recall` \
+                 hit from a document links to. Its JSON form, with versions and \
+                 what cites it, is the record form of the same id.",
+            ),
     ])
 }
 
@@ -121,13 +194,16 @@ pub fn templates() -> ListResourceTemplatesResult {
 pub async fn read(service: &AgmemService, uri: &str) -> Result<ReadResourceResult, ErrorData> {
     let Some(path) = uri.strip_prefix(SCHEME) else {
         return Err(not_found(format!(
-            "no such resource: {uri} — this server serves {SCHEME}<space> and \
-             {SCHEME}<space>/<id>"
+            "no such resource: {uri} — this server serves {SCHEME}<space>, \
+             {SCHEME}<space>/<id> and {SCHEME}<space>/{DOC_SEGMENT}<id>"
         )));
     };
     let text = match path.split_once('/') {
         None => index(service, path).await?,
-        Some((space, id)) => record(service, space, id).await?,
+        Some((space, rest)) => match rest.strip_prefix(DOC_SEGMENT) {
+            Some(id) => return document(service, space, id, uri).await,
+            None => record(service, space, rest).await?,
+        },
     };
     Ok(ReadResourceResult::new(vec![
         ResourceContents::text(text, uri).with_mime_type(MIME),
@@ -218,6 +294,42 @@ async fn record(service: &AgmemService, space: &str, id: &str) -> Result<String,
         }
     })?;
     render(&result)
+}
+
+/// The `memory://<space>/doc/<id>` form: the text, as stored, as itself.
+///
+/// The one resource that is not a tool's JSON: a client attaching a plan
+/// wants the plan, not an envelope around it. Anonymous text has no name to
+/// attach by and answers only at its record form, so it is a miss here — a
+/// miss that says where the text does read.
+async fn document(
+    service: &AgmemService,
+    space: &str,
+    id: &str,
+    uri: &str,
+) -> Result<ReadResourceResult, ErrorData> {
+    let space_name: SpaceName = space.parse().map_err(|_| unknown_space(space))?;
+    let episode_id: EpisodeId = id
+        .parse()
+        .map_err(|_| not_found(format!("{uri}: `{id}` is not a document id")))?;
+    let detail = repo::episode(service.db(), &space_name, &episode_id)
+        .await
+        .map_err(|error| match error {
+            StoreError::UnknownEpisode { .. } => {
+                not_found(format!("{uri}: no document with that id in `{space}`"))
+            }
+            other => store_error(&other),
+        })?;
+    let episode = detail.episode;
+    if !episode.is_document() {
+        return Err(not_found(format!(
+            "{uri}: that is anonymous text, not a document; it reads at {SCHEME}{space}/{id}"
+        )));
+    }
+    let mime = episode.mime.unwrap_or_else(|| DOC_MIME.to_owned());
+    Ok(ReadResourceResult::new(vec![
+        ResourceContents::text(episode.content, uri).with_mime_type(mime),
+    ]))
 }
 
 /// Serde is the renderer, so a resource can never drift from its tool.

--- a/crates/agmem-server/src/service.rs
+++ b/crates/agmem-server/src/service.rs
@@ -235,13 +235,25 @@ believed at some earlier point.",
             read_only_hint = true,
             destructive_hint = false,
             open_world_hint = false
-        )
+        ),
+        // Spelled out because the macro derives it only from a `Json<T>`
+        // return, and this arm builds its own result to append the links.
+        output_schema = rmcp::handler::server::common::schema_for_output::<RecallResult>()
     )]
     async fn recall(
         &self,
         Parameters(params): Parameters<RecallParams>,
-    ) -> Result<Json<RecallResult>, ErrorData> {
-        recall::run(self, params).await.map(Json)
+    ) -> Result<CallToolResult, ErrorData> {
+        // The `Json<T>` shape by hand — JSON text first, structured content
+        // beside it — plus one `resource_link` per document the hits are
+        // slices of (#135), so a client can open the source directly.
+        let result = recall::run(self, params).await?;
+        let links = recall::links(&result);
+        let value = serde_json::to_value(&result)
+            .map_err(|error| crate::tools::internal(format!("rendering recall failed: {error}")))?;
+        let mut answer = CallToolResult::structured(value);
+        answer.content.extend(links);
+        Ok(answer)
     }
 
     /// The session-start verb (design §3.2).

--- a/crates/agmem-server/src/tools/inspect.rs
+++ b/crates/agmem-server/src/tools/inspect.rs
@@ -422,6 +422,9 @@ pub struct SpaceCounts {
     /// Retrieval slices of those episodes.
     pub chunks: u64,
 
+    /// Those episodes that are documents — named, typed, listed by `docs:`.
+    pub documents: u64,
+
     /// Live memories per kind; a kind with none is absent.
     pub live_by_kind: Vec<KindCount>,
 }
@@ -914,6 +917,7 @@ async fn counts(
             invalidated: stats.memories.saturating_sub(stats.live),
             episodes: stats.episodes,
             chunks: stats.chunks,
+            documents: stats.documents,
             live_by_kind: stats
                 .live_by_kind
                 .into_iter()

--- a/crates/agmem-server/src/tools/recall.rs
+++ b/crates/agmem-server/src/tools/recall.rs
@@ -19,9 +19,11 @@ use agmem_core::{DocKind, EpisodeId, Kind, MemoryId, SpaceName};
 use agmem_store::repo::{self, Candidate, Filters, Hit as StoreHit, Liveness, Lookup, Search};
 use jiff::Timestamp;
 use rmcp::ErrorData;
+use rmcp::model::{ContentBlock, Resource};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::resources;
 use crate::service::AgmemService;
 use crate::tools::{self, abstain, embed_query, hop, invalid, occupancy, provenance, store_error};
 
@@ -350,6 +352,37 @@ pub struct RecallHit {
     /// anonymous text and on every other kind of hit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub doc: Option<DocRef>,
+}
+
+/// The documents the hits are slices of, as `resource_link` content blocks
+/// (#135): one per document, in first-hit order, so a client can open the
+/// source without a second tool call. Appended after the JSON text block,
+/// never before it — anything reading `content[0]` as the answer still can.
+pub fn links(result: &RecallResult) -> Vec<ContentBlock> {
+    let mut seen: Vec<(&str, &str)> = Vec::new();
+    let mut links = Vec::new();
+    for hit in &result.hits {
+        let Some(doc) = &hit.doc else { continue };
+        let key = (hit.space.as_str(), doc.id.as_str());
+        if seen.contains(&key) {
+            continue;
+        }
+        seen.push(key);
+        links.push(ContentBlock::resource_link(
+            Resource::new(
+                resources::document_uri(&hit.space, &doc.id),
+                doc.title.clone(),
+            )
+            .with_title(doc.title.clone())
+            .with_description(format!(
+                "The {kind} `{title}` in `{space}`, which the hit is a slice of",
+                kind = doc.doc_kind,
+                title = doc.title,
+                space = hit.space
+            )),
+        ));
+    }
+    links
 }
 
 /// The document a verbatim hit is a slice of (#134).

--- a/crates/agmem-server/src/tools/remember.rs
+++ b/crates/agmem-server/src/tools/remember.rs
@@ -443,7 +443,7 @@ const MAX_MEMORY_CHARS: usize = 10_000;
 /// and stored in a single call, monopolising the model every other session
 /// shares. Ground truth bigger than this belongs in a file, with a memory
 /// pointing at it.
-const MAX_EPISODE_CHARS: usize = 100_000;
+pub const MAX_EPISODE_CHARS: usize = 100_000;
 
 /// A document title is a name, not a summary.
 const MAX_TITLE_CHARS: usize = 200;

--- a/crates/agmem-server/tests/daemon.rs
+++ b/crates/agmem-server/tests/daemon.rs
@@ -375,6 +375,52 @@ async fn a_one_shot_context_reads_through_the_live_daemon() {
 }
 
 #[tokio::test]
+async fn a_document_put_through_the_daemon_is_read_by_the_sessions() {
+    use agmem_server::config::{DocGetArgs, DocPutArgs};
+
+    let shared = Shared::start().await;
+    let cfg = config(shared.data.path(), "hook");
+
+    // What `agmem doc put < plan.md` runs after parsing (#135): same data
+    // dir, so the one-shot finds the daemon above instead of starting one.
+    let content = "# Plan\n\nStep one.\n".repeat(2_000);
+    let line = agmem_server::doc::put(
+        &cfg,
+        DocPutArgs {
+            title: "plan-x".to_owned(),
+            kind: agmem_core::DocKind::Plan,
+            tags: vec!["role:architect".to_owned()],
+            mime: "text/markdown".to_owned(),
+            space: None,
+        },
+        content.clone(),
+    )
+    .await
+    .expect("put through the daemon");
+    let (id, uri) = line.trim_end().split_once(' ').expect("id and uri");
+    assert_eq!(uri, format!("memory://hook/doc/{id}"), "{line}");
+
+    let session = shared.attach("hook").await;
+    let found = call(&session, "inspect", json!({ "ref": "doc:current/plan-x" })).await;
+    assert_eq!(found["found"]["episode"]["id"], id, "{found}");
+    assert_eq!(found["found"]["episode"]["tags"], json!(["role:architect"]));
+
+    let back = agmem_server::doc::get(
+        &cfg,
+        DocGetArgs {
+            reference: "plan-x".to_owned(),
+            offset: None,
+            limit: None,
+            raw: true,
+            space: None,
+        },
+    )
+    .await
+    .expect("get through the daemon");
+    assert_eq!(back, content, "the whole document, through the socket");
+}
+
+#[tokio::test]
 async fn a_probe_that_says_nothing_does_not_wedge_the_daemon() {
     let shared = Shared::start().await;
     // Connect and leave — what `--doctor` does to find out whether a daemon

--- a/crates/agmem-server/tests/doc_cli.rs
+++ b/crates/agmem-server/tests/doc_cli.rs
@@ -1,0 +1,280 @@
+//! `agmem doc` where no daemon applies: the direct route (#135).
+//!
+//! `--no-daemon` on an embedded store takes the same path non-Unix platforms
+//! take — open the store here, call the tool, print — and, unlike `mem://`,
+//! keeps what one call wrote for the next one. Each verb runs as the built
+//! binary, one process per call, the way a shell runs it: an embedded store
+//! releases its lock when the process that opened it exits, so two direct
+//! calls in one process would contend for it — which is a test's shape, not
+//! a user's. The daemon route is covered where the daemon's own harness
+//! lives, in `tests/daemon.rs`.
+
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+use agmem_core::DocKind;
+use agmem_server::config::{Cli, CliCommand, DocForgetArgs, DocGetArgs, DocListArgs, DocVerb};
+use clap::Parser as _;
+use serde_json::Value;
+
+/// What one `agmem --no-daemon … doc <tail>` process printed and how it
+/// ended: `Ok(stdout)` on exit 0, else `Err(stderr)`.
+fn run(data: &tempfile::TempDir, tail: &[&str], stdin: &str) -> Result<String, String> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_agmem"))
+        .args(["--data"])
+        .arg(data.path())
+        .args([
+            "--space",
+            "fresh",
+            "--embedder",
+            "none",
+            "--no-daemon",
+            "doc",
+        ])
+        .args(tail)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn agmem");
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(stdin.as_bytes())
+        .expect("write stdin");
+    let output = child.wait_with_output().expect("wait");
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let stderr = String::from_utf8(output.stderr).expect("utf-8 stderr");
+    if output.status.success() {
+        Ok(stdout)
+    } else {
+        Err(stderr)
+    }
+}
+
+fn put(data: &tempfile::TempDir, tail: &[&str], content: &str) -> Result<String, String> {
+    run(data, tail, content)
+}
+
+fn get(data: &tempfile::TempDir, tail: &[&str]) -> Result<String, String> {
+    run(data, tail, "")
+}
+
+fn list(data: &tempfile::TempDir, tail: &[&str]) -> String {
+    run(data, tail, "").expect("list")
+}
+
+fn forget(data: &tempfile::TempDir, tail: &[&str]) -> Result<String, String> {
+    run(data, tail, "")
+}
+/// `n` characters of markdown with paragraph breaks, so it chunks.
+fn markdown(n: usize) -> String {
+    let mut text = String::from("# The plan\n\n");
+    let mut paragraph = 0;
+    while text.chars().count() < n {
+        text.push_str(&format!(
+            "Paragraph {paragraph}: {}\n\n",
+            "words ".repeat(120)
+        ));
+        paragraph += 1;
+    }
+    text.chars().take(n).collect()
+}
+
+#[test]
+fn a_large_document_round_trips_by_title_and_by_id() {
+    let data = tempfile::tempdir().expect("tempdir");
+    let content = markdown(90_000);
+
+    let line = put(
+        &data,
+        &[
+            "put", "--title", "plan-x", "--kind", "plan", "--tag", "phase-9",
+        ],
+        &content,
+    )
+    .expect("put");
+    let (id, uri) = line
+        .trim_end()
+        .split_once(' ')
+        .expect("`<id> <uri>` on one line");
+    assert_eq!(uri, format!("memory://fresh/doc/{id}"), "{line}");
+    assert!(line.ends_with('\n'));
+
+    let by_title = get(&data, &["get", "--raw", "plan-x"]).expect("get");
+    assert_eq!(by_title, content, "the content comes back as stored, whole");
+    let by_id = get(&data, &["get", "--raw", id]).expect("get");
+    assert_eq!(by_id, content);
+
+    // Without --raw the answer is the tool's, so a caller sees what it is.
+    let shown = get(&data, &["get", "plan-x"]).expect("get");
+    let shown: Value = serde_json::from_str(&shown).expect("json");
+    assert_eq!(shown["found"]["episode"]["title"], "plan-x", "{shown}");
+    assert_eq!(shown["found"]["episode"]["doc_kind"], "plan");
+    assert_eq!(shown["found"]["episode"]["mime"], "text/markdown");
+    assert_eq!(shown["found"]["versions"].as_array().map(Vec::len), Some(1));
+
+    // A window is honoured in characters.
+    let window = get(
+        &data,
+        &["get", "--raw", "--offset", "2", "--limit", "8", "plan-x"],
+    )
+    .expect("get");
+    assert_eq!(window, "The plan");
+}
+
+#[test]
+fn the_write_cap_is_the_tools_and_the_message_names_it() {
+    let data = tempfile::tempdir().expect("tempdir");
+    let error = put(
+        &data,
+        &["put", "--title", "too-big", "--kind", "report"],
+        &markdown(100_001),
+    )
+    .expect_err("one over the cap");
+    assert!(error.to_string().contains("100000"), "{error}");
+    assert_eq!(list(&data, &["list"]), "", "nothing landed");
+}
+
+#[test]
+fn a_listing_is_one_line_per_document_and_filters_by_kind() {
+    let data = tempfile::tempdir().expect("tempdir");
+    let plan = put(
+        &data,
+        &["put", "--title", "plan-a", "--kind", "plan"],
+        "the plan",
+    )
+    .expect("put");
+    let review = put(
+        &data,
+        &[
+            "put", "--title", "review-a", "--kind", "review", "--tag", "pr-1",
+        ],
+        "the review",
+    )
+    .expect("put");
+    let plan_id = plan.split(' ').next().expect("id");
+    let review_id = review.split(' ').next().expect("id");
+
+    let lines: Vec<String> = list(&data, &["list"]).lines().map(str::to_owned).collect();
+    assert_eq!(lines.len(), 2, "{lines:?}");
+    assert!(
+        lines[0].starts_with(review_id) && lines[1].starts_with(plan_id),
+        "newest first, the id first on the line: {lines:?}"
+    );
+    assert!(lines[0].contains("review-a") && lines[0].contains("review"));
+
+    let plans = list(&data, &["list", "--kind", "plan"]);
+    assert!(
+        plans.starts_with(plan_id) && plans.lines().count() == 1,
+        "{plans}"
+    );
+    let tagged = list(&data, &["list", "--tag", "pr-1"]);
+    assert!(
+        tagged.starts_with(review_id) && tagged.lines().count() == 1,
+        "{tagged}"
+    );
+
+    let json = list(&data, &["list", "--json"]);
+    let json: Value = serde_json::from_str(&json).expect("json");
+    assert_eq!(json["found"]["documents"].as_array().map(Vec::len), Some(2));
+}
+
+#[test]
+fn forgetting_purges_on_request_and_a_miss_is_an_error() {
+    let data = tempfile::tempdir().expect("tempdir");
+    let line = put(
+        &data,
+        &["put", "--title", "plan-a", "--kind", "plan"],
+        "the plan",
+    )
+    .expect("put");
+    let id = line.split(' ').next().expect("id");
+
+    let purged = forget(&data, &["forget", "--purge", id]).expect("forget");
+    assert!(purged.starts_with("purged 1 record(s)"), "{purged}");
+    assert!(purged.contains(id), "{purged}");
+    assert_eq!(list(&data, &["list"]), "");
+
+    let missing =
+        get(&data, &["get", "--raw", "plan-a"]).expect_err("purged, so the title names nothing");
+    assert!(missing.to_string().contains("plan-a"), "{missing}");
+
+    let again = forget(&data, &["forget", "--purge", id]).expect_err("an id that names nothing");
+    assert!(again.to_string().contains(id), "{again}");
+}
+
+#[test]
+fn cascade_without_purge_is_refused_at_parse_time() {
+    let error = Cli::try_parse_from([
+        "agmem",
+        "doc",
+        "forget",
+        "--cascade",
+        "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    ])
+    .expect_err("cascade only means something under purge");
+    assert!(error.to_string().contains("--purge"), "{error}");
+
+    let error = Cli::try_parse_from(["agmem", "doc", "put", "--title", "t", "--kind", "memo"])
+        .expect_err("not a kind");
+    assert!(error.to_string().contains("plan"), "{error}");
+}
+
+#[test]
+fn the_verbs_parse_to_the_tool_parameters() {
+    let cfg = Cli::try_parse_from([
+        "agmem", "doc", "get", "--offset", "10", "--limit", "5", "--raw", "--space", "user",
+        "plan-x",
+    ])
+    .expect("parse")
+    .resolve()
+    .expect("resolve");
+    assert_eq!(
+        cfg.command,
+        Some(CliCommand::Doc(agmem_server::config::DocArgs {
+            verb: DocVerb::Get(DocGetArgs {
+                reference: "plan-x".to_owned(),
+                offset: Some(10),
+                limit: Some(5),
+                raw: true,
+                space: Some("user".to_owned()),
+            })
+        }))
+    );
+
+    let cfg = Cli::try_parse_from(["agmem", "doc", "list", "--kind", "plan", "--kind", "probe"])
+        .expect("parse")
+        .resolve()
+        .expect("resolve");
+    let Some(CliCommand::Doc(args)) = cfg.command else {
+        panic!("doc")
+    };
+    assert_eq!(
+        args.verb,
+        DocVerb::List(DocListArgs {
+            kinds: vec![DocKind::Plan, DocKind::Probe],
+            tags: Vec::new(),
+            space: None,
+            json: false,
+        })
+    );
+
+    let cfg = Cli::try_parse_from(["agmem", "doc", "forget", "--purge", "--cascade", "x"])
+        .expect("parse")
+        .resolve()
+        .expect("resolve");
+    let Some(CliCommand::Doc(args)) = cfg.command else {
+        panic!("doc")
+    };
+    assert_eq!(
+        args.verb,
+        DocVerb::Forget(DocForgetArgs {
+            id: "x".to_owned(),
+            purge: true,
+            cascade: true,
+            space: None,
+        })
+    );
+}

--- a/crates/agmem-server/tests/doctor.rs
+++ b/crates/agmem-server/tests/doctor.rs
@@ -23,6 +23,10 @@ fn doctor_passes_on_fresh_setup() {
         stderr.contains("none (test-only, no vectors)"),
         "got: {stderr}"
     );
+    assert!(
+        stderr.contains("documents            no space registered yet"),
+        "the report counts documents per space, even when there is none (#135): {stderr}"
+    );
 }
 
 #[test]

--- a/crates/agmem-server/tests/documents.rs
+++ b/crates/agmem-server/tests/documents.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use agmem_embed::NoopEmbedder;
 use harness::*;
+use rmcp::model::ContentBlock;
 use serde_json::{Value, json};
 
 /// A `remember` carrying one document and nothing else.
@@ -313,6 +314,36 @@ async fn a_verbatim_hit_says_which_document_it_is_a_slice_of() {
     assert!(
         anonymous.get("doc").is_none(),
         "anonymous text has no name to give: {anonymous}"
+    );
+
+    // On the wire the document is also a `resource_link` after the JSON
+    // text (#135): one per document however many slices matched, so a
+    // client can open the source without a second tool call.
+    let result = agmem
+        .call("recall", json!({ "query": "gizmo", "k": 10 }))
+        .await
+        .expect("recall");
+    assert!(
+        matches!(result.content.first(), Some(ContentBlock::Text(_))),
+        "the JSON text stays first: {:?}",
+        result.content
+    );
+    let links: Vec<&rmcp::model::Resource> = result
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::ResourceLink(link) => Some(link),
+            _ => None,
+        })
+        .collect();
+    let [link] = links[..] else {
+        panic!("one link for the one document: {:?}", result.content);
+    };
+    assert_eq!(link.uri, format!("memory://{}/doc/{id}", space()));
+    assert_eq!(link.name, "plan-long");
+    assert!(
+        result.structured_content.is_some(),
+        "the structured answer is untouched: {result:?}"
     );
     agmem.shutdown().await;
 }

--- a/crates/agmem-server/tests/protocol.rs
+++ b/crates/agmem-server/tests/protocol.rs
@@ -224,10 +224,15 @@ async fn resource_templates_publish_the_record_form() {
         .await
         .expect("list_resource_templates");
 
-    let [template] = &listed.resource_templates[..] else {
-        panic!("one template — records are addressed, never enumerated: {listed:?}");
+    let [record, document] = &listed.resource_templates[..] else {
+        panic!("two templates — records are addressed, never enumerated: {listed:?}");
     };
-    assert_eq!(template.uri_template, "memory://{space}/{id}");
+    assert_eq!(record.uri_template, "memory://{space}/{id}");
+    assert_eq!(document.uri_template, "memory://{space}/doc/{id}");
+    assert_eq!(
+        document.mime_type, None,
+        "a document is served under its own media type, so the template names none"
+    );
 
     agmem.shutdown().await;
 }
@@ -363,6 +368,101 @@ async fn a_uri_naming_nothing_is_resource_not_found() {
             "{uri}: {error:?}"
         );
     }
+
+    agmem.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_document_reads_as_its_text_under_its_own_mime_and_is_listed() {
+    let agmem = Harness::start(Arc::new(NoopEmbedder)).await;
+    let content = "# Plan X\n\nStep one.\nStep two.\n";
+    let written = agmem
+        .remember(json!({
+            "memories": [],
+            "episode": {
+                "content": content, "title": "plan-x", "doc_kind": "plan",
+                "tags": ["phase-9"], "mime": "text/markdown"
+            }
+        }))
+        .await;
+    let id = written["episode"].as_str().expect("id").to_owned();
+    let plain = agmem
+        .remember(json!({ "memories": [], "episode": { "content": "just a note" } }))
+        .await;
+    let plain_id = plain["episode"].as_str().expect("id").to_owned();
+
+    let uri = format!("memory://{}/doc/{id}", space());
+    let result = agmem
+        .client
+        .read_resource(ReadResourceRequestParams::new(uri.clone()))
+        .await
+        .expect("read");
+    let [
+        rmcp::model::ResourceContents::TextResourceContents {
+            text,
+            mime_type,
+            uri: echoed,
+            ..
+        },
+    ] = &result.contents[..]
+    else {
+        panic!("one text block, got {result:?}");
+    };
+    assert_eq!(text, content, "the text as stored, not an envelope");
+    assert_eq!(mime_type.as_deref(), Some("text/markdown"));
+    assert_eq!(echoed, &uri);
+
+    // The JSON form still answers at the record address.
+    let record = read_json(&agmem, &format!("memory://{}/{id}", space())).await;
+    assert_eq!(record["found"]["episode"]["title"], "plan-x", "{record}");
+
+    for uri in [
+        format!("memory://{}/doc/{plain_id}", space()),
+        format!("memory://{}/doc/01ARZ3NDEKTSV4RRFFQ69G5FAV", space()),
+        format!("memory://{}/doc/not-an-id", space()),
+        format!("memory://nowhere/doc/{id}"),
+    ] {
+        let error = agmem
+            .client
+            .read_resource(ReadResourceRequestParams::new(uri.clone()))
+            .await
+            .expect_err(&uri);
+        let ServiceError::McpError(error) = &error else {
+            panic!("{uri}: expected a protocol error, got {error:?}");
+        };
+        assert_eq!(
+            error.code,
+            ErrorCode::RESOURCE_NOT_FOUND,
+            "{uri}: {error:?}"
+        );
+    }
+
+    // The picker sees the document, named by its title; anonymous text is
+    // not a thing to attach.
+    let listed = agmem.client.list_resources(None).await.expect("list");
+    let document = listed
+        .resources
+        .iter()
+        .find(|resource| resource.uri == uri)
+        .unwrap_or_else(|| panic!("the document is listed: {:?}", listed.resources));
+    assert_eq!(document.name, "plan-x");
+    assert_eq!(document.mime_type.as_deref(), Some("text/markdown"));
+    assert_eq!(document.size, Some(content.len() as u64));
+    assert!(
+        document
+            .description
+            .as_deref()
+            .is_some_and(|d| d.contains("plan") && d.contains("phase-9")),
+        "{document:?}"
+    );
+    assert!(
+        !listed
+            .resources
+            .iter()
+            .any(|resource| resource.uri.contains(&plain_id)),
+        "{:?}",
+        listed.resources
+    );
 
     agmem.shutdown().await;
 }

--- a/crates/agmem-server/tests/snapshots/protocol__list_tools.snap
+++ b/crates/agmem-server/tests/snapshots/protocol__list_tools.snap
@@ -1466,6 +1466,12 @@ expression: "&tools.tools"
               "minimum": 0,
               "type": "integer"
             },
+            "documents": {
+              "description": "Those episodes that are documents — named, typed, listed by `docs:`.",
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
             "episodes": {
               "description": "Verbatim episodes.",
               "format": "uint64",
@@ -1509,6 +1515,7 @@ expression: "&tools.tools"
             "invalidated",
             "episodes",
             "chunks",
+            "documents",
             "live_by_kind"
           ],
           "type": "object"

--- a/crates/agmem-store/src/queries/read.rs
+++ b/crates/agmem-store/src/queries/read.rs
@@ -433,6 +433,8 @@ pub(crate) const STATS: &str = "RETURN {
          WHERE space = $space GROUP ALL)[0].count ?? 0,
      chunks: (SELECT count() AS count FROM episode_chunk
          WHERE space = $space GROUP ALL)[0].count ?? 0,
+     documents: (SELECT count() AS count FROM episode
+         WHERE space = $space AND doc_kind IS NOT NONE GROUP ALL)[0].count ?? 0,
      live_by_kind: (SELECT kind, count() AS count FROM memory
          WHERE space = $space AND invalid_at IS NONE GROUP BY kind ORDER BY kind)
  }";

--- a/crates/agmem-store/src/repo/read.rs
+++ b/crates/agmem-store/src/repo/read.rs
@@ -227,6 +227,8 @@ pub struct SpaceStats {
     pub episodes: u64,
     /// Retrieval slices of those episodes.
     pub chunks: u64,
+    /// Those episodes that are documents: named and typed (#132).
+    pub documents: u64,
 }
 
 /// Hybrid search over memories and episode chunks, best candidate first.
@@ -1004,6 +1006,7 @@ pub async fn stats(db: &Db, space: &SpaceName) -> Result<SpaceStats, StoreError>
             .collect::<Result<_, StoreError>>()?,
         episodes: count(row.episodes),
         chunks: count(row.chunks),
+        documents: count(row.documents),
     })
 }
 

--- a/crates/agmem-store/src/types.rs
+++ b/crates/agmem-store/src/types.rs
@@ -513,6 +513,7 @@ pub(crate) struct StatsRow {
     pub(crate) live: i64,
     pub(crate) episodes: i64,
     pub(crate) chunks: i64,
+    pub(crate) documents: i64,
     pub(crate) live_by_kind: Vec<KindCountRow>,
 }
 

--- a/crates/agmem-store/tests/documents.rs
+++ b/crates/agmem-store/tests/documents.rs
@@ -82,6 +82,13 @@ async fn a_document_reads_back_with_its_name_kind_tags_and_mime() {
         "NONE on the row reads as empty"
     );
     assert!(!plain.episode.is_document());
+
+    let stats = repo::stats(&db, &space()).await.expect("stats");
+    assert_eq!(
+        (stats.episodes, stats.documents),
+        (2, 1),
+        "the count tells the named episode from the anonymous one"
+    );
 }
 
 #[tokio::test]

--- a/crates/agmem-store/tests/reads.rs
+++ b/crates/agmem-store/tests/reads.rs
@@ -681,6 +681,7 @@ async fn stats_count_what_a_space_holds() {
         (stats.memories, stats.live, stats.episodes, stats.chunks),
         (5, 5, 1, 3)
     );
+    assert_eq!(stats.documents, 0, "the seeded episode is anonymous");
     assert_eq!(
         stats.live_by_kind,
         [(Kind::Fact, 3), (Kind::Instruction, 1), (Kind::Lesson, 1)],

--- a/docs/design.md
+++ b/docs/design.md
@@ -86,7 +86,7 @@ Key properties:
 | Background workers: elaboration, consolidation, decay sweeps | **No background jobs.** Decay is computed at read time; pruning runs lazily at startup; consolidation is agent-invoked (phase 3) |
 | decision/retrieval/response trace graph | Provenance (`source`) on every record + supersession chains; `inspect` walks them. Full trace tables deferred |
 | Grants, principals, key attenuation, delegation | Local trust model: space isolation + destructive-op flags. No auth in v1 |
-| REST + Management API + SDKs + CLI/TUI | **None.** MCP tools only (a `--doctor` CLI flag for self-check is the whole CLI) |
+| REST + Management API + SDKs + CLI/TUI | **None.** MCP tools only; the CLI is `--doctor`, `--reindex`, and the one-shots that mirror a tool (`agmem context`, `agmem doc …`, `agmem hook …`) |
 
 ---
 
@@ -405,7 +405,9 @@ Input schemas (sketch; exact schemars structs are a phase-1 task):
 //              covers,       // summary hits only: the refs it stands in for
 //              doc: { id, title, doc_kind, position } }] }  // episode hits that slice a document (#134)
 // Episode chunks compete in the same order as memories (`kind: "episode"`);
-// they carry no validity window and rank on retrieval alone.
+// they carry no validity window and rank on retrieval alone. On the wire the
+// JSON text block is followed by one `resource_link` per document the hits
+// slice, pointing at memory://<space>/doc/<id> (#135).
 
 // context
 { "query": "optional focus string", "space": "…", "budget_chars": 6000 }
@@ -615,10 +617,20 @@ them. The grammar is two forms: `memory://<space>` reads the index — one page
 of the strongest live claims, slim, each entry carrying its own URI, with a
 `truncated` note naming what the page left out whenever the space holds more
 than one page (#69) — and `memory://<space>/<id>`
-reads the full `inspect` answer for whatever the id names. `resources/list`
-serves one entry per registered space; the record form is published as a URI
-template rather than enumerated, so a large store never pushes thousands of
-rows at a client that renders the list as a menu.
+reads the full `inspect` answer for whatever the id names. A third form,
+`memory://<space>/doc/<id>` (#135), serves a document's text as stored under
+its own media type — the one resource that is not a tool's JSON, because a
+client attaching a plan wants the plan and not an envelope; anonymous text
+has no name to attach by and answers only at its record form. `resources/list`
+serves one entry per registered space plus the newest ten documents of the
+spaces the session reads (`current` and `user`); the record and document
+forms are published as URI templates rather than enumerated, so a large store
+never pushes thousands of rows at a client that renders the list as a menu.
+A `recall` hit that slices a document also carries a `resource_link` content
+block to its `doc/` form, after the JSON text, so a client opens the source
+without a second call. `agmem doc put/get/list/forget` are the same tier from
+the shell, one-shots on the `agmem context` pattern that call `remember`,
+`inspect` and `forget` through the daemon or the store.
 
 ---
 
@@ -674,12 +686,14 @@ agmem/
 │       │   │   ├── mod.rs        #   socket path, handshake, wanted()
 │       │   │   ├── serve.rs      #   owns the store, one service per session
 │       │   │   └── client.rs     #   find or start it, then pump stdio
-│       │   ├── config.rs         # flags + AGMEM_* env + `context` subcommand
+│       │   ├── config.rs         # flags + AGMEM_* env + the subcommands
 │       │   ├── startup.rs        # steps 4–9 of §5.1, shared by every route
 │       │   ├── lock.rs           # the single-writer advisory lock
 │       │   ├── doctor.rs         # --doctor self-check
 │       │   ├── reindex.rs        # --reindex re-embedding pass
-│       │   ├── oneshot.rs        # `agmem context`: one briefing, no server
+│       │   ├── oneshot.rs        # `agmem context`: one briefing, no server;
+│       │   │                     #   the daemon/direct routes `doc` shares
+│       │   ├── doc.rs            # `agmem doc put/get/list/forget` (#135)
 │       │   ├── hook.rs           # `agmem hook <event>`: the plugin's hooks —
 │       │   │                     #   briefing injection, per-session recall
 │       │   │                     #   log, seam nudges
@@ -690,7 +704,7 @@ agmem/
 │       │   │                     #   description text + handler —
 │       │   │                     #   remember / recall / context / forget /
 │       │   │                     #   inspect / consolidate / reflect
-│       │   ├── resources.rs      # memory://<space> index resources
+│       │   ├── resources.rs      # memory:// index, record and doc/ resources
 │       │   ├── prompts.rs        # checkpoint / recall_first rituals
 │       │   └── telemetry.rs      # tracing → stderr (or AGMEM_LOG_FILE)
 │       └── tests/                # protocol, eval, harness, daemon, knn_probe
@@ -1242,7 +1256,7 @@ Each phase is releasable; later phases only add.
   `ws://` sharing-mode hardening docs.
 - **Phase 9 — Documents (#132, #134–#137):** a named, typed artifact tier
   over the episode table (v9 schema, span sidecar); windowed `inspect`, title
-  supersession and cascade purge; `agmem doc` CLI + `agmem://<space>/doc/{id}`
+  supersession and cascade purge; `agmem doc` CLI + `memory://<space>/doc/{id}`
   resource; the ctx-flow framework moves off `.claude/notes/`; recall-precision
   eval with documents present.
 


### PR DESCRIPTION
Closes #135. Depends on #132 and #134, both on main.

## What

- `agmem doc put --title <t> --kind <k> [--tag t] [--mime m] [--space s] < file` prints `<id> memory://<space>/doc/<id>` on one line.
- `agmem doc get <id | title> [--offset N --limit N] [--raw]`, `agmem doc list [--kind k] [--tag t] [--json]`, `agmem doc forget <id> [--purge [--cascade]]`.
- Each verb is the MCP tool it mirrors (`remember`, `inspect`, `forget`), reached through the daemon where a session would attach, else directly against the store. Same refusals, same window, same versions.
- Resource template `memory://<space>/doc/{id}` serves the text under its own media type; unknown id and anonymous text answer `RESOURCE_NOT_FOUND`. `resources/list` adds the newest ten documents of the attached spaces for the `@` picker.
- `recall` hits that slice a document carry a `resource_link` content block after the JSON text; the structured answer is unchanged.
- `--doctor` and the daemon self-check count documents per space.

## Not in the issue as written

- `--supersedes` on `put` is not a flag: a second `put` under the same title is a new version, as #134 defined, and `get <title>` resolves to the newest.
- The URI scheme is `memory://`, matching the existing resources, not the `agmem://` the issue sketched.

## Tests

- `tests/doc_cli.rs` runs the built binary per verb over `--no-daemon`: 90k round-trip by title and by id, 100,001 chars refused with the cap in the message, listing and filters, purge and misses, parse-time refusals.
- `tests/daemon.rs` covers put and get through a live daemon.
- `tests/protocol.rs` and `tests/documents.rs` cover the template, read, not-found, listing and the recall link. The tool-surface snapshot gains inspect's `documents` count.

Workspace suite, clippy with `-D warnings`, and fmt are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aj6D2zsokbFhzrthwJW6J
