### PR TITLE
The framework moves off .claude/notes onto documents (#136)

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -4,8 +4,9 @@ skills/rust-expert-developer/
 # session-local permissions — never ship
 settings.local.json
 
-# this repo's own scratch dropbox (subagent artifacts, legacy pre-agmem
-# notes) — machine-local, never ship
+# the retired artifact dropbox — subagents write agmem documents now, and
+# anything landing here is invisible to memory (/ctx-flow-doctor flags it);
+# stays ignored so a regressed agent can never commit a blob
 notes/
 
 # macOS noise

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -14,9 +14,9 @@ anything missing.
   framework wants
 - **agmem** — persistent cross-session memory over MCP, wired in by its
   Claude Code plugin (`claude plugin marketplace add AlfoldiMate/agmem`,
-  then `claude plugin install agmem@agmem`); needs ≥ v0.1.10, since the
-  plugin's hooks are `agmem hook …` and an older binary answers them with
-  silence. The plugin registers the server, injects the briefing at session
+  then `claude plugin install agmem@agmem`); needs ≥ v0.2.0, since the
+  plugin's hooks are `agmem hook …` and subagents write artifacts with
+  `agmem doc …` — an older binary answers both with a usage error. The plugin registers the server, injects the briefing at session
   start, logs what each session recalled, and nudges at seams; this
   framework adds only the learnings gate in `/checkpoint`
 - **ast-grep** — structural search; prefer over `rg` whenever the question is
@@ -145,8 +145,9 @@ memory already in front of it:
   `instruction` (pinned into every briefing — be sparing). Branch state
   (Next/Blocked) → `fact` with `decay_class: fast`, tagged `branch:<slug>`; it
   fades in days, as branch state should.
-- Subagents still write long output to `.claude/notes/` and return the
-  **path** — agmem holds claims, not artifacts.
+- Subagents write long output as **documents** (`scripts/doc-put.nu`, which
+  tags them with the branch) and return `DOC: <id> <uri>` — claims and the
+  artifacts they cite live in one store, and `.claude/notes/` is retired.
 
 Prefer several short sessions chained through memory over one long one — a
 600k-token session produces worse output than a 100k one even when it never

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -297,9 +297,13 @@ ledger/state files used to: `fact` (fades over weeks unless used), `lesson`
 is a `fact` with `decay_class: fast` tagged `branch:<slug>` — it dies in days,
 as branch state should, with no file to prune.
 
-What agmem does **not** replace: `.claude/notes/` stays as the artifact
-dropbox — subagents write long output there and return the path. Claims go in
-the store; blobs go on disk.
+Artifacts live there too, since v0.2.0: a subagent's long output — a plan,
+a review, a test log — is a **document**, written through
+`scripts/doc-put.nu` (which tags it with the branch and the role) and handed
+back as `DOC: <id> memory://…`. `/checkpoint` reads a `LEARNED:` proposal
+out of the document and stores the accepted lesson citing it. The old
+`.claude/notes/` dropbox is retired; `/agmem-import` moves one in and
+`/ctx-flow-doctor` flags one that comes back.
 
 ## Playbooks — knowledge that accumulates
 
@@ -322,9 +326,9 @@ never self-modify at all.
 ## Git, gitignore, and worktrees
 
 Memory is no longer a git question: the store lives under your home directory,
-not in the repo. What remains in `.claude/` is the framework itself plus
-`notes/`, the scratch dropbox — gitignore `notes/` (artifacts are
-machine-local). When you do write `.gitignore` rules for `.claude`, use
+not in the repo, and so do subagent artifacts. What remains in `.claude/` is
+the framework itself; keep `notes/` gitignored so a regressed agent can never
+commit a blob. When you do write `.gitignore` rules for `.claude`, use
 `.claude/*` (contents), never `.claude/` (directory) — git will not descend
 into an excluded directory, so `!` negations under it would be silently dead.
 
@@ -358,17 +362,16 @@ compacts; the token saving is a side effect of the quality win.
 .claude/                    this folder, copied into your project
 ├── CLAUDE.md               the routing discipline — loads every session
 ├── settings.json           hook registration
