### PR TITLE
The briefing keeps room for its lessons (#152)

### DIFF
--- a/crates/agmem-server/src/hook.rs
+++ b/crates/agmem-server/src/hook.rs
@@ -308,7 +308,15 @@ async fn session_start(cfg: &Config, session: &Session, payload: &Value) -> Opti
         parts.push(note);
     }
 
-    let briefing = oneshot::fetch(cfg, ContextArgs::default()).await;
+    // Aim the Relevant section at the work in front of the session (issue
+    // #152): the branch and the last commit subject are what the repo itself
+    // says the work is. Without them the section is a recency list.
+    let branch = branch_of(&cwd);
+    let args = ContextArgs {
+        query: aim(branch.as_deref(), last_subject(&cwd).as_deref()),
+        ..ContextArgs::default()
+    };
+    let briefing = oneshot::fetch(cfg, args).await;
     let memory = match briefing {
         Ok(block) if !block.trim().is_empty() => format!("{}\n\n{FOOTER}", block.trim()),
         Ok(_) => HEADER.to_owned(),
@@ -317,7 +325,7 @@ async fn session_start(cfg: &Config, session: &Session, payload: &Value) -> Opti
             HEADER.to_owned()
         }
     };
-    let branch_note = branch_of(&cwd)
+    let branch_note = branch
         .map(|b| {
             format!(
                 " In-flight state for the current branch ({b}) carries the tag branch:{} — \
@@ -523,6 +531,32 @@ fn branch_of(cwd: &Path) -> Option<String> {
     (!branch.is_empty() && branch != "HEAD").then_some(branch)
 }
 
+/// The subject line of the last commit, or `None` outside a repo or on an
+/// unborn branch.
+fn last_subject(cwd: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(["log", "-1", "--format=%s"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let subject = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    (!subject.is_empty()).then_some(subject)
+}
+
+/// The briefing query the repo state implies: "<branch>: <subject>", either
+/// half alone when the other is missing, nothing when both are.
+fn aim(branch: Option<&str>, subject: Option<&str>) -> Option<String> {
+    match (branch, subject) {
+        (Some(branch), Some(subject)) => Some(format!("{branch}: {subject}")),
+        (Some(one), None) | (None, Some(one)) => Some(one.to_owned()),
+        (None, None) => None,
+    }
+}
+
 /// A branch name as the tag carries it — the rule the ctx-flow hooks and
 /// `/checkpoint` share, so the two sides of the tag cannot drift.
 fn slug(branch: &str) -> String {
@@ -585,6 +619,17 @@ mod tests {
                 "{shape}"
             );
         }
+    }
+
+    #[test]
+    fn the_briefing_is_aimed_from_whatever_the_repo_can_say() {
+        assert_eq!(
+            aim(Some("main"), Some("Fix the retry loop (#12)")),
+            Some("main: Fix the retry loop (#12)".to_owned())
+        );
+        assert_eq!(aim(Some("main"), None), Some("main".to_owned()));
+        assert_eq!(aim(None, Some("Initial")), Some("Initial".to_owned()));
+        assert_eq!(aim(None, None), None);
     }
 
     #[test]

--- a/crates/agmem-server/src/tools/context.rs
+++ b/crates/agmem-server/src/tools/context.rs
@@ -35,11 +35,25 @@ const DEFAULT_BUDGET_CHARS: u32 = 6_000;
 /// budget this small is refused rather than served misleadingly.
 const MIN_BUDGET_CHARS: u32 = 200;
 
-/// How many claims the Relevant section contributes.
+/// How many claims the Relevant section contributes when a query aims it.
 const RELEVANT_K: usize = 10;
+
+/// How many claims the Relevant section contributes with no query (issue
+/// #152). Unaimed, the section is a recency-and-strength list rather than an
+/// answer, and ten of those filled the default budget before Lessons got a
+/// line on a real store.
+const RELEVANT_UNAIMED_K: usize = 5;
 
 /// How many lessons the Lessons section contributes (design §3.2).
 const LESSONS_K: usize = 5;
+
+/// How much of the budget the sections above Lessons may not spend, so a
+/// store's hard-won how-tos reach the session even when Relevant could fill
+/// the block on its own (issue #152). A third of the default budget: three
+/// lessons of the length a real store writes them (~600 characters). Capped at
+/// a third of any budget so a small block still leads with its instructions,
+/// and never held back for room the section has nothing to put in.
+const LESSONS_RESERVE_CHARS: usize = 2_000;
 
 /// The tag that makes a fact part of the profile (design §3.2).
 const IDENTITY_TAG: &str = "identity";
@@ -86,6 +100,27 @@ pub struct ContextParams {
 struct Section {
     heading: &'static str,
     entries: Vec<Entry>,
+    /// Characters the sections before this one may not spend, so that filling
+    /// in priority order cannot starve it. Bounded by what the section could
+    /// actually use, so an empty section reserves nothing.
+    reserve: usize,
+}
+
+impl Section {
+    /// The room this section can hold back from the ones above it: its
+    /// reserve, or less when its heading and every entry would not fill it.
+    fn held(&self) -> usize {
+        if self.reserve == 0 || self.entries.is_empty() {
+            return 0;
+        }
+        let demand = format!("\n\n{}", self.heading).chars().count()
+            + self
+                .entries
+                .iter()
+                .map(|entry| entry.line().chars().count())
+                .sum::<usize>();
+        self.reserve.min(demand)
+    }
 }
 
 /// One line of the block: a claim, and the id that leads back to it.
@@ -136,10 +171,13 @@ pub async fn run(
     let pool = usize::from(service.config().pool);
 
     // The order is the priority order: what the agent must obey, who it is
-    // working for, what today is about, what past sessions paid to learn.
+    // working for, what today is about, what past sessions paid to learn. The
+    // last of those holds a reserve (issue #152): priority decides who fills
+    // first, not who gets to exist.
     let sections = [
         Section {
             heading: HEADING_INSTRUCTIONS,
+            reserve: 0,
             entries: lookup_section(
                 service,
                 &spaces,
@@ -155,6 +193,7 @@ pub async fn run(
         },
         Section {
             heading: HEADING_PROFILE,
+            reserve: 0,
             entries: lookup_section(
                 service,
                 &spaces,
@@ -171,12 +210,15 @@ pub async fn run(
         },
         Section {
             heading: HEADING_RELEVANT,
+            reserve: 0,
             entries: match &query {
                 Some(text) => search_section(service, &spaces, text, now).await?,
                 // No query is not "nothing to say" — it is the general case,
                 // and what a session wants then is the strongest facts that
                 // have held up (design §3.2), with the summaries that stand
-                // in for whole groups of them (issue #85) alongside.
+                // in for whole groups of them (issue #85) alongside. Fewer of
+                // them than an aimed search returns: unaimed, the list is
+                // orientation, not an answer (issue #152).
                 None => {
                     lookup_section(
                         service,
@@ -185,7 +227,7 @@ pub async fn run(
                             kinds: vec![Kind::Fact, Kind::Summary],
                             ..Filters::default()
                         },
-                        RELEVANT_K,
+                        RELEVANT_UNAIMED_K,
                         None,
                         now,
                     )
@@ -195,6 +237,7 @@ pub async fn run(
         },
         Section {
             heading: HEADING_LESSONS,
+            reserve: lessons_reserve(budget),
             entries: lookup_section(
                 service,
                 &spaces,
@@ -212,6 +255,11 @@ pub async fn run(
 
     let markdown = assemble(&spaces, &sections, budget);
     Ok(CallToolResult::success(vec![ContentBlock::text(markdown)]))
+}
+
+/// What Lessons holds back from the sections above it at this budget.
+fn lessons_reserve(budget: usize) -> usize {
+    LESSONS_RESERVE_CHARS.min(budget / 3)
 }
 
 /// The block, fitted to its budget in up to three fills.
@@ -392,6 +440,13 @@ fn cap_by_tag(records: Vec<MemoryRecord>, cap: usize) -> Vec<MemoryRecord> {
 /// marks everything it covers as already shown, so its children neither cost
 /// budget nor count as dropped — the digest is standing in for them, which is
 /// what it was written to do, and each one stays one `inspect` away.
+///
+/// A section fills against the budget less what every later section holds
+/// back (`Section::held`), so filling in priority order can no longer starve a
+/// section that has something to say (issue #152). What a reserved section
+/// then leaves unused is not lost — it simply was not needed. The first
+/// section never yields to a reserve: what the agent must obey outranks what
+/// would help it, and at the budget floor the two cannot both fit.
 fn render(
     spaces: &[SpaceName],
     sections: &[Section],
@@ -406,7 +461,13 @@ fn render(
     let mut dropped = 0;
     let mut seen: HashSet<&MemoryId> = HashSet::new();
 
-    for section in sections {
+    for (index, section) in sections.iter().enumerate() {
+        let held: usize = if index == 0 {
+            0
+        } else {
+            sections[index + 1..].iter().map(Section::held).sum()
+        };
+        let budget = budget.saturating_sub(held);
         let header = format!("\n\n{}", section.heading);
         let mut header_cost = header.chars().count();
         for entry in &section.entries {
@@ -510,10 +571,12 @@ mod tests {
         let sections = [
             Section {
                 heading: HEADING_INSTRUCTIONS,
+                reserve: 0,
                 entries: vec![entry('A', "Run the linter before committing.")],
             },
             Section {
                 heading: HEADING_PROFILE,
+                reserve: 0,
                 entries: Vec::new(),
             },
         ];
@@ -541,10 +604,12 @@ mod tests {
         let sections = [
             Section {
                 heading: HEADING_INSTRUCTIONS,
+                reserve: 0,
                 entries: vec![entry('A', "Short instruction.")],
             },
             Section {
                 heading: HEADING_LESSONS,
+                reserve: 0,
                 entries: vec![entry('B', &"long ".repeat(60))],
             },
         ];
@@ -557,9 +622,94 @@ mod tests {
     }
 
     #[test]
+    fn a_reserve_keeps_a_later_section_from_being_starved() {
+        // Ten facts of ~90 chars would take every character of a 700 budget on
+        // their own; the reserve holds room back for the lessons behind them.
+        let sections = |reserve| {
+            [
+                Section {
+                    heading: HEADING_INSTRUCTIONS,
+                    reserve: 0,
+                    entries: vec![entry('Z', "Obey the budget.")],
+                },
+                Section {
+                    heading: HEADING_RELEVANT,
+                    reserve: 0,
+                    entries: ('A'..='J')
+                        .map(|last| entry(last, &format!("fact {last} {}", "words ".repeat(8))))
+                        .collect(),
+                },
+                Section {
+                    heading: HEADING_LESSONS,
+                    reserve,
+                    entries: vec![
+                        entry('K', "lesson one: warm the cache first"),
+                        entry('L', "lesson two: pin the toolchain"),
+                        entry('M', "lesson three: never trust a green cold build"),
+                    ],
+                },
+            ]
+        };
+
+        let (starved, _) = render(&spaces(), &sections(0), 700, false);
+        assert!(!starved.contains(HEADING_LESSONS), "{starved}");
+
+        let (fed, _) = render(&spaces(), &sections(220), 700, false);
+        assert!(fed.chars().count() <= 700, "{fed}");
+        for lesson in ["lesson one", "lesson two", "lesson three"] {
+            assert!(fed.contains(lesson), "{lesson} is missing from {fed}");
+        }
+        assert!(
+            fed.contains("fact A"),
+            "the section above still fills first: {fed}"
+        );
+
+        // A reserve is bounded by demand: an empty section holds nothing back
+        // from the ones above it.
+        let empty = [
+            Section {
+                heading: HEADING_INSTRUCTIONS,
+                reserve: 0,
+                entries: vec![entry('Z', "Obey the budget.")],
+            },
+            Section {
+                heading: HEADING_RELEVANT,
+                reserve: 0,
+                entries: vec![entry('A', "the only fact")],
+            },
+            Section {
+                heading: HEADING_LESSONS,
+                reserve: 5_000,
+                entries: Vec::new(),
+            },
+        ];
+        let (block, dropped) = render(&spaces(), &empty, 250, false);
+        assert_eq!(dropped, 0, "{block}");
+        assert!(block.contains("the only fact"), "{block}");
+
+        // And the first section never yields: a reserve that would evict the
+        // instruction is what gives, not the instruction.
+        let squeezed = [
+            Section {
+                heading: HEADING_INSTRUCTIONS,
+                reserve: 0,
+                entries: vec![entry('Z', &"obey ".repeat(20))],
+            },
+            Section {
+                heading: HEADING_LESSONS,
+                reserve: 5_000,
+                entries: vec![entry('K', &"learn ".repeat(20))],
+            },
+        ];
+        let (block, _) = render(&spaces(), &squeezed, 200, false);
+        assert!(block.contains("obey obey"), "{block}");
+    }
+
+    #[test]
     fn a_later_entry_still_fits_after_one_too_long_for_the_budget() {
         let sections = [Section {
             heading: HEADING_PROFILE,
+            reserve: 0,
             entries: vec![
                 entry('A', &"long ".repeat(60)),
                 entry('B', "The user works in Rust."),
@@ -576,10 +726,12 @@ mod tests {
         let sections = [
             Section {
                 heading: HEADING_PROFILE,
+                reserve: 0,
                 entries: vec![entry('A', "The user prefers Rust.")],
             },
             Section {
                 heading: HEADING_RELEVANT,
+                reserve: 0,
                 entries: vec![entry('A', "The user prefers Rust.")],
             },
         ];
@@ -599,6 +751,7 @@ mod tests {
     fn covered_sections() -> [Section; 1] {
         [Section {
             heading: HEADING_RELEVANT,
+            reserve: 0,
             entries: vec![
                 summary('S', "Refresh was hardened end to end.", &['A', 'B']),
                 entry('A', "The refresh timeout was raised to thirty seconds."),
@@ -731,6 +884,7 @@ mod tests {
     fn a_multi_line_claim_stays_one_bullet() {
         let sections = [Section {
             heading: HEADING_LESSONS,
+            reserve: 0,
             entries: vec![entry('A', "  Builds fail\non a cold cache.\n")],
         }];
         let (block, _) = render(&spaces(), &sections, 6_000, false);

--- a/crates/agmem-server/tests/protocol.rs
+++ b/crates/agmem-server/tests/protocol.rs
@@ -2187,6 +2187,50 @@ async fn a_small_budget_keeps_the_first_section_and_says_it_trimmed() {
 }
 
 #[tokio::test]
+async fn lessons_reach_the_block_when_the_facts_alone_would_fill_it() {
+    let agmem = Harness::start(Arc::new(NoopEmbedder)).await;
+    // Ten facts of ~700 characters: on their own they exceed the default
+    // budget, which is exactly the store shape that used to leave the Lessons
+    // section starved (issue #152).
+    let mut memories: Vec<Value> = (1..=10)
+        .map(|n| {
+            json!({ "content": format!("fact {n}: {}", "the deployment pipeline runs the same way every time ".repeat(13)) })
+        })
+        .collect();
+    for lesson in [
+        "lesson: warm the cargo cache before the release build",
+        "lesson: the toolchain pin must match the CI image",
+        "lesson: a green cold build is not a green warm one",
+    ] {
+        memories.push(json!({ "content": lesson, "kind": "lesson" }));
+    }
+    agmem.remember(json!({ "memories": memories })).await;
+
+    let block = agmem.context(json!({})).await;
+    assert!(block.chars().count() <= 6_000, "{block}");
+    assert_eq!(
+        block.matches("lesson:").count(),
+        3,
+        "every lesson reaches the session: {block}"
+    );
+    assert!(
+        block.contains("fact "),
+        "the reserve costs Relevant room, not its place: {block}"
+    );
+    assert!(
+        block.matches("\n- fact ").count() <= 5,
+        "an unaimed Relevant section is orientation, five at most: {block}"
+    );
+
+    // Squeezed to two thirds, the block still carries lessons — at least two,
+    // the issue's acceptance line.
+    let squeezed = agmem.context(json!({ "budget_chars": 4_000 })).await;
+    assert!(squeezed.chars().count() <= 4_000, "{squeezed}");
+    assert!(squeezed.matches("lesson:").count() >= 2, "{squeezed}");
+    agmem.shutdown().await;
+}
+
+#[tokio::test]
 async fn a_flooded_tag_yields_lessons_slots_and_recall_stays_uncapped() {
     let agmem = Harness::start(Arc::new(RecordedEmbedder)).await;
     agmem

--- a/docs/design.md
+++ b/docs/design.md
@@ -535,7 +535,7 @@ Behavioral rules baked into the tools:
 # Memory context (space: <name> + user)
 ## Instructions        ← kind=instruction, live, all (pinned, cheap)
 ## Profile             ← facts tagged `identity`, live, ranked by strength
-## Relevant            ← recall(query) top-k if query given, else recent high-strength facts
+## Relevant            ← recall(query) top-10 if query given, else the 5 strongest facts
 ## Lessons             ← kind=lesson, live, top 5 by strength·recency, ≤3 per tag (#82)
 ```
 
@@ -545,6 +545,16 @@ best idea (`context` verb) merged with its `profile` layout, minus the LLM
 synthesis — pure retrieval and formatting.
 
 What the sketch leaves out, settled while building it (#19):
+
+- **Priority decides who fills first, not who gets to exist (#152).** Lessons
+  holds a reserve — 2000 characters, capped at a third of the budget, and never
+  more than the section could actually use — that the sections above it may
+  not spend. On a real store ten 600-character facts filled the default budget
+  before a single lesson landed, which turned the one section that carries
+  hard-won how-tos into decoration. The unaimed Relevant list is also cut to
+  five: without a query it is orientation, not an answer, and the plugin's
+  SessionStart hook now aims it with `<branch>: <last commit subject>` so a
+  session opens on what the repo says the work is.
 
 - **Every line ends with its memory id**, in backticks. 26 characters of the
   budget per entry buys a block an agent can act on: a stale claim goes to


### PR DESCRIPTION
## Problem

On this repo's store the briefing held 2 Instructions and 8 Relevant claims and zero Lessons, with the trim note emitted: Relevant filled the 6000-character budget before Lessons got a line, so 66 stored lessons never reached a session (#152).

## Change

- **Lessons holds a reserve** the sections above it may not spend: 2000 characters, capped at a third of the budget, bounded by what the section could actually use (an empty section holds nothing back), and never taken from Instructions. Priority still decides who fills first; it no longer decides who gets to exist.
- **Unaimed Relevant is cut from 10 to 5.** Without a query the list is orientation, not an answer. An aimed search still returns 10.
- **The SessionStart hook aims the briefing** with `<branch>: <last commit subject>`, so Relevant is targeted rather than recency-sorted.
- `docs/design.md` §3.2 records the rule and the reason.

## Measured on the live store (copy, `--no-daemon`)

| budget | query | instructions | relevant | lessons |
|---|---|---|---|---|
| 6000 | none | 2 | 4 | 4 |
| 6000 | branch + subject | 2 | 5 | 3 |
| 4000 | none | 2 | 3 | 2 |
| 4000 | branch + subject | 2 | 3 | 2 |

Before: 0 lessons at both budgets. Meets the issue's acceptance (≥3 lessons at 6000, same instructions plus ≥2 lessons at 4000).

## Tests

- `context::tests::a_reserve_keeps_a_later_section_from_being_starved` — reserve feeds the later section, is bounded by demand, and never evicts the first section.
- `protocol::lessons_reach_the_block_when_the_facts_alone_would_fill_it` — 10 long facts + 3 lessons: all 3 lessons land at 6000, ≥2 at 4000, Relevant ≤5.
- `hook::tests::the_briefing_is_aimed_from_whatever_the_repo_can_say`.
- clippy clean; 112 lib, 79 protocol, 12 oneshot+daemon tests pass.

Not in scope: the "N documents this branch" briefing line and the payload reconciliation stay with #151.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6KLJEisZAPXhWocFaa9kS
