### PR TITLE
The read guard: a whole-file read asks for a window (#145, #146)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -89,8 +89,11 @@ it is on you at the point of the call.
 ## Shell work
 
 The harness sometimes routes file reads and edits through `Bash` rather than the
-Read/Edit tools. That chooses the *tool*, not the *language* — and the language
-is nu, for the same reason as everything else here.
+Read/Edit tools (auto mode's preamble asks for `cat`/`sed -n` and `sed`). That
+chooses the *tool*, not the *language* — and the language is nu, for the same
+reason as everything else here. Settled 2026-09-04: a windowed `sed -n 'a,bp'`
+read is fine (it is Read offset/limit spelled in shell); a `sed` *edit* is not,
+and the nudge stays.
 
 - **Edit with nu, not sed or python.**
   `open --raw f | str replace <old> <new> | save -f f` is safe onto the same

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -82,7 +82,8 @@ it is on you at the point of the call.
 
 - Anything you can't predict the size of is a `runner` job.
 - Through `Bash`, filter at the source: `--json`/`--jq`, `git diff --stat`
-  before `git diff`, `Read` with `offset`/`limit` over `cat`.
+  before `git diff`, `Read` with `offset`/`limit` over `cat` — a hook denies a
+  whole-file read past 300 lines and asks for the window.
 - Through the nu MCP server, run once and slice `$history` afterwards.
 
 ## Shell work

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -160,14 +160,14 @@ where is X, which files do Y — that should come back as refs, not prose.
 ### The hooks
 
 Deterministic work that costs zero tokens and happens *every* time, which no
-prompt instruction achieves. Three are `.nu` scripts under `hooks/scripts/`;
-the fourth is rtk's. The memory hooks — briefing injection, the recall log,
+prompt instruction achieves. Four are `.nu` scripts under `hooks/scripts/`;
+the fifth is rtk's. The memory hooks — briefing injection, the recall log,
 the seam nudges — are the agmem plugin's (`agmem hook …`), not this file's.
 
 | Event | Does |
 |---|---|
 | `SessionStart` | the worktree layout check: in a bare layout the real `.claude` is symlinked into each worktree, and one carrying its own copy has silently diverged — a fact about this checkout the plugin cannot know. The briefing, the branch tag and the post-compaction warning arrive through the plugin's SessionStart hook |
-| `PreToolUse` | `rtk hook claude` — transparently rewrites Bash commands so their output arrives compressed; plus the bare-worktree guard that denies raw `git worktree add/remove/move` in a bare layout |
+| `PreToolUse` | `rtk hook claude` — transparently rewrites Bash commands so their output arrives compressed; plus the bare-worktree guard that denies raw `git worktree add/remove/move` in a bare layout; plus the read guard (`Read` and `Bash`), which denies a whole-file read — a bare `Read` with no `offset`/`limit`, or `cat`/`head`/`tail`/`sed` printing more than 300 lines of a file over 12 kB — and asks for a window instead. The 2026-09-03 token audit found those two shapes were 46% of every tool-result character this repo's sessions ever paid for. Any windowed call passes, including one whose `limit` covers the whole file; `cat big \| wc -l`, heredocs and redirects pass; knobs `CTX_FLOW_READ_MAX_LINES` / `CTX_FLOW_READ_SMALL_BYTES`; cases in `hooks/tests/read-guard.nu` |
 | `PostToolUse` | one nudge, fired at most once per session and unable to block: when a Bash call reached for `sed`/`python`/`grep` where nu or ast-grep is the house tool. It exists because a rule in an always-loaded file is a rule you stop seeing — this repo`s own transcripts showed CLAUDE.md losing to habit on 18% of Bash calls. The `git push` checkpoint nudge moved to the plugin |
 
 ### Where the rules live
@@ -366,7 +366,7 @@ compacts; the token saving is a side effect of the quality win.
 ├── agents/                 runner, verifier, architect, browser, tracker, scout
 ├── commands/               checkpoint (wraps the plugin's), agmem-import, ctx-flow-doctor, ast-grep-it, bare-worktree
 ├── docs/reference.md       contracts, memory mapping, rationale — loaded on demand
-├── hooks/scripts/          the three hooks + shared _common.nu + paths resolver
+├── hooks/scripts/          the four hooks + shared _common.nu + paths resolver; hooks/tests/ their cases
 ├── output-styles/          ctx-flow.md — the hard rules, appended to the system prompt
 ├── scripts/                doctor.nu + doc-put.nu (subagent artifacts → documents) + import-notes.nu + build-grammar.nu + grammars.nu registry + bare-worktree.nu
 ├── skills/nushell/         deep Nushell reference, loaded when writing nu

--- a/.claude/hooks/scripts/pre-read-guard.nu
+++ b/.claude/hooks/scripts/pre-read-guard.nu
@@ -1,0 +1,187 @@
+#!/usr/bin/env nu
+# PreToolUse(Read | Bash): the flood guard. The 2026-09-03 token audit of this
+# repo's 71 sessions found that whole-file reads were the single largest
+# tool-result cost — a bare `Read` with neither `offset` nor `limit` was 28%
+# of all result characters, and `cat` / `sed -n` / `head` / `tail` used as a
+# Read another 18%. Every one of the fifteen largest results was one file
+# read whole. CLAUDE.md already says to window; this hook makes the window
+# the default, at the one moment the rule applies.
+#
+# What it denies, and only that:
+#
+# - `Read` with no `offset` and no `limit` of a file that is both longer than
+#   MAX_LINES and larger than SMALL_BYTES. Any windowed call passes, including
+#   one whose `limit` covers the whole file — that is the explicit way to say
+#   "all of it", and it costs one round trip only when the guard fired first.
+# - A Bash statement whose *output-producing* command (the last in its pipe)
+#   is `cat`/`bat`/`nl`, `head`/`tail` with a large count, or `sed` printing a
+#   large or unbounded range, on such a file. `cat big | wc -l` passes: the
+#   flood never reaches the model. A windowed `sed -n '40,120p'` passes: it
+#   is Read offset/limit spelled in shell, which the auto-mode preamble asks
+#   for. Redirects and heredocs pass: they are writes.
+#
+# Everything the guard cannot resolve — a path through a variable, a file
+# that does not exist yet, a command shape it does not parse — passes. The
+# guard fails open, always: a hook that denied on doubt would cost more turns
+# than the floods it prevents. Same safety rule as every hook here: wrapped
+# in try, exit 0.
+const COMMON = path self "_common.nu"
+use $COMMON *
+
+# Longer than this AND larger than SMALL_BYTES is a flood. Both knobs are
+# environment variables (see env-int in _common.nu).
+const MAX_LINES = 300
+const SMALL_BYTES = 12000
+
+# Files Read handles as something other than text — never guarded.
+const BINARY_EXT = [png jpg jpeg gif webp bmp svg pdf ipynb]
+
+# {lines, bytes} of a text file, or null when it is absent, a directory,
+# unreadable, binary, or already small enough that counting is a waste.
+def stats [path: string]: nothing -> any {
+    if ($path | path type) != "file" { return null }
+    let bytes = try { ls -l $path | get 0.size | into int } catch { return null }
+    if $bytes <= (env-int CTX_FLOW_READ_SMALL_BYTES $SMALL_BYTES) { return null }
+    let text = try { open --raw $path } catch { return null }
+    if ($text | describe) != "string" { return null }
+    { lines: ($text | lines | length), bytes: $bytes }
+}
+
+def flood? [s: any]: nothing -> bool {
+    $s != null and $s.lines > (env-int CTX_FLOW_READ_MAX_LINES $MAX_LINES)
+}
+
+def kchars [n: int]: nothing -> string { $"(($n / 1000) | math round)k chars" }
+
+def deny [reason: string] {
+    print -n ({ hookSpecificOutput: {
+        hookEventName: "PreToolUse"
+        permissionDecision: "deny"
+        permissionDecisionReason: $reason
+    } } | to json -r)
+}
+
+# --- Read ----------------------------------------------------------------
+
+def guard-read [p: record] {
+    let t = $p.tool_input? | default {}
+    if ($t.offset? != null) or ($t.limit? != null) { return }
+    let path = $t.file_path? | default ""
+    if ($path | is-empty) { return }
+    if (($path | path parse | get extension | str lowercase) in $BINARY_EXT) { return }
+    let s = stats $path
+    if not (flood? $s) { return }
+    deny ($"($path | path basename) is ($s.lines) lines \((kchars $s.bytes)\); a bare Read pulls all of it. "
+        + "Read again with offset+limit \(~120 lines a window\), or let a scout/Explore return the part needed.")
+}
+
+# --- Bash ----------------------------------------------------------------
+
+# Resolve a command-line token to a path, or null when it cannot be one.
+def resolve [tok: string, cwd: string]: nothing -> any {
+    if ($tok | is-empty) or ($tok starts-with "-") or ($tok starts-with "$") or ($tok == "-") { return null }
+    let p = if ($tok starts-with "~") { $tok | path expand } else if ($tok starts-with "/") { $tok } else { $cwd | path join $tok }
+    if ($p | path type) == "file" { $p } else { null }
+}
+
+# The value of `-n N` / `-nN` / `-N` / `--lines=N` in a head/tail arg list,
+# or null when absent. A `+K` (tail) comes back as a negative number so the
+# caller can tell "last N" from "from line K".
+def count-flag [args: list<string>]: nothing -> any {
+    mut i = 0
+    while $i < ($args | length) {
+        let a = $args | get $i
+        let next = $args | get ($i + 1) -o | default ""
+        let v = if $a in ["-n" "--lines"] { $next
+            } else if ($a starts-with "--lines=") { $a | str substring 8..
+            } else if ($a =~ '^-n.+') { $a | str substring 2..
+            } else if ($a =~ '^-\d+$') { $a | str substring 1..
+            } else { null }
+        if $v != null {
+            if ($v =~ '^\+\d+$') { return (0 - ($v | str substring 1.. | into int)) }
+            if ($v =~ '^\d+$') { return ($v | into int) }
+            return null
+        }
+        $i += 1
+    }
+    null
+}
+
+# Lines a `sed` invocation prints from a file of `total` lines: whole file
+# without -n; with -n, the size of an `N,Mp` / `N,$p` / `Np` range; null for
+# a script the guard does not read (`/re/p`, `s///p`), which passes.
+def sed-lines [args: list<string>, total: int]: nothing -> any {
+    if ("-i" in $args) or ($args | any {|a| $a starts-with "-i" }) { return null }   # an edit, not a read
+    let quiet = $args | any {|a| $a =~ '^-[a-zA-Z]*n' }
+    if not $quiet { return $total }
+    let scripts = $args | where {|a| $a =~ '^[0-9$]' }
+    if ($scripts | is-empty) { return null }
+    let s = $scripts | first
+    let m = $s | parse -r '^(?<a>\d+|\$)(?:,(?<b>\d+|\$))?p$'
+    if ($m | is-empty) { return null }
+    let a = if $m.0.a == '$' { $total } else { $m.0.a | into int }
+    let b = if ($m.0.b | is-empty) { $a } else if $m.0.b == '$' { $total } else { $m.0.b | into int }
+    ([(([$b $total] | math min) - $a + 1), 0] | math max)
+}
+
+# The reading command at the end of one pipeline, as {cmd, args}, or null.
+def reader-of [segment: string]: nothing -> any {
+    if ($segment =~ '(^|[^<])<<|>') { return null }             # heredoc or redirect: a write
+    let toks = $segment
+        | str replace -ra `"([^"]*)"|'([^']*)'` '$1$2'          # unquote; keeps the inner text
+        | str trim | split row -r '\s+'
+        | where {|t| not ($t =~ '^[A-Za-z_][A-Za-z0-9_]*=') }   # drop leading FOO=bar assignments
+    if ($toks | is-empty) { return null }
+    let cmd = $toks | first | path basename
+    if not ($cmd in [cat bat nl head tail sed]) { return null }
+    { cmd: $cmd, args: ($toks | skip 1) }
+}
+
+# Lines this reader would print, or null when unbounded-by-guard (passes).
+def printed-lines [r: record, cwd: string]: nothing -> any {
+    let files = $r.args | each {|a| resolve $a $cwd } | compact
+    if ($files | is-empty) { return null }
+    let s = $files | each {|f| stats $f } | compact
+    if ($s | is-empty) { return null }
+    let total = $s | get lines | math sum
+    match $r.cmd {
+        "head" => {
+            let n = count-flag $r.args | default 10
+            if $n < 0 { null } else { [$n $total] | math min }
+        }
+        "tail" => {
+            let n = count-flag $r.args | default 10
+            if $n < 0 { $total + $n + 1 } else { [$n $total] | math min }
+        }
+        "sed" => { sed-lines $r.args $total }
+        _ => { $total }
+    }
+}
+
+def guard-bash [p: record] {
+    let cmd = $p.tool_input?.command? | default ""
+    if ($cmd | is-empty) { return }
+    let cwd = cwd-of $p
+    let max = env-int CTX_FLOW_READ_MAX_LINES $MAX_LINES
+    for stmt in ($cmd | split row -r '\s*(?:&&|\|\||;|\n)\s*') {
+        let last = $stmt | split row "|" | last | str trim
+        let r = reader-of $last
+        if $r == null { continue }
+        let n = printed-lines $r $cwd
+        if $n == null or $n <= $max { continue }
+        deny ($"`($last | str substring ..<40)` would print ($n) lines into the context. "
+            + "Read with offset+limit for a window \(or `sed -n 'a,bp'`\), or let a scout/Explore return the part needed.")
+        return
+    }
+}
+
+def main []: any -> nothing {
+    let p = $in | payload
+    try {
+        match ($p.tool_name? | default "") {
+            "Read" => { guard-read $p }
+            "Bash" => { guard-bash $p }
+            _ => {}
+        }
+    }
+}

--- a/.claude/hooks/tests/read-guard.nu
+++ b/.claude/hooks/tests/read-guard.nu
@@ -1,0 +1,72 @@
+#!/usr/bin/env nu
+# Cases for pre-read-guard.nu, run from the repo root:
+#
+#     nu .claude/hooks/tests/read-guard.nu
+#
+# Each case pipes a PreToolUse payload through the hook exactly as Claude Code
+# would and checks whether it came back with a deny. The files named are this
+# repo's own: docs/design.md and tests/protocol.rs are floods, Cargo.toml is
+# not. Exits 1 on the first mismatch, so it can sit in a pre-push check.
+const HOOK = path self "../scripts/pre-read-guard.nu"
+
+const BIG = "crates/agmem-server/tests/protocol.rs"
+
+def hook [tool: string, input: record]: nothing -> record {
+    let payload = { session_id: "t", cwd: $env.PWD, tool_name: $tool, tool_input: $input } | to json -r
+    let out = $payload | nu --stdin $HOOK | complete
+    let denied = ($out.stdout | str contains '"deny"')
+    let reason = try { $out.stdout | from json | get hookSpecificOutput.permissionDecisionReason } catch { "" }
+    { denied: $denied, reason: $reason, exit: $out.exit_code, stderr: $out.stderr }
+}
+
+def read [file: string, ...rest: any]: nothing -> record { hook Read ({ file_path: ($env.PWD | path join $file) } | merge ($rest | first | default {})) }
+def bash [command: string]: nothing -> record { hook Bash { command: $command } }
+
+def main [] {
+    let cases = [
+        # --- Read ---
+        [name, result, expect];
+        ["bare Read of design.md"                (read docs/design.md)                       true]
+        ["Read design.md with offset+limit"      (read docs/design.md {offset: 40, limit: 120}) false]
+        ["Read design.md with limit only"        (read docs/design.md {limit: 2000})         false]
+        ["bare Read of Cargo.toml"               (read Cargo.toml)                           false]
+        ["bare Read of a missing file"           (read does/not/exist.rs)                    false]
+        ["bare Read of a png"                    (hook Read {file_path: "/tmp/x.png"})        false]
+        # --- Bash ---
+        ["cat protocol.rs"                       (bash $"cat ($BIG)")                        true]
+        ["cat Cargo.toml"                        (bash "cat Cargo.toml")                     false]
+        ["cat protocol.rs | wc -l"               (bash $"cat ($BIG) | wc -l")                false]
+        ["cat with a quoted path"                (bash $"cat '($BIG)'")                      true]
+        ["cd then cat protocol.rs"               (bash $"cd crates && cat ($BIG)")            true]
+        ["sed -n windowed"                       (bash $"sed -n '40,120p' ($BIG)")           false]
+        ["sed -n wide window"                    (bash $"sed -n '1,900p' ($BIG)")            true]
+        ["sed -n to end"                         (bash $"sed -n '10,$p' ($BIG)")             true]
+        ["sed -n regex print"                    (bash $"sed -n '/fn /p' ($BIG)")            false]
+        ["sed substitution preview"              (bash $"sed 's/a/b/' ($BIG)")               true]
+        ["sed -i edit"                           (bash $"sed -i '' 's/a/b/' ($BIG)")         false]
+        ["head default"                          (bash $"head ($BIG)")                       false]
+        ["head -n 50"                            (bash $"head -n 50 ($BIG)")                 false]
+        ["head -500"                             (bash $"head -500 ($BIG)")                  true]
+        ["tail -n 20"                            (bash $"tail -n 20 ($BIG)")                 false]
+        ["tail -n +1"                            (bash $"tail -n +1 ($BIG)")                 true]
+        ["heredoc write"                         (bash $"cat > /tmp/x.rs <<'EOF'\nfn main\(\) {}\nEOF")  false]
+        ["redirect"                              (bash $"cat ($BIG) > /tmp/copy.rs")         false]
+        ["cat via variable"                      (bash 'cat "$CLAUDE_PROJECT_DIR/docs/design.md"') false]
+        ["grep unaffected"                       (bash $"grep -n fn ($BIG)")                 false]
+    ]
+
+    mut failed = 0
+    for c in $cases {
+        let ok = ($c.result.denied == $c.expect) and ($c.result.exit == 0)
+        if not $ok { $failed += 1 }
+        let mark = if $ok { "ok  " } else { "FAIL" }
+        print $"($mark) ($c.name)  → denied=($c.result.denied) expected=($c.expect)"
+        if not $ok and ($c.result.stderr | is-not-empty) { print $"     stderr: ($c.result.stderr)" }
+        if $c.result.denied and ($c.result.reason | str length) > 200 {
+            $failed += 1
+            print $"FAIL ($c.name): reason is (($c.result.reason | str length)) chars \(cap 200\)"
+        }
+    }
+    if $failed > 0 { print $"($failed) failure\(s\)"; exit 1 }
+    print $"all (($cases | length)) cases pass"
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,21 @@
             "type": "command",
             "command": "nu --stdin \"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/pre-worktree-guard.nu\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "nu --stdin \"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/pre-read-guard.nu\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "nu --stdin \"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/pre-read-guard.nu\"",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
Closes #145. Closes #146: parts 1 and 3 here; part 2 settled by the user (keep auto mode, tolerate windowed `sed -n` reads, keep the edit nudge) and recorded in CLAUDE.md.

## What

A PreToolUse hook on `Read` and `Bash`, `.claude/hooks/scripts/pre-read-guard.nu`:

- Denies a bare `Read` (neither `offset` nor `limit`) of a file over 300 lines **and** 12 kB. Any windowed call passes, including a `limit` covering the whole file — that is the explicit "all of it", one round trip only when the guard fired first.
- Denies a Bash statement whose output-producing command (last in its pipe) is `cat`/`bat`/`nl`, `head`/`tail` with a large count, or `sed` printing a large or unbounded range, of such a file. `cat big | wc -l`, `sed -n '40,120p'`, heredocs, redirects, `$VAR` paths and missing files pass.
- Fails open on anything it cannot resolve. ~50–70 ms per call. Knobs: `CTX_FLOW_READ_MAX_LINES`, `CTX_FLOW_READ_SMALL_BYTES`.
- Denial text under 200 chars, names the file, its line count and the fix.

## Acceptance

- `nu .claude/hooks/tests/read-guard.nu`: 26 cases pass (design.md bare Read denied / windowed allowed; `cat protocol.rs` denied / `cat Cargo.toml` passes; sed/head/tail shapes; heredoc, redirect, pipe-to-filter, variable path).
- Replay of the repo's 71 transcripts (2,882 Read+Bash calls): of the 123 whole-file `Read` calls with a >5k-char result whose file still exists, **99 (80.5%) would have been windowed**. The 24 that pass are files that are ≤12 kB (18) or ≤300 lines (6) today. Bash: 46 of 228 large results denied; the rest are not read-shaped (cargo, gh, git output). Zero denials on results under 2k chars once file growth since the transcript is accounted for.

## #146 part 3 — the nudge marker

Checked the sampled session (`1a496abd`): the transcript holds one nudge attachment per idiom, not 14. The audit counted the model quoting the nudge text. The temp-dir marker holds; nothing to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6KLJEisZAPXhWocFaa9kS