-├── .gitignore              the machine-local parts: notes/, settings.local.json, one local skill (sgconfig.yml lives at the repo root)
+├── .gitignore              the machine-local parts: settings.local.json, one local skill, the retired notes/ (sgconfig.yml lives at the repo root)
 ├── agents/                 runner, verifier, architect, browser, tracker, scout
 ├── commands/               checkpoint (wraps the plugin's), agmem-import, ctx-flow-doctor, ast-grep-it, bare-worktree
 ├── docs/reference.md       contracts, memory mapping, rationale — loaded on demand
 ├── hooks/scripts/          the three hooks + shared _common.nu + paths resolver
 ├── output-styles/          ctx-flow.md — the hard rules, appended to the system prompt
-├── scripts/                doctor.nu + build-grammar.nu + grammars.nu registry + bare-worktree.nu
+├── scripts/                doctor.nu + doc-put.nu (subagent artifacts → documents) + import-notes.nu + build-grammar.nu + grammars.nu registry + bare-worktree.nu
 ├── skills/nushell/         deep Nushell reference, loaded when writing nu
 ├── skills/ast-grep/        rule-writing workflow, loaded when a query needs more than a pattern
-│                           (a machine-local skill dropped in here stays untracked — list it in .gitignore)
-└── notes/                  subagent artifact dropbox   (created by use)
+└── skills/                 (a machine-local skill dropped in here stays untracked — list it in .gitignore)
 ```
 
 MIT.

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: Designs the approach for a non-trivial change — reads the existing code, weighs options, returns a concrete build sequence with files and risks. Read-only; never edits. Use before writing code for anything spanning more than two files.
 model: fable
-effort: xhigh
+effort: high
 tools: Read, Glob, Grep, Bash, mcp__plugin_agmem_agmem__recall, mcp__plugin_agmem_agmem__context
 mcpServers:
   - plugin:agmem:agmem
@@ -51,8 +51,12 @@ UNKNOWNS:
 - <what the code could not tell you>
 ```
 
-Under 60 lines. No code block over 5 lines. A longer design goes to
-`.claude/notes/plan-<name>.md`; return the path plus APPROACH.
+Under 60 lines. No code block over 5 lines. Before returning, store the full
+design as a document — pipe it into
+`nu "$CLAUDE_PROJECT_DIR/.claude/scripts/doc-put.nu" architect plan plan-<name>`
+(Bash heredoc; the wrapper tags it with the branch and prints `<id> <uri>`) —
+and open the reply with `DOC: <id> <uri>` so the caller can `agmem doc get`
+what the 60 lines left out. A longer design lives there, never in the reply.
 
 ## Learned
 
@@ -62,5 +66,7 @@ Only if it would change a future run of this agent **in this project**, end with
 LEARNED: <one sentence> — <evidence>
 ```
 
+If you wrote a document, the same line closes it under a `## Learned`
+heading, so the proposal survives the reply scrolling out of context.
 You propose; the caller commits. Skip it unless durable, non-obvious, and earned
 twice or once at real cost. Most runs emit nothing.

--- a/.claude/agents/browser.md
+++ b/.claude/agents/browser.md
@@ -37,12 +37,14 @@ DID:
 - <step>                     (at most 4)
 SAW:
 - <observation or error, quoted>   (at most 5)
-ARTIFACTS:
-- .claude/notes/<file>       (omit if none)
+DOC: <id> <uri>              (omit if none)
 ```
 
 **Never** paste a snapshot, DOM, accessibility tree, HTML source, or full console
-log. Write it to `.claude/notes/` and return the path. No exceptions.
+log. Store it as a document — pipe it into
+`nu "$CLAUDE_PROJECT_DIR/.claude/scripts/doc-put.nu" browser report report-<flow>-<date>`
+(`--mime text/plain` for anything not markdown) — and return `DOC: <id> <uri>`.
+No exceptions.
 
 ## Learned
 
@@ -52,5 +54,7 @@ Only if it would change a future run of this agent **in this project**, end with
 LEARNED: <one sentence> — <evidence>
 ```
 
+If you wrote a document, the same line closes it under a `## Learned`
+heading, so the proposal survives the reply scrolling out of context.
 You propose; the caller commits. Skip it unless durable, non-obvious, and earned
 twice or once at real cost. Most runs emit nothing.

--- a/.claude/agents/runner.md
+++ b/.claude/agents/runner.md
@@ -41,7 +41,9 @@ SUPPRESSED: <n> more of the same kind
 ```
 
 Forbidden: raw log output, stack traces, compiler notes, passing test names. If
-the full log matters, write it to `.claude/notes/` and return the path.
+the full log matters, store it as a document — pipe it into
+`nu "$CLAUDE_PROJECT_DIR/.claude/scripts/doc-put.nu" runner report report-<command>-<date>`
+— and add `DOC: <id> <uri>` to the report.
 
 ## Learned
 
@@ -51,5 +53,7 @@ Only if it would change a future run of this agent **in this project**, end with
 LEARNED: <one sentence> — <evidence>
 ```
 
+If you wrote a document, the same line closes it under a `## Learned`
+heading, so the proposal survives the reply scrolling out of context.
 You propose; the caller commits. Skip it unless durable, non-obvious, and earned
 twice or once at real cost. Most runs emit nothing.

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -46,8 +46,10 @@ SUPPRESSED: <n> more of the same kind
 If nothing matches: `FOUND: nothing — <where you looked, one clause>`.
 
 Forbidden: file bodies, code blocks over 2 lines, explanations of how the code
-works, next steps, "you could". Over 8 hits or any real detail goes to
-`.claude/notes/` and you return the path.
+works, next steps, "you could". Over 8 hits or any real detail becomes a
+document — pipe it into
+`nu "$CLAUDE_PROJECT_DIR/.claude/scripts/doc-put.nu" scout report report-<what>-<date>`
+— and you return `DOC: <id> <uri>`.
 
 ## Learned
 
@@ -57,5 +59,7 @@ Only if it would change a future run of this agent **in this project**, end with
 LEARNED: <one sentence> — <evidence>
 ```
 
+If you wrote a document, the same line closes it under a `## Learned`
+heading, so the proposal survives the reply scrolling out of context.
 You propose; the caller commits. Skip it unless durable, non-obvious, and earned
 twice or once at real cost. Most runs emit nothing.

--- a/.claude/agents/tracker.md
+++ b/.claude/agents/tracker.md
@@ -44,8 +44,10 @@ BLOCKING:
 
 Writes: `DONE: <what changed> → <url>`
 
-Forbidden: full descriptions, comment threads, field dumps. Over 20 lines goes to
-`.claude/notes/` and you return the path.
+Forbidden: full descriptions, comment threads, field dumps. Over 20 lines
+becomes a document — pipe it into
+`nu "$CLAUDE_PROJECT_DIR/.claude/scripts/doc-put.nu" tracker report report-<what>-<date>`
+— and you return `DOC: <id> <uri>`.
 
 ## Learned
 
@@ -55,5 +57,7 @@ Only if it would change a future run of this agent **in this project**, end with
 LEARNED: <one sentence> — <evidence>
 ```
 
+If you wrote a document, the same line closes it under a `## Learned`
+heading, so the proposal survives the reply scrolling out of context.
 You propose; the caller commits. Skip it unless durable, non-obvious, and earned
 twice or once at real cost. Most runs emit nothing.

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -37,7 +37,10 @@ VERDICT: CONFIRMED | REFUTED | UNCERTAIN
 BECAUSE: <one sentence>
 ```
 
-If REFUTED you may add `INSTEAD: <what is actually true>`.
+If REFUTED you may add `INSTEAD: <what is actually true>`. Evidence that
+outgrows the three lines becomes a document — pipe it into
+`nu "$CLAUDE_PROJECT_DIR/.claude/scripts/doc-put.nu" verifier review review-<claim>-<date>`
+— and add `DOC: <id> <uri>`.
 
 Forbidden: preamble, restating the claim, hedging paragraphs, next steps.
 
@@ -49,5 +52,7 @@ Only if it would change a future run of this agent **in this project**, end with
 LEARNED: <one sentence> — <evidence>
 ```
 
+If you wrote a document, the same line closes it under a `## Learned`
+heading, so the proposal survives the reply scrolling out of context.
 You propose; the caller commits. Skip it unless durable, non-obvious, and earned
 twice or once at real cost. Most runs emit nothing.

--- a/.claude/commands/agmem-import.md
+++ b/.claude/commands/agmem-import.md
@@ -1,5 +1,5 @@
 ---
-description: Migrate a pre-agmem checkout's file memory — LEDGER.md and branch state files — into the agmem store, once. Showing and tidying the store are the plugin's /agmem:memory.
+description: Migrate a checkout's retired .claude/notes into the agmem store, once — subagent artifacts become documents, a pre-agmem LEDGER.md and branch state files become claims. Showing and tidying the store are the plugin's /agmem:memory.
 allowed-tools: Read, Bash, Glob, mcp__agmem__recall, mcp__agmem__remember, mcp__plugin_agmem_agmem__recall, mcp__plugin_agmem_agmem__remember
 ---
 
@@ -7,9 +7,10 @@ allowed-tools: Read, Bash, Glob, mcp__agmem__recall, mcp__agmem__remember, mcp__
 
 Showing and tidying the store are the plugin's `/agmem:memory show` and
 `/agmem:memory tidy`. What this framework still owns is the one-time
-migration of the file memory it used before agmem existed; in a checkout
-that has already run it (the files carry an `.imported` suffix) this is a
-no-op.
+migration of the files it used before the store held them: the `.claude/notes/`
+dropbox subagents wrote artifacts to, and before that the LEDGER and branch
+state files. In a checkout that has already run it (the files carry an
+`.imported` suffix) this is a no-op.
 
 Resolve the legacy paths:
 
@@ -17,8 +18,26 @@ Resolve the legacy paths:
 nu "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/scripts/ctx-flow-paths.nu"
 ```
 
-Then, for whichever of these exist — `LEDGER=` and every file under
-`.claude/notes/state/`:
+## 1. Artifacts → documents
+
+Deterministic, so a script does it — the kind comes from the filename
+(`plan-`/`-plan` → plan, `review-` → review, `research-`/audits → report or
+review, `.txt` → probe, else other), the title is the file stem, every
+import carries the tag `legacy-notes`:
+
+```bash
+nu "${CLAUDE_PROJECT_DIR:-.}/.claude/scripts/import-notes.nu" --dry-run
+```
+
+Show the user the table. If a kind looks wrong, `agmem doc put` that file
+by hand afterwards with the right `--kind`. Then run it without `--dry-run`;
+it renames each imported file to `<name>.imported` and lists what it left
+alone — scripts and subdirectories, which the steps below or the user
+handle.
+
+## 2. Ledger and state → claims
+
+For whichever of these exist — `LEDGER=` and every file under `NOTES=/state/`:
 
 1. Read the file. Distil each entry into one atomic, third-person claim —
    ledger decisions and map entries → `fact` (set `valid_from` from the
@@ -36,7 +55,14 @@ Then, for whichever of these exist — `LEDGER=` and every file under
    entries is normal.
 4. Rename each imported file to `<name>.imported` in place — keep it on disk;
    the `.imported` suffix is what stops a second import and marks the store
-   as the live copy. Deleting is the user's call, later.
+   as the live copy.
 
-Report per file: entries seen, claims stored, entries dropped. If none of the
-legacy files exist, say the project has no pre-agmem memory and stop.
+## 3. Report, then the directory
+
+Per file: entries seen, claims stored, entries dropped; per document: kind
+and id. If nothing under `NOTES=` was importable, say the project has no
+pre-documents memory and stop.
+
+The directory itself is meant to be gone — nothing reads it, and
+`/ctx-flow-doctor` reports it while it holds files. Deleting is the user's
+action: tell them the `rm -r` to run once they have checked the table.

--- a/.claude/commands/checkpoint.md
+++ b/.claude/commands/checkpoint.md
@@ -30,8 +30,22 @@ Subagents may end a response with `LEARNED: <claim> — <evidence>`. Those are
 is deliberate: the agent proposing a rule is often the cheapest, least
 informed thing in the system, and rules it writes bind every future run.
 
-For each proposal from this session, apply all four tests. Store it only if it
-passes all of them:
+Collect them from two places. The replies still in context, and this
+branch's **documents** — an agent that wrote one closed it with the same
+line, and that copy survives compaction. List them with the branch tag the
+plugin announced at session start (or `nu
+"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/scripts/ctx-flow-paths.nu" --tag`):
+
+```bash
+agmem doc list --tag branch:<slug>
+agmem doc get <id> --raw | rg '^LEARNED:'      # per document written this session
+```
+
+Keep the documents in the shell; only the proposal lines reach the thread.
+The `agent:<name>` tag on a document names the role a proposal belongs to.
+
+For each proposal, apply all four tests. Store it only if it passes all of
+them:
 
 1. **Durable** — true of this project, not of this task.
 2. **Non-obvious** — not something the repo, a type, or a test already says.
@@ -43,20 +57,25 @@ passes all of them:
 An accepted proposal becomes a `lesson` tagged `role:<agent>`, with the
 evidence in the claim itself ("… — proved by the 2026-08-30 retry-path
 deadlock"), because a rule whose reason is invisible cannot be pruned honestly
-later. A proposal that binds *every* session, not just one role, becomes an
-`instruction` — rare, and worth a second look before pinning.
+later. One that came out of a document is stored with `reflect`, not
+`remember`, with `derived_from: ["episode:<doc id>"]` — the lesson then cites
+the report it was earned in, and `inspect` can open it. A proposal that
+binds *every* session, not just one role, becomes an `instruction` — rare,
+and worth a second look before pinning.
 
 Before storing, `recall` with the same `role:` tag: if an existing rule
 contradicts the new one, resolve it now with `supersedes` — two opposing rules
 are worse than neither.
 
 **Dropping a proposal is the common outcome and needs no justification.** Say
-how many you saw and how many you kept, and move on.
+how many you saw (and how many of those came from documents) and how many
+you kept, and move on.
 
 ## 3. Legacy files
 
-If `.claude/notes/LEDGER.md` exists, this checkout predates agmem — run
-`/agmem-import` once to move its contents into the store.
+If `/ctx-flow-doctor`'s `notes` row is not `ok`, this checkout still carries
+the retired `.claude/notes/` dropbox — a pre-agmem ledger, or artifacts from
+before documents. Run `/agmem-import` once to move them into the store.
 
 ## Then
 

--- a/.claude/docs/reference.md
+++ b/.claude/docs/reference.md
@@ -32,7 +32,9 @@ VERDICT_KEY: <enum of 2-4 values>
 <CLOSING_KEY>: <one sentence>
 
 Forbidden: <the specific padding this role tends to produce>
-Anything longer than N lines → write to .claude/notes/ and return the path.
+Anything longer than N lines → pipe it into
+`nu "$CLAUDE_PROJECT_DIR/.claude/scripts/doc-put.nu" <agent> <kind> <title>`
+and return `DOC: <id> <uri>`.
 ```
 
 ## Dispatching well
@@ -82,8 +84,9 @@ The lifetime split the two files used to carry maps onto kinds and decay:
 
 The slug in `branch:<slug>` is computed inside the agmem binary — its
 SessionStart hook announces it and its checkpoint writes it, one rule for
-both sides. `hooks/scripts/ctx-flow-paths.nu` (`TAG=`) carries the same rule
-for `/agmem-import`, and is the one place here that must keep matching it.
+both sides. `hooks/scripts/ctx-flow-paths.nu` (`TAG=`, `--tag`) carries the
+same rule for `/agmem-import`, and `scripts/doc-put.nu` reaches it through
+the same `_common.nu` — the one place here that must keep matching it.
 
 Writing well is `/checkpoint`'s job, and its order matters: distil → `recall`
 the topic → `remember`, with `supersedes` carrying the id of anything now
@@ -93,10 +96,21 @@ checkpoints are idempotent and history survives correction — `inspect` shows
 any claim's chain and source, and `recall` with `as_of` replays what was
 believed at any past instant.
 
-What does **not** go in the store: anything git records, anything the code
-says plainly, anything true only for the current turn — and artifacts. Long
-tool output goes under `.claude/notes/` with the path returned; agmem holds
-claims, not blobs.
+What does **not** go in the store as a *claim*: anything git records,
+anything the code says plainly, anything true only for the current turn.
+Long tool output is not a claim either, but it does go in the store — as a
+**document**, the named, typed artifact tier over the episode table. A
+subagent pipes it into `scripts/doc-put.nu <agent> <kind> <title>` and
+returns `DOC: <id> memory://<space>/doc/<id>`; the wrapper tags it
+`branch:<slug>` (so `agmem doc list --tag branch:<slug>` is this branch's
+artifacts) and `agent:<name>` (so `/checkpoint` knows which role's playbook
+a proposal inside it joins). The kinds: `plan` (architect), `review`
+(verifier), `report` (runner, browser, scout, tracker), `probe`,
+`transcript`, `other`. A lesson accepted from a document is stored with
+`reflect` and `derived_from: ["episode:<id>"]`, so the claim cites the
+artifact it came from — the provenance the old `.claude/notes/` dropbox
+never had. `agmem doc get <id|title> --raw` reads one back; `/agmem-import`
+moves a pre-documents dropbox in.
 
 ## Staying ahead of compaction
 

--- a/.claude/hooks/scripts/_common.nu
+++ b/.claude/hooks/scripts/_common.nu
@@ -38,9 +38,9 @@ def absolute? [p: string]: nothing -> bool {
 # Root of the MAIN worktree — shared by every linked worktree of this repo.
 #
 # `git rev-parse --git-common-dir` points at the one real .git directory from
-# anywhere in the repo, including linked worktrees, so durable notes written
-# here follow you across every branch and every worktree — with or without a
-# symlinked .claude. Outside a repo this degrades to the cwd.
+# anywhere in the repo, including linked worktrees, so the framework files
+# resolve to one place from every branch and every worktree — with or without
+# a symlinked .claude. Outside a repo this degrades to the cwd.
 export def shared-root [cwd: string]: nothing -> string {
     let common = git-out $cwd rev-parse "--git-common-dir"
     if ($common | is-empty) { return $cwd }
@@ -71,12 +71,12 @@ export def slug [b: string]: nothing -> string {
     | default --empty "detached"
 }
 
-# {root, ledger, branch, state, tag} — root and tag serve the live flow (the
-# .claude/notes artifact dropbox and the agmem branch tag, one slug rule for
-# the hook that announces it and the /checkpoint that writes it); ledger and
-# state are the LEGACY file locations, still resolved so /agmem-import can find
-# what a pre-agmem checkout wrote. `state` and `tag` are null on a detached
-# HEAD.
+# {root, notes, ledger, branch, state, tag} — root and tag serve the live
+# flow (the shared root and the agmem branch tag, one slug rule for the hook
+# that announces it, the /checkpoint that writes it, and doc-put.nu that tags
+# documents with it); notes, ledger and state are the LEGACY file locations,
+# still resolved so /agmem-import can find what a pre-agmem checkout wrote.
+# `state` and `tag` are null on a detached HEAD.
 export def paths [p: record]: nothing -> record {
     let cwd = cwd-of $p
     let root = shared-root $cwd
@@ -84,6 +84,7 @@ export def paths [p: record]: nothing -> record {
 
     {
         root: $root
+        notes: ($root | path join $NOTES_REL)
         ledger: ($root | path join $NOTES_REL "LEDGER.md")
         branch: $branch
         state: (if $branch == null { null } else {
@@ -93,13 +94,28 @@ export def paths [p: record]: nothing -> record {
     }
 }
 
+# Warning text when the retired notes dropbox holds files, or null when it is
+# absent or empty. Subagents write documents into agmem now; a file landing
+# under .claude/notes is invisible to memory and to every other worktree, so
+# it is reported rather than tolerated. `.imported` files count: the directory
+# is meant to be gone, not archived.
+export def notes-check [root: string]: nothing -> any {
+    let dir = $root | path join $NOTES_REL
+    if ($dir | path type) != "dir" { return null }
+    let files = try { glob ($dir | path join "**" "*") --no-dir } | default []
+    if ($files | is-empty) { return null }
+    ($"RETIRED NOTES DROPBOX: ($dir) holds ($files | length) file\(s\). Subagents write agmem "
+        + "documents now \(`agmem doc list`\); nothing reads this directory. Fix: `/agmem-import` "
+        + "moves the files into the store, then `rm -r` the directory.")
+}
+
 # Warning text when the worktree layout strands the shared .claude, or null
-# when the layout is sound. The framework and the .claude/notes artifact
-# dropbox resolve through `shared-root` — the main worktree, or with a bare
-# repo the directory holding the bare git dir — so a `.claude` that exists only
-# inside one linked worktree has diverged from the copy every other worktree
-# shares. (Durable memory itself lives in agmem, keyed off the same shared git
-# dir, so it is immune to this — the stakes here are profiles and artifacts.)
+# when the layout is sound. The framework resolves through `shared-root` — the
+# main worktree, or with a bare repo the directory holding the bare git dir —
+# so a `.claude` that exists only inside one linked worktree has diverged from
+# the copy every other worktree shares. (Durable memory itself lives in agmem,
+# keyed off the same shared git dir, so it is immune to this — the stakes here
+# are profiles and the framework files.)
 export def layout-check [cwd: string]: nothing -> any {
     let top = git-out $cwd rev-parse "--show-toplevel"
     if ($top | is-empty) { return null }                                # not in a work tree
@@ -109,8 +125,8 @@ export def layout-check [cwd: string]: nothing -> any {
     if not ($top | path join ".claude" | path exists) { return null }   # no .claude anywhere — nothing stranded
     ($"WORKTREE LAYOUT MISMATCH: ($root)/.claude does not exist, but this worktree carries its "
         + "own .claude — in this layout the real .claude lives at the shared root and is "
-        + "symlinked into each worktree, so profiles and the .claude/notes artifact dropbox "
-        + "stay one copy. Fix: `bare-worktree apply`. /ctx-flow-doctor explains the layout.")
+        + "symlinked into each worktree, so profiles and the framework files stay one copy. "
+        + "Fix: `bare-worktree apply`. /ctx-flow-doctor explains the layout.")
 }
 
 # --- tunables ------------------------------------------------------------

--- a/.claude/hooks/scripts/ctx-flow-paths.nu
+++ b/.claude/hooks/scripts/ctx-flow-paths.nu
@@ -10,20 +10,25 @@
 # session is cleared, and the branch state is never recalled. Anything git
 # permits but a slug should not carry — `+ # ( ) % &`, non-ASCII, over 80
 # characters — diverges the same way. One resolver, called by both sides, is
-# the only version of this that stays correct. LEDGER/STATE are the legacy
-# file locations, kept so /agmem-import can find a pre-agmem checkout's notes.
+# the only version of this that stays correct. NOTES/LEDGER/STATE are the
+# legacy file locations, kept so /agmem-import can find a pre-agmem
+# checkout's notes; `scripts/doc-put.nu` reaches the same tag through
+# `_common.nu` directly.
 #
 # Usage, from anywhere inside the repo:
 #     nu ctx-flow-paths.nu            # KEY=VALUE lines, shell-friendly
 #     nu ctx-flow-paths.nu --json
+#     nu ctx-flow-paths.nu --tag      # the branch tag alone; nothing on a detached HEAD
 const COMMON = path self "_common.nu"
 use $COMMON *
 
-# Keys are printed straight from the record, so ROOT/LEDGER/BRANCH/STATE/TAG
-# cannot drift from what `paths` actually returns.
-def main [--json]: nothing -> nothing {
+# Keys are printed straight from the record, so ROOT/NOTES/LEDGER/BRANCH/
+# STATE/TAG cannot drift from what `paths` actually returns.
+def main [--json, --tag]: nothing -> nothing {
     let r = paths { cwd: $env.PWD }
-    if $json {
+    if $tag {
+        if $r.tag != null { print $r.tag }
+    } else if $json {
         print ($r | to json)
     } else {
         # BRANCH, STATE and TAG come back empty on a detached HEAD.

--- a/.claude/hooks/scripts/session-start-layout.nu
+++ b/.claude/hooks/scripts/session-start-layout.nu
@@ -5,17 +5,20 @@
 # SessionStart hook (`agmem hook session-start`), so nothing here touches the
 # store; a second briefing would only be noise on top of the plugin's.
 #
-# What remains is the worktree layout check: in a bare layout the real
-# `.claude` lives at the shared root and is symlinked into each worktree, and
-# a worktree carrying its own copy has silently diverged. That is a fact
-# about this checkout, which the plugin cannot know.
+# What remains is two checks about this checkout's files, which the plugin
+# cannot know: the worktree layout — in a bare layout the real `.claude` lives
+# at the shared root and is symlinked into each worktree, and a worktree
+# carrying its own copy has silently diverged — and the retired
+# `.claude/notes/` dropbox, which subagents no longer write and nothing reads,
+# so a file landing there is a regression worth one line.
 const COMMON = path self "_common.nu"
 use $COMMON *
 
 def main []: any -> nothing {
     let p = $in | payload
     try {
-        let mismatch = layout-check (cwd-of $p)
-        if $mismatch != null { context "SessionStart" $mismatch }
+        let cwd = cwd-of $p
+        let findings = [(layout-check $cwd) (notes-check (shared-root $cwd))] | compact
+        if not ($findings | is-empty) { context "SessionStart" ($findings | str join "\n\n") }
     }
 }

--- a/.claude/scripts/doc-put.nu
+++ b/.claude/scripts/doc-put.nu
@@ -1,0 +1,58 @@
+#!/usr/bin/env nu
+# Store stdin as an agmem document and print its address — the one way a
+# subagent hands back anything longer than its return contract.
+#
+# Why a wrapper and not `agmem doc put` inline: the document must carry the
+# same `branch:<slug>` tag the SessionStart hook announces and /checkpoint
+# writes, so `agmem doc list --tag branch:<slug>` is "this branch's
+# documents". That slug has one rule, in `_common.nu`; an agent substituting
+# it by hand drifts, and on a detached HEAD an empty expansion becomes
+# `--tag ""`. The wrapper resolves the tag through `paths`, adds
+# `agent:<name>` so /checkpoint knows which role's playbook a proposal joins,
+# and refuses loudly where the raw CLI would fail quietly: a binary without
+# `agmem doc`, an empty document, one over the store's size cap.
+#
+# Usage, content on stdin:
+#     nu .claude/scripts/doc-put.nu <agent> <kind> <title> [--mime text/plain]
+# Prints `<id> memory://<space>/doc/<id>` — return it as `DOC: <id> <uri>`.
+const COMMON = path self "../hooks/scripts/_common.nu"
+use $COMMON [paths]
+
+# `MAX_EPISODE_CHARS` in the server — a document past it is refused, not cut.
+const CAP = 100000
+
+def main [
+    agent: string   # the role writing: architect, runner, browser, scout, tracker, verifier
+    kind: string    # plan | review | report | probe | transcript | other
+    title: string   # `<kind>-<topic>[-<date>]`; a second put under one title is a new version
+    --mime: string  # media type when not markdown, e.g. text/plain
+]: nothing -> nothing {
+    # A script's `main` does not receive stdin as pipeline input; read it.
+    let content = try { ^cat | complete | get stdout } | default ""
+    if ($content | str trim | is-empty) {
+        print -e "doc-put: nothing on stdin — pipe the document in"
+        exit 2
+    }
+    let chars = $content | str length
+    if $chars > $CAP {
+        print -e $"doc-put: ($chars) chars is over the ($CAP) cap — write it to /tmp/($title).md and return that path"
+        exit 2
+    }
+    let probe = try { ^agmem doc --help | complete | get exit_code } | default 1
+    if $probe != 0 {
+        print -e "doc-put: agmem has no `doc` subcommand (needs 0.2.0+) — write to /tmp and return the path"
+        exit 2
+    }
+
+    let p = paths { cwd: $env.PWD }
+    let tags = [$"agent:($agent)"] | append (if $p.tag == null { [] } else { [$p.tag] })
+    let tag_args = $tags | each {|t| ["--tag" $t] } | flatten
+    let mime_args = if $mime == null { [] } else { ["--mime" $mime] }
+
+    let r = $content | ^agmem doc put --kind $kind --title $title ...$tag_args ...$mime_args | complete
+    if $r.exit_code != 0 {
+        print -e ($r.stderr | str trim)
+        exit $r.exit_code
+    }
+    print -n $r.stdout
+}

--- a/.claude/scripts/doctor.nu
+++ b/.claude/scripts/doctor.nu
@@ -31,7 +31,7 @@ const PROJECT_SETTINGS = path self "../settings.json"
 const GRAMMARS = path self "grammars.nu"
 const COMMON = path self "../hooks/scripts/_common.nu"
 use $GRAMMARS *
-use $COMMON [layout-check]
+use $COMMON [layout-check notes-check shared-root]
 
 # agmem's version string under-reports (a build can carry space derivation
 # while still saying 0.1.0), so probe behaviour, not the version: --doctor
@@ -55,6 +55,16 @@ def agmem-row []: nothing -> record {
         let v = (try { ^agmem --version | complete | get stdout | str trim } | default "unknown version")
         return { dep: "agmem", status: "OLD", detail: $"($v), no `agmem hook`"
             fix: "brew upgrade agmem — without `agmem hook` (0.1.10+) the plugin's hooks are silent" }
+    }
+
+    # Subagents hand back long output as documents through `agmem doc put`
+    # (scripts/doc-put.nu); without the subcommand every such write fails and
+    # the agent falls back to a /tmp path nothing else reads.
+    let doc = (try { ^agmem doc --help | complete | get exit_code } | default 1)
+    if $doc != 0 {
+        let v = (try { ^agmem --version | complete | get stdout | str trim } | default "unknown version")
+        return { dep: "agmem", status: "OLD", detail: $"($v), no `agmem doc`"
+            fix: "brew upgrade agmem — without `agmem doc` (0.2.0+) subagents cannot write documents" }
     }
 
     let r = try { ^agmem --doctor | complete }
@@ -91,15 +101,25 @@ def agmem-plugin-row []: nothing -> record {
     }
 }
 
-# In a linked worktree, the framework and the .claude/notes artifact dropbox
-# resolve to the shared root — verify a .claude actually exists there, or
-# subagent artifacts land where nothing reads.
+# In a linked worktree, the framework resolves to the shared root — verify a
+# .claude actually exists there, or profiles and hooks come from a stray copy.
 def layout-row []: nothing -> record {
     let broken = try { layout-check $env.PWD }
     if $broken == null {
         { dep: "worktree layout", status: "ok", detail: "shared .claude reachable", fix: "" }
     } else {
         { dep: "worktree layout", status: "BROKEN", detail: "", fix: $broken }
+    }
+}
+
+# `.claude/notes/` is retired: subagents write agmem documents. A file that
+# lands there is invisible to memory, so a populated directory is a finding.
+def notes-row []: nothing -> record {
+    let warning = try { notes-check (shared-root $env.PWD) }
+    if $warning == null {
+        { dep: "notes", status: "ok", detail: "no .claude/notes dropbox", fix: "" }
+    } else {
+        { dep: "notes", status: "STALE", detail: "retired dropbox holds files", fix: $warning }
     }
 }
 
@@ -136,6 +156,7 @@ def main []: nothing -> nothing {
         (agmem-row)
         (agmem-plugin-row)
         (layout-row)
+        (notes-row)
         (dep "acli" false (probe acli "--version") "https://developer.atlassian.com/cloud/acli/ — only needed for Jira")
     ]
 

--- a/.claude/scripts/import-notes.nu
+++ b/.claude/scripts/import-notes.nu
@@ -1,0 +1,92 @@
+#!/usr/bin/env nu
+# Move the retired `.claude/notes/` dropbox into agmem as documents, once.
+#
+# Deterministic on purpose — the kind comes from the filename, the title is
+# the stem, nothing is distilled — so it is a script and not a prompt. Each
+# imported file is renamed `<name>.imported` in place (the ledger convention:
+# a second run is a no-op, and the rename is reversible); deleting the
+# directory stays the user's action, which /agmem-import asks for last.
+#
+# What it does not import, and says so: `.imported` files, anything that is
+# not `.md`/`.txt`, subdirectories (`state/`, `agmem-archive/` — their claims
+# went in through /agmem-import already), and a file over the store's cap.
+#
+# Usage, from anywhere inside the repo:
+#     nu .claude/scripts/import-notes.nu --dry-run   # the table, no writes
+#     nu .claude/scripts/import-notes.nu
+const COMMON = path self "../hooks/scripts/_common.nu"
+use $COMMON [paths]
+
+const CAP = 100000
+const TAG = "legacy-notes"
+
+# The filename rule, first match wins. `research-` files are reports (#154's
+# wording); audits and analyses are reviews; a `.txt` is an eval log — a probe.
+def kind-of [name: string]: nothing -> record {
+    let parsed = $name | path parse
+    let stem = $parsed.stem
+    if ($stem starts-with "plan-") or ($stem ends-with "-plan") {
+        { kind: "plan", mime: null }
+    } else if ($stem starts-with "review-") {
+        { kind: "review", mime: null }
+    } else if ($stem starts-with "research-") {
+        { kind: "report", mime: null }
+    } else if ($stem =~ 'audit|analysis') {
+        { kind: "review", mime: null }
+    } else if $parsed.extension == "txt" {
+        { kind: "probe", mime: "text/plain" }
+    } else {
+        { kind: "other", mime: null }
+    }
+}
+
+def main [--dry-run]: nothing -> nothing {
+    let dir = (paths { cwd: $env.PWD }).notes
+    if ($dir | path type) != "dir" {
+        print $"no notes directory at ($dir) — nothing to import"
+        return
+    }
+
+    let entries = ls $dir
+    let files = $entries
+        | where type == file
+        | where { ($in.name | path parse | get extension) in ["md" "txt"] }
+        | get name
+    let done = $entries | where name ends-with ".imported" | get name
+    let leftovers = $entries | where name not-in $files and name not-in $done | get name
+
+    let rows = $files | each {|f|
+        let content = open --raw $f
+        let chars = $content | str length
+        let k = kind-of $f
+        let title = $f | path parse | get stem
+        let base = { file: ($f | path basename), kind: $k.kind, chars: $chars }
+        if $chars > $CAP {
+            $base | merge { id: "", uri: $"skipped: over the ($CAP)-char cap" }
+        } else if $dry_run {
+            $base | merge { id: "", uri: "(dry run)" }
+        } else {
+            let mime_args = if $k.mime == null { [] } else { ["--mime" $k.mime] }
+            let r = $content
+                | ^agmem doc put --kind $k.kind --title $title --tag $TAG ...$mime_args
+                | complete
+            if $r.exit_code != 0 {
+                $base | merge { id: "", uri: $"FAILED: ($r.stderr | str trim | lines | first | default '')" }
+            } else {
+                let parts = $r.stdout | str trim | split row " "
+                mv $f $"($f).imported"
+                $base | merge { id: ($parts | first), uri: ($parts | get 1 | default "") }
+            }
+        }
+    }
+
+    print ($rows | table -i false --width 160)
+    if not ($done | is-empty) {
+        print $"already imported \(.imported\): ($done | length)"
+    }
+    if not ($leftovers | is-empty) {
+        print ""
+        print "not documents — move or delete by hand:"
+        $leftovers | each {|l| print $"  ($l)" } | ignore
+    }
+}

--- a/docs/design.md
+++ b/docs/design.md
@@ -1257,8 +1257,8 @@ Each phase is releasable; later phases only add.
 - **Phase 9 — Documents (#132, #134–#137):** a named, typed artifact tier
   over the episode table (v9 schema, span sidecar); windowed `inspect`, title
   supersession and cascade purge; `agmem doc` CLI + `memory://<space>/doc/{id}`
-  resource; the ctx-flow framework moves off `.claude/notes/`; recall-precision
-  eval with documents present.
+  resource; the ctx-flow framework moves off its notes dropbox onto
+  documents (#136); recall-precision eval with documents present.
 
 ## 9. Risks & open questions
 

--- a/docs/eval/token-analysis.nu
+++ b/docs/eval/token-analysis.nu
@@ -1,0 +1,223 @@
+# Token-spend analysis over Claude Code transcripts for this project.
+# Usage:  nu token-analysis-2026-09-03.nu            (uses cache if present)
+#         nu token-analysis-2026-09-03.nu --rebuild  (re-extracts from the jsonl)
+# Writes the tables to token-analysis-2026-09-03.md next to this script.
+
+const DIR = '/Users/Matthew/.claude/projects/-Users-Matthew-Development-agmem/'
+# The 2026-09-03 run is the `token-analysis-2026-09-03` review document in
+# the agmem store; a rerun writes to the temp dir, not the repo.
+const OUT = '/tmp/token-analysis.md'
+const CACHE = '/tmp/agmem-token-analysis.msgpackz'
+
+# chars of a content field that may be a string, a list of blocks, or anything
+def content-chars [c] {
+  match ($c | describe -d | get type) {
+    string => ($c | str length),
+    list => ($c | each {|b|
+      if ($b | describe -d | get type) == string { $b | str length } else if ($b.text? | is-not-empty) { $b.text | str length } else { $b | to json | str length }
+    } | math sum),
+    nothing => 0,
+    _ => ($c | to json | str length),
+  }
+}
+
+def user-text [c] {
+  match ($c | describe -d | get type) {
+    string => $c,
+    list => ($c | where ($it | describe -d | get type) == record | where type == text | get -o text | default [] | str join "\n"),
+    _ => '',
+  }
+}
+
+def classify-user [t: string] {
+  if ($t =~ '<command-name>') {
+    let name = ($t | parse -r '<command-name>([^<]+)</command-name>' | get -o capture0.0 | default '?')
+    $'slash:($name | str trim)'
+  } else if ($t | str starts-with '/') { $'slash:($t | split row " " | first | lines | first)' } else if ($t =~ '<task-notification>') { 'task-notification' } else if ($t =~ '<system-reminder>') { 'system-reminder' } else if ($t =~ 'Memory context') { 'memory-context' } else if ($t =~ '<local-command-') { 'local-command' } else if ($t | is-empty) { 'empty' } else { 'plain' }
+}
+
+def bash-head [cmd: string] {
+  $cmd
+  | str replace -r '^\s*(cd\s+\S+\s*&&\s*)+' ''
+  | str replace -r '^\s*rtk\s+' ''
+  | str replace -r '^\s*(RUST_\w+=\S+\s+|\w+=\S+\s+)+' ''
+  | str trim
+  | split row -r '\s+' | first | default ''
+  | str replace -r '^\((.*)' '$1'
+}
+
+def extract [f: string] {
+  let is_sub = ($f | str contains '/subagents/')
+  let session = if $is_sub { $f | path dirname | path dirname | path basename } else { $f | path basename | str replace '.jsonl' '' }
+  let recs = (open --raw $f | lines | each {|l| try { $l | from json } })
+  let base = {session: $session, is_sub: $is_sub, file: $f}
+
+  let turns = ($recs | where type == assistant
+    | where ($it.message?.id? | is-not-empty)
+    | each {|r| $base | merge {
+        kind: 'turn', ts: $r.timestamp?, model: ($r.message.model? | default '?'), msgid: $r.message.id,
+        input: ($r.message.usage?.input_tokens? | default 0),
+        cache_creation: ($r.message.usage?.cache_creation_input_tokens? | default 0),
+        cache_read: ($r.message.usage?.cache_read_input_tokens? | default 0),
+        output: ($r.message.usage?.output_tokens? | default 0),
+      }}
+    # streaming writes one record per content block; only the last carries the final output_tokens
+    | group-by msgid --to-table | each {|g| $g.items | first | merge {
+        input: ($g.items.input | math max), cache_creation: ($g.items.cache_creation | math max),
+        cache_read: ($g.items.cache_read | math max), output: ($g.items.output | math max) }})
+
+  let tool_uses = ($recs | where type == assistant
+    | each {|r| $r.message?.content? | default [] | each {|b| if ($b | describe -d | get type) == record { $b | merge {ts: $r.timestamp?} } } }
+    | flatten | where type == tool_use
+    | each {|b|
+        let i = ($b.input? | default {})
+        let cmd = ($i.command? | default '')
+        let snip = (if ($cmd | is-not-empty) { $cmd } else if ($i.file_path? | is-not-empty) { $i.file_path } else if ($i.prompt? | is-not-empty) { $i.prompt } else if ($i.input? | is-not-empty) { $i.input } else if ($i.query? | is-not-empty) { $i.query } else if ($i.pattern? | is-not-empty) { $i.pattern } else { $i | to json })
+        $base | merge {
+          kind: 'tool_use', ts: $b.ts, id: $b.id, name: $b.name,
+          input_chars: ($i | to json | str length),
+          snip: ($snip | str replace -a "\n" ' ' | str substring 0..100),
+          bash_head: (if ($cmd | is-not-empty) { bash-head $cmd } else { '' }),
+          skill: ($i.skill? | default ''),
+          subagent_type: ($i.subagent_type? | default ''),
+          agent_model: ($i.model? | default ''),
+          prompt_len: ($i.prompt? | default '' | str length),
+          has_limit: (($i.limit? | is-not-empty) or ($i.offset? | is-not-empty)),
+        }})
+
+  let user_recs = ($recs | where type == user)
+  let tool_results = ($user_recs
+    | each {|r| let c = $r.message?.content?; if ($c | describe -d | get type) == list { $c | each {|b| if ($b | describe -d | get type) == record { $b | merge {ts: $r.timestamp?} } } } else { [] } }
+    | flatten | where type == tool_result
+    | each {|b| $base | merge {kind: 'tool_result', ts: $b.ts, id: $b.tool_use_id, chars: (content-chars $b.content?),
+        has_reminder: (($b.content? | to json) =~ 'system-reminder')}})
+
+  let users = ($user_recs | each {|r|
+    let t = (user-text $r.message?.content?)
+    let cls = (if ($r.isCompactSummary? | default false) { 'compact-summary' } else { classify-user $t })
+    if ($t | is-not-empty) or ($cls != 'empty') {
+      $base | merge {kind: 'user', ts: $r.timestamp?, uclass: $cls, chars: ($t | str length), is_meta: ($r.isMeta? | default false),
+        ref_id: ($t | parse -r '<tool-use-id>([^<]+)</tool-use-id>' | get -o capture0.0 | default '')}
+    }})
+
+  let atts = ($recs | where type == attachment | each {|r|
+    let a = $r.attachment
+    let chars = (match $a.type {
+      hook_success => ($a.stdout? | default '' | str length),
+      hook_additional_context => (content-chars $a.content?),
+      _ => ($a | to json | str length),
+    })
+    $base | merge {kind: 'attachment', ts: $r.timestamp?, atype: $a.type, hook: ($a.hookName? | default ''), chars: $chars}})
+
+  let systems = ($recs | where type == system | each {|r| $base | merge {kind: 'system', ts: $r.timestamp?, subtype: ($r.subtype? | default ''), chars: (content-chars $r.content?)}})
+
+  [$turns $tool_uses $tool_results $users $atts $systems] | flatten
+}
+
+def build [] {
+  let files = (glob ($DIR + '**/*.jsonl'))
+  print $'extracting ($files | length) files'
+  let rows = ($files | par-each {|f| extract $f } | flatten)
+  $rows | to msgpackz | save -f $CACHE
+  $rows
+}
+
+def md-table [t] { $t | to md --pretty }
+
+def main [--rebuild] {
+  let rows = (if $rebuild or not ($CACHE | path exists) { build } else { open $CACHE | from msgpackz })
+  let turns = ($rows | where kind == 'turn')
+  let uses = ($rows | where kind == 'tool_use')
+  let results = ($rows | where kind == 'tool_result')
+  let users = ($rows | where kind == 'user')
+  let atts = ($rows | where kind == 'attachment')
+  let systems = ($rows | where kind == 'system')
+
+  # ---- 1. totals -----------------------------------------------------------
+  def tot [t] {
+    { sessions: ($t | get session | uniq | length), files: ($t | get file | uniq | length), turns: ($t | length),
+      input: ($t.input | math sum), cache_creation: ($t.cache_creation | math sum), cache_read: ($t.cache_read | math sum), output: ($t.output | math sum) }
+  }
+  let totals = ([
+    ({scope: 'all'} | merge (tot $turns)),
+    ({scope: 'main'} | merge (tot ($turns | where not is_sub))),
+    ({scope: 'subagent'} | merge (tot ($turns | where is_sub))),
+  ])
+  let per_model = ($turns | group-by model --to-table | each {|g| {model: $g.model, scope: 'all'} | merge (tot $g.items | reject sessions files)}
+    | append ($turns | group-by {|r| $'($r.model)|($r.is_sub)'} --to-table | each {|g| {model: ($g.items.0.model), scope: (if $g.items.0.is_sub { 'subagent' } else { 'main' })} | merge (tot $g.items | reject sessions files)})
+    | sort-by scope model)
+
+  # ---- 2. per session --------------------------------------------------------
+  let joined = ($uses | join ($results | select id chars has_reminder) id --left | default 0 chars)
+  let per_session = ($turns | group-by session --to-table | each {|g|
+    let s = $g.session
+    let su = ($uses | where session == $s)
+    { session: ($s | str substring 0..8), date: ($g.items | get ts | sort | first | default '' | str substring 0..10),
+      turns: ($g.items | length), main_turns: ($g.items | where not is_sub | length),
+      cache_read: ($g.items.cache_read | math sum), cache_creation: ($g.items.cache_creation | math sum), output: ($g.items.output | math sum),
+      total: (($g.items.cache_read | math sum) + ($g.items.cache_creation | math sum) + ($g.items.output | math sum) + ($g.items.input | math sum)),
+      tool_calls: ($su | length), agents: ($su | where name == 'Agent' | length),
+      compacted: ((($users | where session == $s and uclass == 'compact-summary' | length) > 0) or (($systems | where session == $s and subtype == 'compact_boundary' | length) > 0)),
+    }} | sort-by total -r)
+
+  # ---- 3. tool usage ---------------------------------------------------------
+  def tool-table [j] { $j | group-by name --to-table | each {|g| {tool: $g.name, calls: ($g.items | length), result_chars: ($g.items.chars | math sum), avg_chars: (($g.items.chars | math avg) | math round), input_chars: ($g.items.input_chars | math sum)}} | sort-by result_chars -r }
+  let tools_all = (tool-table $joined)
+  let tools_main = (tool-table ($joined | where not is_sub))
+  let tools_sub = (tool-table ($joined | where is_sub))
+  let result_total = ($joined.chars | math sum)
+
+  # ---- 4. agent dispatches ---------------------------------------------------
+  # background agents return a ~1k "launched" stub as the tool_result; the real report arrives later as a
+  # <task-notification> user message carrying the Agent tool_use id — join that in as `avg_notification`
+  let notes = ($users | where uclass == 'task-notification' and ($it.ref_id | is-not-empty) | select ref_id chars | rename id note_chars)
+  let agents = ($joined | where name == 'Agent' | join $notes id --left | default 0 note_chars | group-by {|r| $'($r.subagent_type)|($r.agent_model)'} --to-table | each {|g|
+    {subagent_type: ($g.items.0.subagent_type | default '' | if ($in | is-empty) { '(none)' } else { $in }), model: ($g.items.0.agent_model | if ($in | is-empty) { '(default)' } else { $in }), count: ($g.items | length), avg_prompt: ($g.items.prompt_len | math avg | math round), avg_result_stub: ($g.items.chars | math avg | math round), notified: ($g.items | where note_chars > 0 | length), avg_notification: ($g.items | where note_chars > 0 | get note_chars | append 0 | math avg | math round), max_notification: ($g.items.note_chars | math max)}} | sort-by count -r)
+
+  # ---- 5. bash -----------------------------------------------------------------
+  let bash = ($joined | where name == 'Bash')
+  let bash_by_count = ($bash | group-by bash_head --to-table | each {|g| {cmd: $g.bash_head, count: ($g.items | length), result_chars: ($g.items.chars | math sum), avg: ($g.items.chars | math avg | math round), over_5k: ($g.items | where chars > 5000 | length)}})
+  let bash_top_count = ($bash_by_count | sort-by count -r | first 25)
+  let bash_top_chars = ($bash_by_count | sort-by result_chars -r | first 25)
+  let bash_big = ($bash | where chars > 5000 | sort-by chars -r | select session bash_head chars snip | update session { str substring 0..8 })
+
+  # ---- 6. slash / skills -----------------------------------------------------
+  let skills = ($joined | where name == 'Skill' | group-by skill --to-table | each {|g| {skill: $g.skill, count: ($g.items | length), result_chars: ($g.items.chars | math sum)}} | sort-by count -r)
+  let slash = ($users | where ($it.uclass | str starts-with 'slash:') | group-by uclass --to-table | each {|g| {command: ($g.uclass | str replace 'slash:' ''), count: ($g.items | length), main: ($g.items | where not is_sub | length)}} | sort-by count -r)
+
+  # ---- 7. mcp -----------------------------------------------------------------
+  let mcp = ($tools_all | where ($it.tool | str starts-with 'mcp__'))
+
+  # ---- 8. injected context ---------------------------------------------------
+  let inj_users = ($users | where {|r| ($r.uclass in ['system-reminder' 'memory-context' 'task-notification' 'local-command' 'compact-summary']) or $r.is_meta }
+    | group-by {|r| if $r.is_meta and $r.uclass == 'plain' { 'meta' } else { $r.uclass }} --to-table | each {|g| {kind: $'user:($g.closure_0)', count: ($g.items | length), chars: ($g.items.chars | math sum)}})
+  let inj_atts = ($atts | group-by {|r| if ($r.hook | is-not-empty) { $'($r.atype):($r.hook)' } else { $r.atype }} --to-table | each {|g| {kind: $'attachment:($g.closure_0)', count: ($g.items | length), chars: ($g.items.chars | math sum)}})
+  let inj_results = ([{kind: 'tool_result containing <system-reminder>', count: ($results | where has_reminder | length), chars: ($results | where has_reminder | get chars | append 0 | math sum)}])
+  let injected = ($inj_users | append $inj_atts | append $inj_results | sort-by chars -r)
+  let compaction = {compact_summaries: ($users | where uclass == 'compact-summary' | length), chars: ($users | where uclass == 'compact-summary' | get chars | append 0 | math sum), compact_boundaries: ($systems | where subtype == 'compact_boundary' | length)}
+
+  # ---- 9. largest results ----------------------------------------------------
+  let largest = ($joined | sort-by chars -r | first 15 | select name chars session is_sub snip | update session { str substring 0..8 })
+
+  # ---- 10. Read ----------------------------------------------------------------
+  let reads = ($joined | where name == 'Read')
+  let read_tbl = ($reads | group-by {|r| if $r.has_limit { 'with limit/offset' } else { 'no limit/offset' }} --to-table | each {|g| {reads: $g.closure_0, count: ($g.items | length), chars: ($g.items.chars | math sum), avg: ($g.items.chars | math avg | math round), pct_of_all_result_chars: ((($g.items.chars | math sum) * 100 / $result_total) | math round -p 1)}})
+
+  let md = ([
+    '# Token analysis — agmem project transcripts — 2026-09-03',
+    $'Source: `($DIR)` — ($rows | get file | uniq | length) transcript files, ($turns | get session | uniq | length) sessions.',
+    '', '## 1. Totals', (md-table $totals), '', '### Per model', (md-table $per_model),
+    '', '## 2. Per session (top 15 by total tokens)', (md-table ($per_session | first 15)),
+    '', '## 3. Tool usage (all threads, by result chars)', $'Total tool_result chars: ($result_total)', (md-table $tools_all),
+    '', '### Main thread only', (md-table $tools_main), '', '### Subagents only', (md-table $tools_sub),
+    '', '## 4. Agent dispatches', (md-table $agents),
+    '', '## 5. Bash commands', '### Top 25 by count', (md-table $bash_top_count), '', '### Top 25 by result chars', (md-table $bash_top_chars), '', $'### Commands returning > 5,000 chars \(($bash_big | length)\)', (md-table $bash_big),
+    '', '## 6. Skills and slash commands', '### Skill tool', (md-table $skills), '', '### User slash commands', (md-table $slash),
+    '', '## 7. MCP tools', (md-table $mcp),
+    '', '## 8. Injected context', (md-table $injected), '', $'Compaction: ($compaction | to nuon)',
+    '', '## 9. Largest single tool_results', (md-table $largest),
+    '', '## 10. Read tool', (md-table $read_tbl),
+  ] | str join "\n")
+  $md | save -f $OUT
+  { totals: $totals, per_model: $per_model, per_session: ($per_session | first 15), tools: ($tools_all | first 12), tools_main: ($tools_main | first 8), tools_sub: ($tools_sub | first 8), agents: $agents, bash_count: ($bash_top_count | first 10), bash_chars: ($bash_top_chars | first 10), bash_big_n: ($bash_big | length), skills: $skills, slash: $slash, mcp: $mcp, injected: $injected, compaction: $compaction, largest: $largest, reads: $read_tbl, result_total: $result_total }
+}


### PR DESCRIPTION
Closes #136. No Rust; the framework needs the release that carries `agmem doc` (v0.2.0, #144).

**What changes**
- `.claude/scripts/doc-put.nu` — subagents pipe long output into it; it runs `agmem doc put`, tags the document `branch:<slug>` (resolved through `_common.nu`, so a detached HEAD gets no tag, never an empty one) and `agent:<role>`, probes for the `doc` subcommand, refuses an empty or over-cap document, and prints `<id> memory://<space>/doc/<id>`.
- The six agents return `DOC: <id> <uri>` where they returned a path. `architect` always stores its plan (`plan`); `verifier` → `review`; `runner`, `browser`, `scout`, `tracker` → `report`, only when output outgrows the contract. A `LEARNED:` line closes the document too.
- `/checkpoint` §2 lists this branch's documents, greps `LEARNED:` out of them in the shell, and stores an accepted lesson via `reflect` with `derived_from: ["episode:<doc id>"]`.
- `.claude/scripts/import-notes.nu` + `/agmem-import` step 1 — deterministic import of a notes dropbox (kind from filename, title from stem, tag `legacy-notes`, `.imported` rename, `--dry-run`). Run here: 19 documents, ids in the #154 comment.
- `/ctx-flow-doctor` gains a `notes` row and an `agmem doc` probe (`OLD` without it); the SessionStart layout hook reports a populated `.claude/notes/` too.
- `ctx-flow-paths.nu --tag`; `NOTES=` in its output. Docs: CLAUDE.md, README, reference.md, design.md roadmap line; `.claude/.gitignore` keeps `notes/` ignored.
- `docs/eval/token-analysis.nu` — the probe script that lived in the dropbox, output redirected to `/tmp`.

**Deliberate departures from the issue text**
- No `agmem --doctor` warning in Rust: the binary is generic by the issue's own note; the check lives in the framework's doctor and hook.
- The "N documents this branch" briefing line goes to #151 with the footer rewrite; it is a second daemon round trip on every SessionStart.

**Side change:** `architect` runs at effort `high` rather than `xhigh` (reverts eb5f1d4 on purpose).

**Verified:** `import-notes.nu --dry-run` and the real run, `doc-put.nu` with a smoke document (purged), the empty-stdin refusal, `doctor.nu` (`notes ok`, `agmem ok`), the hook silent with the directory gone, `rg '\.claude/notes'` over `.claude plugin docs` returns only the retired-dropbox wording and `NOTES_REL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013aj6D2zsokbFhzrthwJW6J
