### PR TITLE
The session-length nudge: a long context is told so, once per step (#147)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -155,7 +155,7 @@ memory already in front of it:
 
 Prefer several short sessions chained through memory over one long one — a
 600k-token session produces worse output than a 100k one even when it never
-compacts.
+compacts. A hook says so at 120k tokens of context, and again per 40k after.
 
 ## Playbooks
 

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -160,12 +160,13 @@ where is X, which files do Y — that should come back as refs, not prose.
 ### The hooks
 
 Deterministic work that costs zero tokens and happens *every* time, which no
-prompt instruction achieves. Four are `.nu` scripts under `hooks/scripts/`;
-the fifth is rtk's. The memory hooks — briefing injection, the recall log,
+prompt instruction achieves. Five are `.nu` scripts under `hooks/scripts/`;
+the sixth is rtk's. The memory hooks — briefing injection, the recall log,
 the seam nudges — are the agmem plugin's (`agmem hook …`), not this file's.
 
 | Event | Does |
 |---|---|
+| `UserPromptSubmit` | the session-length nudge: reads the context size the last turn was served with (the API `usage` on the transcript's last assistant line — a `tail -c`, no parse of the file) and, from 120k tokens, says once "/checkpoint then /clear", then again only per further 40k. CLAUDE.md's "prefer several short sessions" rule had no enforcement; the audit's two largest sessions ran 400+ turns at ~267k each and never cleared. Knobs `CTX_FLOW_CONTEXT_NUDGE_TOKENS` / `_STEP`; cases in `hooks/tests/context-nudge.nu` |
 | `SessionStart` | the worktree layout check: in a bare layout the real `.claude` is symlinked into each worktree, and one carrying its own copy has silently diverged — a fact about this checkout the plugin cannot know. The briefing, the branch tag and the post-compaction warning arrive through the plugin's SessionStart hook |
 | `PreToolUse` | `rtk hook claude` — transparently rewrites Bash commands so their output arrives compressed; plus the bare-worktree guard that denies raw `git worktree add/remove/move` in a bare layout; plus the read guard (`Read` and `Bash`), which denies a whole-file read — a bare `Read` with no `offset`/`limit`, or `cat`/`head`/`tail`/`sed` printing more than 300 lines of a file over 12 kB — and asks for a window instead. The 2026-09-03 token audit found those two shapes were 46% of every tool-result character this repo's sessions ever paid for. Any windowed call passes, including one whose `limit` covers the whole file; `cat big \| wc -l`, heredocs and redirects pass; knobs `CTX_FLOW_READ_MAX_LINES` / `CTX_FLOW_READ_SMALL_BYTES`; cases in `hooks/tests/read-guard.nu` |
 | `PostToolUse` | one nudge, fired at most once per session and unable to block: when a Bash call reached for `sed`/`python`/`grep` where nu or ast-grep is the house tool. It exists because a rule in an always-loaded file is a rule you stop seeing — this repo`s own transcripts showed CLAUDE.md losing to habit on 18% of Bash calls. The `git push` checkpoint nudge moved to the plugin |
@@ -366,7 +367,7 @@ compacts; the token saving is a side effect of the quality win.
 ├── agents/                 runner, verifier, architect, browser, tracker, scout
 ├── commands/               checkpoint (wraps the plugin's), agmem-import, ctx-flow-doctor, ast-grep-it, bare-worktree
 ├── docs/reference.md       contracts, memory mapping, rationale — loaded on demand
-├── hooks/scripts/          the four hooks + shared _common.nu + paths resolver; hooks/tests/ their cases
+├── hooks/scripts/          the five hooks + shared _common.nu + paths resolver; hooks/tests/ their cases
 ├── output-styles/          ctx-flow.md — the hard rules, appended to the system prompt
 ├── scripts/                doctor.nu + doc-put.nu (subagent artifacts → documents) + import-notes.nu + build-grammar.nu + grammars.nu registry + bare-worktree.nu
 ├── skills/nushell/         deep Nushell reference, loaded when writing nu

--- a/.claude/hooks/scripts/prompt-context-nudge.nu
+++ b/.claude/hooks/scripts/prompt-context-nudge.nu
@@ -1,0 +1,78 @@
+#!/usr/bin/env nu
+# UserPromptSubmit: the session-length nudge. CLAUDE.md says to prefer several
+# short sessions chained through memory over one long one, and nothing
+# enforces it — the 2026-09-03 token audit found the two largest sessions ran
+# 400+ turns at ~267k tokens of context each and never cleared, a fifth of all
+# cache-read between them. Cache-read is 91% main-thread and scales with
+# context × turns, so the cheapest token is the one a fresh session never
+# carries. This hook says so, once, when the context is large enough for it
+# to matter, and again only when it has grown by a further step.
+#
+# The number is exact, not a proxy: the transcript's last assistant line
+# carries the API's `usage` for that turn, and input + cache_read +
+# cache_creation is the context that turn was served with. Reading it costs a
+# `tail -c` of the file's last 128 kB, no full parse — a session's transcript
+# runs to tens of MB. When no usage line is in reach the file size stands in,
+# at the bytes-per-token ratio measured across this repo's own transcripts.
+#
+# Once-gating lives in a temp-dir marker holding the last level nudged at,
+# keyed by session id AND transcript path: a resumed session keeps both and
+# stays quiet until the next step; a /clear gets a new transcript and starts
+# over. Same safety rule as every hook here: wrapped in try, exit 0 — a bug
+# costs a missing nudge, never a broken prompt.
+const COMMON = path self "_common.nu"
+use $COMMON *
+
+# First nudge at this many context tokens; then every STEP more.
+const THRESHOLD = 120000
+const STEP = 40000
+
+# Fallback only: transcript bytes per context token (median across the
+# repo's 69 transcripts at end of file: median 6.5, measured 2026-09-04; the
+# exact path found a usage line in every one of them, so this rarely runs).
+const BYTES_PER_TOKEN = 6
+
+# Bytes read from the end of the transcript to find the last usage line.
+const TAIL = 131072
+
+# Context tokens the last assistant turn was served with, or null.
+def context-tokens [transcript: string]: nothing -> any {
+    let chunk = try { ^tail -c $TAIL $transcript | complete | get stdout } catch { return null }
+    let hits = $chunk | lines | where {|l| ($l | str contains '"usage"') and ($l | str contains '"cache_read_input_tokens"') }
+    if ($hits | is-empty) { return null }
+    let line = $hits | last
+    let u = try { $line | from json | get message.usage } catch { return null }
+    ([input_tokens cache_read_input_tokens cache_creation_input_tokens]
+        | each {|k| $u | get $k -o | default 0 } | math sum)
+}
+
+# The marker's recorded level for this session+transcript, or 0.
+def last-level [marker: string, transcript: string]: nothing -> int {
+    let m = try { open --raw $marker | from json } catch { return 0 }
+    if ($m.transcript? | default "") == $transcript { $m.level? | default 0 } else { 0 }
+}
+
+def main []: any -> nothing {
+    let p = $in | payload
+    try {
+        let transcript = $p.transcript_path? | default ""
+        if ($transcript | is-empty) or (($transcript | path type) != "file") { return }
+        let threshold = env-int CTX_FLOW_CONTEXT_NUDGE_TOKENS $THRESHOLD
+        let step = env-int CTX_FLOW_CONTEXT_NUDGE_STEP $STEP
+
+        let tokens = context-tokens $transcript
+            | default {|| (ls -l $transcript | get 0.size | into int) / $BYTES_PER_TOKEN | math round }
+        if $tokens < $threshold { return }
+
+        # The step level this context sits at: 120k → 120000, 175k → 160000.
+        let level = $threshold + ((($tokens - $threshold) / $step | math floor) * $step)
+        let session = $p.session_id? | default "nosession"
+        let marker = $nu.temp-dir | path join $"ctx-flow-context-($session)"
+        if $level <= (last-level $marker $transcript) { return }
+        try { { transcript: $transcript, level: $level } | to json -r | save -f $marker }
+
+        let k = ($tokens / 1000 | math round)
+        context "UserPromptSubmit" ($"Context ~($k)k tokens. /checkpoint then /clear: a fresh session "
+            + "starts from the briefing at a fraction of the cost.")
+    }
+}

--- a/.claude/hooks/tests/context-nudge.nu
+++ b/.claude/hooks/tests/context-nudge.nu
@@ -1,0 +1,64 @@
+#!/usr/bin/env nu
+# Cases for prompt-context-nudge.nu, run from anywhere:
+#
+#     nu .claude/hooks/tests/context-nudge.nu
+#
+# Each case writes a synthetic transcript — assistant lines carrying the
+# API's `usage` block, as Claude Code records them — and pipes a
+# UserPromptSubmit payload through the hook. Checks: silent below the
+# threshold, one nudge at it, silence on the next prompt, a second nudge only
+# after a further step, a fresh transcript under the same session id starts
+# over, and the nudge text stays under 120 chars.
+const HOOK = path self "../scripts/prompt-context-nudge.nu"
+
+def transcript [name: string, tokens: int]: nothing -> string {
+    let path = $nu.temp-dir | path join $"ctx-flow-test-($name).jsonl"
+    let filler = { type: "user", message: { role: "user", content: "x" } } | to json -r
+    let usage = { type: "assistant", message: { role: "assistant", usage: {
+        input_tokens: 40, cache_read_input_tokens: ($tokens - 1040), cache_creation_input_tokens: 1000, output_tokens: 5
+    } } } | to json -r
+    [$filler $usage $filler] | str join "\n" | save -f $path
+    $path
+}
+
+def fire [session: string, transcript: string]: nothing -> record {
+    let out = { session_id: $session, transcript_path: $transcript, cwd: $env.PWD, prompt: "hi" }
+        | to json -r | nu --stdin $HOOK | complete
+    let text = try { $out.stdout | from json | get hookSpecificOutput.additionalContext } catch { "" }
+    { nudged: ($text | is-not-empty), text: $text, exit: $out.exit_code, stderr: $out.stderr }
+}
+
+def main [] {
+    rm -f ($nu.temp-dir | path join "ctx-flow-context-ctxtest*")
+    let s = "ctxtest-a"
+    let low = transcript low 80000
+    let at = transcript at 125000
+    let up = transcript up 170000
+    let fresh = transcript fresh 130000
+
+    let cases = [
+        [name, result, expect];
+        ["silent below threshold"          (fire $s $low)    false]
+        ["nudges at threshold"             (fire $s $at)     true]
+        ["silent on the next prompt"       (fire $s $at)     false]
+        ["nudges again one step up"        (fire $s $up)     true]
+        ["silent at the same step"         (fire $s $up)     false]
+        ["fresh transcript, same session"  (fire $s $fresh)  true]
+        ["no transcript_path"              (fire $s "")      false]
+    ]
+
+    mut failed = 0
+    for c in $cases {
+        let ok = ($c.result.nudged == $c.expect) and ($c.result.exit == 0)
+        if not $ok { $failed += 1 }
+        print $"(if $ok { 'ok  ' } else { 'FAIL' }) ($c.name)  → nudged=($c.result.nudged) expected=($c.expect)"
+        if not $ok and ($c.result.stderr | is-not-empty) { print $"     stderr: ($c.result.stderr)" }
+        if $c.result.nudged and ($c.result.text | str length) > 120 {
+            $failed += 1
+            print $"FAIL ($c.name): text is (($c.result.text | str length)) chars \(cap 120\)"
+        }
+    }
+    rm -f ($nu.temp-dir | path join "ctx-flow-test-*.jsonl") ($nu.temp-dir | path join "ctx-flow-context-ctxtest*")
+    if $failed > 0 { print $"($failed) failure\(s\)"; exit 1 }
+    print $"all (($cases | length)) cases pass"
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,17 @@
     "CLAUDE_CODE_ENABLE_TODO_TOOLS": "1"
   },
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "nu --stdin \"$CLAUDE_PROJECT_DIR/.claude/hooks/scripts/prompt-context-nudge.nu\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup|resume|clear|compact|fork",


### PR DESCRIPTION
Closes #147. Replaces #164, which GitHub closed when its stacked base branch was deleted at the #163 merge.

## What

A UserPromptSubmit hook, `.claude/hooks/scripts/prompt-context-nudge.nu`:

- Reads the **exact** context size the last turn was served with: `input + cache_read + cache_creation` from the API `usage` block on the transcript's last assistant line, found with a `tail -c 128 kB` of the file. No full parse; a transcript runs to tens of MB. File size at 6 bytes/token is the fallback (median 6.5 measured across the repo's 69 transcripts; the exact path found a usage line in every one).
- From 120k tokens, prints once: `Context ~134k tokens. /checkpoint then /clear: a fresh session starts from the briefing at a fraction of the cost.` (113 chars). Then again only per further 40k.
- Once-gating: a temp-dir marker keyed by session id and transcript path. A resumed session keeps both and stays quiet until the next step; a `/clear` gets a new transcript and starts over.
- Knobs `CTX_FLOW_CONTEXT_NUDGE_TOKENS` / `CTX_FLOW_CONTEXT_NUDGE_STEP`. Fails open, exit 0 always.

## Acceptance

- Silent below threshold, one nudge at it, silent on the next prompt, again one step up, fresh transcript restarts: `nu .claude/hooks/tests/context-nudge.nu`, 7 cases pass.
- Fired live in the session that wrote it, at 140k.
- Latency ~50 ms per prompt. The issue's 20 ms is not reachable by any nu hook (bare `nu -n -c null` is 20 ms); the work itself is a stat plus a 128 kB tail.
- Statusline: Claude Code's statusLine JSON does expose `context_window.used_percentage`, so a statusline can show it without a hook; none is configured on this machine, left as an optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6KLJEisZAPXhWocFaa9kS