### PR TITLE
chore: release v0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
   "owner": { "name": "Mate Alfoldi" },
   "metadata": {
     "description": "agmem — persistent memory for coding agents over MCP",
-    "version": "0.1.11"
+    "version": "0.2.0"
   },
   "plugins": [
     {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-core"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "jiff",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-embed"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "fastembed",
  "serde_json",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-server"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "agmem-core",
  "agmem-embed",
@@ -83,7 +83,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-store"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "agmem-core",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.11"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -21,9 +21,9 @@ homepage = "https://github.com/AlfoldiMate/agmem"
 # dependency with no version requirement. Local builds resolve by path either
 # way, and a caret requirement stays satisfied across the bumps release-plz
 # makes.
-agmem-core = { path = "crates/agmem-core", version = "0.1.11" }
-agmem-store = { path = "crates/agmem-store", version = "0.1.11" }
-agmem-embed = { path = "crates/agmem-embed", version = "0.1.11" }
+agmem-core = { path = "crates/agmem-core", version = "0.2.0" }
+agmem-store = { path = "crates/agmem-store", version = "0.2.0" }
+agmem-embed = { path = "crates/agmem-embed", version = "0.2.0" }
 
 # MCP + storage + embeddings (pinned per docs/design.md §4.1)
 rmcp = { version = "3.1", features = ["server", "macros", "transport-io"] }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "agmem",
   "displayName": "agmem memory",
   "description": "Persistent cross-session memory for Claude Code: the agmem MCP server, a briefing injected at every session start, checkpoint and tidy commands, and hooks that log what memory was used so the store can learn what helped.",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "author": { "name": "Mate Alfoldi" },
   "homepage": "https://github.com/AlfoldiMate/agmem",
   "repository": "https://github.com/AlfoldiMate/agmem",


### PR DESCRIPTION



## 🤖 New release

* `agmem-core`: 0.1.11 -> 0.2.0 (⚠ API breaking changes)
* `agmem-store`: 0.1.11 -> 0.2.0 (✓ API compatible changes)
* `agmem-embed`: 0.1.11 -> 0.2.0
* `agmem-server`: 0.1.11 -> 0.2.0 (✓ API compatible changes)

### ⚠ `agmem-core` breaking changes

```text
--- failure constructible_struct_adds_field: struct exhaustively constructible through public API adds field ---

Description:
A pub struct that could be exhaustively constructed with a literal using only public API has a new pub field, breaking existing exhaustive literals.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Episode.title in /tmp/.tmpAOA5Qr/agmem/crates/agmem-core/src/model.rs:636
  field Episode.doc_kind in /tmp/.tmpAOA5Qr/agmem/crates/agmem-core/src/model.rs:638
  field Episode.tags in /tmp/.tmpAOA5Qr/agmem/crates/agmem-core/src/model.rs:640
  field Episode.mime in /tmp/.tmpAOA5Qr/agmem/crates/agmem-core/src/model.rs:642
  field Episode.title in /tmp/.tmpAOA5Qr/agmem/crates/agmem-core/src/model.rs:636
  field Episode.doc_kind in /tmp/.tmpAOA5Qr/agmem/crates/agmem-core/src/model.rs:638
  field Episode.tags in /tmp/.tmpAOA5Qr/agmem/crates/agmem-core/src/model.rs:640
  field Episode.mime in /tmp/.tmpAOA5Qr/agmem/crates/agmem-core/src/model.rs:642
```

<details><summary><i><b>Changelog</b></i></summary><p>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).