### PR TITLE
The plugin hooks go on a diet (#151)

### DIFF
--- a/crates/agmem-server/src/doc.rs
+++ b/crates/agmem-server/src/doc.rs
@@ -228,7 +228,11 @@ fn written_space(cfg: &Config, space: Option<&str>) -> anyhow::Result<SpaceName>
 }
 
 /// The tool's JSON answer, by whichever route this configuration serves.
-async fn call(cfg: &Config, tool: &'static str, arguments: Value) -> anyhow::Result<Value> {
+pub(crate) async fn call(
+    cfg: &Config,
+    tool: &'static str,
+    arguments: Value,
+) -> anyhow::Result<Value> {
     #[cfg(unix)]
     if crate::daemon::wanted(cfg) {
         return through_daemon(cfg, tool, arguments).await;

--- a/crates/agmem-server/src/hook.rs
+++ b/crates/agmem-server/src/hook.rs
@@ -15,8 +15,9 @@
 //!   and after a compaction lists what the session had recalled so the
 //!   checkpoint that follows can cite it.
 //! - `post-tool-use` keeps the per-session log — which claims `recall`
-//!   returned, which `remember`/`reflect` wrote and cited — and nudges at
-//!   two seams: a successful `git push`, and an answered `AskUserQuestion`.
+//!   returned, which `remember`/`reflect` wrote and cited — and nudges once
+//!   per session at two seams: a successful `git push`, and an answered
+//!   `AskUserQuestion`.
 //! - `stop` nudges once, when a session recalled memory and wrote none.
 //!
 //! The log is the one thing the store cannot keep (issue #86): `REINFORCE`
@@ -60,20 +61,18 @@ const LOG_RETENTION_DAYS: i64 = 7;
 /// recalled hundreds of claims needs the recent ones, not all of them.
 const COMPACT_RECALLED_CAP: usize = 40;
 
-const HEADER: &str = "Durable project memory lives in agmem, not in this window. Before the first \
-move, call the agmem `context` tool with a short query naming the work at hand, and treat \
-the briefing as established fact — do not re-derive what it records; verify a specific \
-claim only before acting on it. The `recall` tool reaches what the briefing omits; ask \
-in words, not keywords. A claim that turns out to be stale is corrected with `remember` + \
-`supersedes` (its id ends its line), never worked around. /agmem:checkpoint stores this \
-session's durable state back.";
+/// What the session gets when the briefing could not be assembled: the one
+/// move that recovers it. The store's own emptiness is not this case — an
+/// empty store still yields a block, with its own note.
+const UNAVAILABLE: &str = "The agmem memory briefing could not be assembled at session start. Before \
+the first move, call the agmem `context` tool with a short query naming the work at hand.";
 
-const FOOTER: &str = "The block above is this project's memory briefing (agmem). Treat it as \
-established fact — do not re-derive what it records; verify a specific claim only \
-before acting on it. The `recall` tool reaches what it omits; ask in words, not \
-keywords. A claim that turns out to be stale is corrected with `remember` + `supersedes` \
-(its id ends its line), never worked around. /agmem:checkpoint stores this session's \
-durable state back.";
+/// One sentence after the block (issue #151). The rules it used to restate —
+/// established fact, correct with `supersedes`, checkpoint at seams — are
+/// already in the server instructions and the `agmem` skill; saying them a
+/// third time cost ~160 tokens per session start and taught nothing.
+const FOOTER: &str = "The block above is this project's agmem memory briefing — established fact, \
+corrected with `remember` + `supersedes` when stale; the `agmem` skill holds the judgement.";
 
 const COMPACTED: &str = "NOTE: context was compacted immediately before this. Anything not in agmem \
 or on disk is gone — re-read files before assuming their contents, and do not trust \
@@ -316,26 +315,61 @@ async fn session_start(cfg: &Config, session: &Session, payload: &Value) -> Opti
         query: aim(branch.as_deref(), last_subject(&cwd).as_deref()),
         ..ContextArgs::default()
     };
-    let briefing = oneshot::fetch(cfg, args).await;
-    let memory = match briefing {
-        Ok(block) if !block.trim().is_empty() => format!("{}\n\n{FOOTER}", block.trim()),
-        Ok(_) => HEADER.to_owned(),
+    // An empty store is not the fallback case: the tool answers it with its
+    // own `_Nothing stored_` note, so only a failed fetch lands here.
+    let memory = match oneshot::fetch(cfg, args).await {
+        Ok(block) => format!("{}\n\n{FOOTER}", block.trim()),
         Err(error) => {
             tracing::warn!(%error, "briefing unavailable; falling back to the pull nudge");
-            HEADER.to_owned()
+            UNAVAILABLE.to_owned()
         }
     };
-    let branch_note = branch
-        .map(|b| {
-            format!(
-                " In-flight state for the current branch ({b}) carries the tag branch:{} — \
-                 recall with that tag when resuming work here.",
-                slug(&b)
-            )
-        })
-        .unwrap_or_default();
+    let branch_note = match branch {
+        Some(b) => {
+            let tag = format!("branch:{}", slug(&b));
+            let documents = documents_tagged(cfg, &tag).await.unwrap_or(0);
+            branch_note(&b, &tag, documents)
+        }
+        None => String::new(),
+    };
     parts.push(format!("{memory}{branch_note}"));
     Some(parts.join("\n\n"))
+}
+
+/// The sentence that names the branch tag, and — when subagents left any —
+/// how many documents carry it (owed from issue #136): the artifacts of the
+/// work in flight are one listing away, and a session that does not know they
+/// exist re-derives what they hold.
+fn branch_note(branch: &str, tag: &str, documents: usize) -> String {
+    let mut note = format!(
+        " In-flight state for the current branch ({branch}) carries the tag {tag} — recall \
+         with that tag when resuming work here"
+    );
+    match documents {
+        0 => note.push('.'),
+        1 => note.push_str(&format!(
+            "; one document carries it too (`agmem doc list --tag {tag}`)."
+        )),
+        n => note.push_str(&format!(
+            "; {n} documents carry it too (`agmem doc list --tag {tag}`)."
+        )),
+    }
+    note
+}
+
+/// How many of the current space's documents carry `tag`, or `None` when the
+/// store could not be asked — the note then says nothing about documents
+/// rather than claiming there are none.
+async fn documents_tagged(cfg: &Config, tag: &str) -> Option<usize> {
+    let answer = crate::doc::call(
+        cfg,
+        "inspect",
+        json!({ "ref": "docs:current", "tags": [tag] }),
+    )
+    .await
+    .map_err(|error| tracing::warn!(%error, "document count unavailable"))
+    .ok()?;
+    answer["found"]["documents"].as_array().map(Vec::len)
 }
 
 fn post_tool_use(session: &Session, payload: &Value) -> Option<String> {
@@ -353,7 +387,11 @@ fn post_tool_use(session: &Session, payload: &Value) -> Option<String> {
                 == 0;
             (ok && is_push(command) && session.first_time("push")).then(|| PUSH_NUDGE.to_owned())
         }
-        "AskUserQuestion" => Some(DECISION_NUDGE.to_owned()),
+        // Once per session, like the push nudge: the second answer of a
+        // session is not a new lesson about answers (issue #151).
+        "AskUserQuestion" => session
+            .first_time("decision")
+            .then(|| DECISION_NUDGE.to_owned()),
         _ => {
             let (server, verb) = mcp_parts(tool)?;
             if !server.contains("agmem") {
@@ -741,5 +779,18 @@ mod tests {
 
         let decision = json!({"session_id": "s4", "tool_name": "AskUserQuestion"});
         assert!(post_tool_use(&session, &decision).is_some());
+        assert_eq!(post_tool_use(&session, &decision), None, "once per session");
+    }
+
+    #[test]
+    fn the_branch_note_counts_documents_only_when_there_are_any() {
+        let none = branch_note("main", "branch:main", 0);
+        assert!(none.ends_with("resuming work here."), "{none}");
+        assert!(!none.contains("document"), "{none}");
+        let one = branch_note("fix/x", "branch:fix-x", 1);
+        assert!(one.contains("one document carries it too"), "{one}");
+        assert!(one.contains("`agmem doc list --tag branch:fix-x`"), "{one}");
+        let many = branch_note("fix/x", "branch:fix-x", 3);
+        assert!(many.contains("3 documents carry it too"), "{many}");
     }
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -1199,7 +1199,7 @@ rather than details:
 | `--doctor` | — | One-shot self check: lock, DB open, migrate, embedder, sample roundtrip, vector coverage; prints report, exits |
 | `--reindex` | — | Re-embed every row under the configured backend and record its model/dim pair — the one sanctioned way to change embedders; exits |
 | `context` subcommand | — | Print one session-start briefing to stdout and exit (`--query`, `--space`, `--budget-chars`) — the shell-hook surface, no MCP served |
-| `hook <event>` subcommand | — | The Claude Code plugin's hooks, reading the hook JSON on stdin: `session-start` (briefing plus branch tag, post-compaction recall list), `post-tool-use` (recall/write log, seam nudges), `stop` (recalled-but-wrote-nothing nudge); no MCP served |
+| `hook <event>` subcommand | — | The Claude Code plugin's hooks, reading the hook JSON on stdin: `session-start` (aimed briefing, one-sentence footer, branch tag with its document count, post-compaction recall list), `post-tool-use` (recall/write log, once-per-session seam nudges), `stop` (recalled-but-wrote-nothing nudge); no MCP served |
 
 Client registration: in Claude Code the plugin does it — `claude plugin
 marketplace add AlfoldiMate/agmem`, then `claude plugin install agmem@agmem`

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -29,8 +29,8 @@ the crate version, since the hooks are subcommands of that binary.
 | Piece | What it does |
 |---|---|
 | `.mcp.json` | Registers `agmem` over stdio. The space derives from the repo, so every branch and worktree of a project reads one store. |
-| `SessionStart` hook | Injects the briefing (`agmem context`) before the first token, names the branch tag, and after a compaction lists the claims the session had recalled so the next checkpoint can cite them. |
-| `PostToolUse` hook | Logs the ids each `recall` returned and each `remember`/`reflect` wrote or cited, under `<data dir>/hooks/<session>.jsonl`. Nudges once after a successful `git push`, and after every answered `AskUserQuestion` — both are decision seams. |
+| `SessionStart` hook | Injects the briefing (`agmem context`, aimed at the branch and last commit) before the first token, names the branch tag and how many documents carry it, and after a compaction lists the claims the session had recalled so the next checkpoint can cite them. |
+| `PostToolUse` hook | Logs the ids each `recall` returned and each `remember`/`reflect` wrote or cited, under `<data dir>/hooks/<session>.jsonl`. Nudges once per session after a successful `git push`, and once after an answered `AskUserQuestion` — both are decision seams. |
 | `Stop` hook | Nudges once per session when memory was recalled and nothing was written back. |
 | `/agmem:checkpoint` | The distil → recall → remember → reflect ritual. Step 4 (cite with `derived_from`) is byte-identical to the server's own checkpoint prompt; a test in the server crate fails if they drift. |
 | `/agmem:memory show\|tidy` | Show the store and judge the briefing; consolidate duplicates, contradictions and stale claims. |


### PR DESCRIPTION
Closes #151.

- **AskUserQuestion nudge** prints once per session, on the same marker mechanism as the push and stop nudges.
- **Briefing footer** is one sentence pointing at the `agmem` skill; the supersedes rule no longer appears three times.
- **Dead fallback removed**: an empty store yields the tool's own `_Nothing stored_` block, so only a failed fetch falls back, and that fallback now just says to call `context`.
- **Branch note counts documents** carrying `branch:<slug>` (owed from #136) via the same `inspect` call `agmem doc list` makes; silent when the store cannot be asked. Verified end to end with a throwaway tagged document.

**Payload finding.** The SessionStart `hook_additional_context` attachment in the last three transcripts is the briefing alone: ~6.6k chars, not duplicated. The audit's 22k counted the harness's deferred-tool, agent and skill listings in the same turn, which the plugin cannot cut. The hook's payload on this repo is now 6.3k, under the 8k acceptance line.

Tests: `hook::` unit tests (10) and the protocol suite (79) pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6KLJEisZAPXhWocFaa9kS
