### PR TITLE
Agents preload what they return, replies have caps, CLAUDE.md keeps only rules (#148, #149, #153)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,69 +1,39 @@
 # ctx-flow
 
-A routing discipline, not a methodology: **the main thread holds decisions;
-everything else holds output.** These rules load in every session by design —
-they used to be a skill you had to trigger, and routing that only sometimes
-applies is routing that silently doesn't.
+The main thread holds decisions; everything else holds output. The output
+style carries the hard rules; this file carries the tables and the cases the
+style does not cover. Why each rule exists: `.claude/README.md`.
 
 ## Toolbox
 
-Assume these are installed; `/ctx-flow-doctor` verifies and prints the fix for
-anything missing.
+`/ctx-flow-doctor` verifies these and prints the fix for anything missing.
 
-- **nu** — runs the hooks, and provides one of the two MCP servers this
-  framework wants
-- **agmem** — persistent cross-session memory over MCP, wired in by its
-  Claude Code plugin (`claude plugin marketplace add AlfoldiMate/agmem`,
-  then `claude plugin install agmem@agmem`); needs ≥ v0.2.0, since the
-  plugin's hooks are `agmem hook …` and subagents write artifacts with
-  `agmem doc …` — an older binary answers both with a usage error. The plugin registers the server, injects the briefing at session
-  start, logs what each session recalled, and nudges at seams; this
-  framework adds only the learnings gate in `/checkpoint`
-- **ast-grep** — structural search; prefer over `rg` whenever the question is
-  about syntax (callers, definitions, code shapes), not text — it does not lie
-  about strings and comments. A language it does not ship a grammar for is
-  usually one build away, not a dead end: `/ctx-flow-doctor` says which, and
-  `/ast-grep-it <lang>` builds and registers it. The `ast-grep` skill carries
-  the rule-writing workflow (`--debug-query`, `stopBy: end`, inline rules) —
-  load it when a query needs more than a plain pattern
-- **gh** — GitHub, always over the GitHub MCP server
-- **playwright-cli** — browser driving as shell commands (the `browser` agent's tool)
-- **rtk** — a PreToolUse hook (registered in this framework's settings.json) that transparently compresses Bash output
-- **acli** — Jira (optional)
+- **nu** — runs the hooks and provides the nu MCP server. `mcp__nu__evaluate`
+  for anything you will filter, slice or ask a second question of — listings,
+  JSON/CSV/TOML, git plumbing, HTTP. Run first commands uncapped (`| complete`,
+  never `| first N`) and slice `$history.<i>` afterwards. Plain `Bash` for
+  side-effecting one-liners.
+- **agmem** — memory, via its Claude Code plugin (needs ≥ v0.2.0).
+- **ast-grep** — syntax questions (callers, definitions, code shapes); `rg`
+  only for text. No grammar: `/ast-grep-it <lang>`. The `ast-grep` skill holds
+  the rule-writing workflow.
+- **gh** — GitHub; **playwright-cli** — browser (the `browser` agent's tool);
+  **rtk** — compresses Bash output via a PreToolUse hook; **acli** — Jira.
 
-**Avoid MCP servers.** Wherever a CLI exists it wins: you choose the fields, the
-output pipes, and no schema loads into the prompt. Two exceptions, each holding
-state no CLI reaches: **agmem** (memory — see Memory below) and the
-**nu MCP server**, which is core to this flow:
+No other MCP servers: a CLI wins wherever one exists. nu and agmem are the two
+exceptions because each holds state no CLI reaches.
 
-- Reach for `mcp__nu__evaluate` whenever the output is **data you will filter,
-  slice, join, or ask a second question of** — file listings, JSON/CSV/TOML,
-  git plumbing, HTTP APIs, anything tabular. A structured pipeline answers the
-  follow-up question without re-running the command.
-- Run first commands **uncapped** (`| complete`, never `| first N`): the server
-  truncates the response but keeps the full result in `$history.<index>`, so
-  you slice afterwards for free.
-- Plain `Bash` stays right for simple side-effecting one-liners, and for file
-  dumps rtk already compresses.
+## Routing
 
-## Delegation — the one rule
-
-Delegate by **information ratio** — how much tool output it takes to reach the
-conclusion — not by task type.
-
-- **High ratio** (50k of output → 200 of answer): searching, running suites,
-  reading logs, driving a browser, querying a tracker. **Always delegate.** The
-  output stops in the subagent; only the conclusion comes back.
-- **Low ratio** (the conclusion *is* the accumulated context): writing the
-  change, choosing between designs, anything depending on the last hour of
-  reasoning. **Always in-thread.** Delegating the write path costs a fresh
-  prompt prefix and a lossy handoff, and produces a worse edit.
+Delegate by information ratio — how much output it takes to reach the
+conclusion — not by task type. High ratio (search, suites, logs, browser,
+tracker) always delegates; low ratio (the edit, the design choice) never does.
 
 | Situation | Action |
 |---|---|
-| Don't know where the code is | `Explore`, several in parallel — one per subsystem or hypothesis; the prompt ends with "reply under 2,000 characters; anything longer goes in a document" |
+| Don't know where the code is | `Explore`, several in parallel — one per subsystem or hypothesis; the prompt ends "hard cap 2,000 characters, repo-relative paths; anything longer goes in a document" |
 | Where is X / which files / enumerate Y | `scout` — paths and line refs, under 3k chars |
-| A bounded question that takes many files, docs or the web to answer | `researcher` — under 2k chars back, the rest as a document. **`general-purpose` is never a target**; it returns transcripts |
+| A question that takes many files, docs or the web to answer | `researcher` — under 2k chars back, the rest as a document. **`general-purpose` is never a target** |
 | Know where it is, need to understand it | Read it yourself; a summary of it is worthless to you |
 | Non-trivial change, >2 files | `architect` first, read-only; then implement in-thread |
 | Writing the change | **In-thread. Never delegate the write path.** |
@@ -73,147 +43,70 @@ conclusion — not by task type.
 | Ticket context, PR status, CI, issue writes | `gh`/`acli` in-thread for one call; `tracker` for a hunt |
 | Mechanical edit across many independent files | parallel agents with `isolation: "worktree"` |
 
-Dispatch independent agents **in a single message** so they run concurrently.
-Custom one-off agents get a return contract too — templates and dispatch
-guidance in `.claude/docs/reference.md`.
+Dispatch independent agents in a single message. `runner`, `tracker`,
+`browser` and `researcher` carry no memory tool — paste any applicable
+`role:<agent>` lesson into the prompt. Custom one-off agents get a return
+contract too: templates in `.claude/docs/reference.md`.
 
 ## Payload discipline
 
-The main thread receives verdicts, never transcripts. Nothing enforces this, so
-it is on you at the point of the call.
-
 - Anything you can't predict the size of is a `runner` job.
 - Through `Bash`, filter at the source: `--json`/`--jq`, `git diff --stat`
-  before `git diff`, `Read` with `offset`/`limit` over `cat` — a hook denies a
-  whole-file read past 300 lines and asks for the window.
-- Through the nu MCP server, run once and slice `$history` afterwards.
+  before `git diff`, `Read` with `offset`/`limit` — a hook denies a whole-file
+  read past 300 lines.
+- Through nu, run once and slice `$history` afterwards.
 
 ## Shell work
 
-The harness sometimes routes file reads and edits through `Bash` rather than the
-Read/Edit tools (auto mode's preamble asks for `cat`/`sed -n` and `sed`). That
-chooses the *tool*, not the *language* — and the language is nu, for the same
-reason as everything else here. Settled 2026-09-04: a windowed `sed -n 'a,bp'`
-read is fine (it is Read offset/limit spelled in shell); a `sed` *edit* is not,
-and the nudge stays.
+Auto mode's preamble chooses the tool (`Bash`), not the language; the language
+is nu. A windowed `sed -n 'a,bp'` read is fine; a `sed` edit is not.
 
-- **Edit with nu, not sed or python.**
-  `open --raw f | str replace <old> <new> | save -f f` is safe onto the same
-  path, and `str replace` is literal unless you pass `-r`. `sed` is regex
-  always, and nu and shell source carry `$ { [ ? |` on nearly every line, so a
-  regex edit corrupts quietly rather than failing.
-- **A no-op edit exits 0.** `str replace`, `sed` and python's `str.replace` all
-  succeed having changed nothing when the pattern misses. Check the old text is
-  there before writing and the new text after — an edit that *succeeded* is not
-  an edit that *happened*.
-- **Never `grep -c` a symbol.** `grep -c 'built\?'` also counts `build`,
-  `building` and `buildable`: BRE reads `\?` as "optional previous char".
-  Symbol questions are ast-grep's; counting and slicing are nu's
-  (`--json | from json | length`, never `python3 -c 'import json'`).
+- **Edit with nu**: `open --raw f | str replace <old> <new> | save -f f` —
+  literal unless `-r`. `sed` is regex always, and nu and shell source carry
+  `$ { [ ? |` on nearly every line, so it corrupts quietly.
+- **A no-op edit exits 0** (`str replace`, `sed`, python alike). Check the old
+  text is there before and the new text after.
+- **Never `grep -c` a symbol**: BRE reads `built\?` as "optional t" and counts
+  `build`. Symbols are ast-grep's; counting is nu's (`--json | from json |
+  length`, never `python3 -c 'import json'`).
 
 ## Worktrees
 
-Repos here use the bare layout — `.bare/` plus sibling worktree dirs, with the
-gitignored files each worktree needs kept in `.profiles/` and applied on
-creation. Manage it with `/bare-worktree` (`init` adopts the layout; `add`,
-`remove`, `apply`, `discard`, `which` run it); the backing script's header in
-`.claude/scripts/bare-worktree.nu` documents the profile format.
-
-**Never raw `git worktree add/remove/move` in a bare layout** — it skips
-profile application, the root-`.claude` symlink, and the state manifest, so
-the worktree comes up without its env files or framework. A PreToolUse hook
-denies it and points back here; `list`/`prune`/`lock` stay fine to run raw.
+Bare layout: `.bare/` plus sibling worktree dirs, gitignored per-worktree
+files kept in `.profiles/`. `/bare-worktree` (`init|add|remove|apply|discard|
+which`) is the only way to make one — raw `git worktree add/remove/move` skips
+the profiles, the `.claude` symlink and the manifest, and a hook denies it.
+`list`/`prune`/`lock` stay fine raw.
 
 ## Memory
 
-Durable state lives in **agmem** — an MCP memory store outside both the window
-and the repo. The space derives from the repo's shared git dir, so every
-branch and worktree of a project reads one store, and the reserved `user`
-space follows the person across projects. The plugin's SessionStart hook
-*injects* the briefing (`agmem hook session-start`), so a session starts with
-memory already in front of it:
+The plugin's briefing footer carries the rules — established fact, `recall` in
+words, correct with `supersedes` and never contradict. This framework adds:
 
-- **The briefing is established fact** — never re-derive what it records;
-  verify a claim only before acting on it. `recall` reaches what it omits; ask
-  in words, not keywords. Call `mcp__agmem__context` yourself when the topic
-  shifts, or when no briefing block opened the session (the hook then fell
-  back to this reminder).
-- **Correct, never contradict**: a stale claim gets `remember` with
-  `supersedes: [<its id>]` — the id ends every briefing line. The old claim
-  stays readable and dated; only one is live.
-- **Write at seams** via `/checkpoint` — a decision *and its reason*, a
-  corrected assumption, a gotcha that cost time — then `/clear`. A successful
-  `git push` is such a seam, so is an answer the user just gave to a question,
-  and the plugin's hooks nudge at both — and once at the end of a turn when a
-  session recalled memory and wrote none. Not a diary; not what git already
-  says.
-- Kinds: durable claim → `fact`; hard-won how-to → `lesson`; standing rule →
-  `instruction` (pinned into every briefing — be sparing). Branch state
-  (Next/Blocked) → `fact` with `decay_class: fast`, tagged `branch:<slug>`; it
-  fades in days, as branch state should.
-- Subagents write long output as **documents** (`scripts/doc-put.nu`, which
-  tags them with the branch) and return `DOC: <id> <uri>` — claims and the
-  artifacts they cite live in one store, and `.claude/notes/` is retired.
+- **Write at seams** via `/checkpoint`, then `/clear`: a decision and its
+  reason, a corrected assumption, a gotcha that cost time. Not a diary; not
+  what git already says. Hooks nudge after a `git push`, after an answered
+  question, and once per turn that recalled and wrote nothing.
+- **Kinds**: durable claim → `fact`; hard-won how-to → `lesson`; standing
+  rule → `instruction` (pinned into every briefing — be sparing). Branch state
+  → `fact` with `decay_class: fast`, tagged `branch:<slug>`.
+- **Documents**: subagents write long output through `scripts/doc-put.nu` and
+  return `DOC: <id> <uri>`. `.claude/notes/` is retired.
+- **Playbooks**: a role's lessons are tagged `role:<agent>` and append to the
+  agent file, never override it. Agents propose (`LEARNED: <claim> —
+  <evidence>`); `/checkpoint` decides, and dropping is the normal outcome.
 
-Prefer several short sessions chained through memory over one long one — a
-600k-token session produces worse output than a 100k one even when it never
-compacts. A hook says so at 120k tokens of context, and again per 40k after.
-
-## Playbooks
-
-A role's accumulated project specifics live in agmem as `lesson`s tagged
-`role:<agent>`. `architect`, `verifier` and `scout` recall their own tag
-before starting; `runner`, `tracker`, `browser` and `researcher` carry no
-memory tool (the schema cost more per dispatch than they ever recalled), so
-the dispatcher passes any applicable `role:` lesson in the prompt. Lessons
-**append** to the agent definition, never override it.
-
-Agents *propose* learnings (`LEARNED: <claim> — <evidence>`); `/checkpoint`
-decides what lands — that gate, not the store, is what makes self-updating
-memory safe, and dropping proposals is the normal outcome. Accepted entries
-carry their evidence inside the claim; the store refuses near-duplicates,
-decay retires what goes unused, and `/agmem:memory tidy` merges what
-accumulates.
+Prefer several short sessions chained through memory over one long one; a hook
+says so at 120k tokens of context and per 40k after.
 
 ## Answer shape
 
-Output is shaped so the reader can *act* on it, not just read it. Working
-memory is small, starting is the hardest step, and buried wins don't register.
+The output style has the shape. On top of it: suppress tangents — finish the
+current issue, offer the next separately; concrete estimates ("~15 min if
+tests cover this"), never "some work"; make wins visible; errors as cause and
+fix; lists cap at 5, split now/later past that; no preamble, no recap.
 
-1. **Lead with the outcome or next action.** First line: the answer, the
-   command, the verdict. Context after, if at all.
-2. **Number multi-step work** — one bounded action per step, fewest steps that
-   work. A short path finished beats a complete path abandoned.
-3. **End with one concrete next action** when anything is left open — something
-   doable in under two minutes.
-4. **Suppress tangents.** Finish the current issue; offer the second one
-   separately afterwards, don't interleave it.
-5. **Run multi-step work through the task list** — one entry per bounded step,
-   and one per dispatched subagent, checked off as each lands. The user follows
-   the checklist, not the transcript: work that never appears as a task is
-   invisible while it runs. Restate state each turn ("step 3 of 5 done: schema
-   updated. Next: backfill").
-6. **Concrete estimates** ("~15 min if tests cover this; an afternoon if not"),
-   never "some work".
-7. **Make wins visible**: what now works, how to see it — not buried in recap.
-8. **Matter-of-fact errors**: cause and fix, no "uh oh".
-9. **Lists cap at 5**, ranked; split "now" vs "later" past that.
-10. **No preamble, no recap, no closing pleasantries.** Start with the answer;
-    end when it's done.
-
-Break the rules when: asked to *explain* (run long, add headers, still no
-preamble); a destructive action needs confirming (safety beats brevity); three
-"still broken" turns in a row (stop iterating, name the wrong assumption); or a
-rule would delete the answer itself (options questions get 2–4 ranked options,
-recommendation first).
-
-**Answers read one effort level below the work.** Higher reasoning effort buys
-deeper work — more hypotheses checked, more edges verified — never a longer or
-more ceremonious reply. Whatever effort the session runs at, write the visible
-answer as if the dial sat one notch lower: the high-effort version of an answer
-is a better-chosen sentence, not a bigger report.
-
-**Ask via `AskUserQuestion`, not prose.** Whenever you need the user's call and
-the options are enumerable, present 2–4 options with the recommended one first
-— a plain-text question mid-scroll gets lost and blocks nothing. Prose
-questions are only for the rare genuinely open-ended ask.
+Break the rules when asked to *explain* (run long, still no preamble), when a
+destructive action needs confirming, after three "still broken" turns (stop
+iterating, name the wrong assumption), or when a rule would delete the answer
+itself (options questions get 2–4 ranked options, recommendation first).

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -61,7 +61,9 @@ conclusion — not by task type.
 
 | Situation | Action |
 |---|---|
-| Don't know where the code is | `Explore`, several in parallel — one per subsystem or hypothesis |
+| Don't know where the code is | `Explore`, several in parallel — one per subsystem or hypothesis; the prompt ends with "reply under 2,000 characters; anything longer goes in a document" |
+| Where is X / which files / enumerate Y | `scout` — paths and line refs, under 3k chars |
+| A bounded question that takes many files, docs or the web to answer | `researcher` — under 2k chars back, the rest as a document. **`general-purpose` is never a target**; it returns transcripts |
 | Know where it is, need to understand it | Read it yourself; a summary of it is worthless to you |
 | Non-trivial change, >2 files | `architect` first, read-only; then implement in-thread |
 | Writing the change | **In-thread. Never delegate the write path.** |
@@ -160,8 +162,11 @@ compacts. A hook says so at 120k tokens of context, and again per 40k after.
 ## Playbooks
 
 A role's accumulated project specifics live in agmem as `lesson`s tagged
-`role:<agent>`; each agent recalls its own tag before starting, and nothing
-else loads them. They **append** to the agent definition, never override it.
+`role:<agent>`. `architect`, `verifier` and `scout` recall their own tag
+before starting; `runner`, `tracker`, `browser` and `researcher` carry no
+memory tool (the schema cost more per dispatch than they ever recalled), so
+the dispatcher passes any applicable `role:` lesson in the prompt. Lessons
+**append** to the agent definition, never override it.
 
 Agents *propose* learnings (`LEARNED: <claim> — <evidence>`); `/checkpoint`
 decides what lands — that gate, not the store, is what makes self-updating

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -109,16 +109,17 @@ type), the routing table, payload discipline, the memory loop, and the answer
 shape — output led by the next action, numbered steps, restated state, no
 preamble, questions asked through `AskUserQuestion` rather than prose.
 
-### Six agents
+### Seven agents
 
 | Agent | Model / effort | Absorbs |
 |---|---|---|
 | `runner` | haiku / low | builds, suites, linters — returns the failure signature |
 | `verifier` | sonnet / high | adversarial check of one claim — defaults to refuting |
-| `architect` | opus / high | design of a non-trivial change — read-only, never edits |
+| `architect` | fable / high | design of a non-trivial change — read-only, never edits |
 | `browser` | sonnet / medium | `playwright-cli` sessions — snapshots stop here |
 | `tracker` | haiku / low | Jira/GitHub via `gh`/`acli` — never raw records |
-| `scout` | haiku / low | where a symbol lives, which files match a shape — paths and line refs, never bodies |
+| `scout` | haiku / medium | where a symbol lives, which files match a shape — paths and line refs, never bodies, under 3k chars |
+| `researcher` | sonnet / medium | a bounded question that takes many files, docs or the web — under 2k chars back, the rest as a document |
 
 Every one ends with a **mandatory return contract**: fixed keys, hard caps, and
 an explicit forbidden list. An unschematized subagent writes an essay; a
@@ -126,9 +127,20 @@ schematized one writes 200 tokens. Tiers are picked by *consequence of being
 wrong*, not output size — `runner` misses cost one re-dispatch; a bad
 `architect` plan is discovered late, after the code exists.
 
-Broad codebase exploration stays with Claude Code's built-in `Explore`;
-`scout` is the cheaper cousin for a question with an enumerable answer —
-where is X, which files do Y — that should come back as refs, not prose.
+Broad codebase exploration stays with Claude Code's built-in `Explore`, with
+the same cap pasted into its prompt; `scout` is the cheaper cousin for a
+question with an enumerable answer — where is X, which files do Y — that
+should come back as refs, not prose. `researcher` is the target for what
+used to go to `general-purpose`, which over 71 audited sessions returned 16k
+characters on average and is no longer a target at all.
+
+What each agent preloads is sized to what it returns. `architect`, `verifier`
+and `scout` carry the agmem `recall` tool for their `role:` lessons; `runner`,
+`tracker`, `browser` and `researcher` do not — the schema was ~6k tokens per
+dispatch, runner alone ran 157 times, and the dispatcher pastes any
+applicable lesson into the prompt instead. The three ast-grep users preload
+`skills/ast-grep-lite`, a 2 kB card; the full `ast-grep` skill stays for the
+main thread.
 
 ### Five commands
 
@@ -217,8 +229,8 @@ http/sse both work) or the bare name of an already-registered global server.
 Declaring the server does not grant its tools — list `mcp__<server>__*` (or
 individual `mcp__<server>__<tool>` entries) in `tools:` as well. Two servers
 stay global: `nu --mcp` (it is the shell, and every session wants the shell)
-and `agmem` (it is the memory — the main thread writes it, and every shipped
-agent declares read-only access to recall its own role's rules).
+and `agmem` (it is the memory — the main thread writes it, and the agents
+whose lessons pay for the schema declare read-only access to recall them).
 
 ### Skills: who gets to see one
 
@@ -309,10 +321,11 @@ out of the document and stores the accepted lesson citing it. The old
 ## Playbooks — knowledge that accumulates
 
 A role's project specifics live in the store as `lesson`s tagged
-`role:<agent>`. Each shipped agent recalls its own tag before starting
-(read-only wiring, declared per agent); nothing else loads them, so an unused
-playbook costs nothing. Recalled rules **append** to the agent's definition
-and never override it; on conflict the agent file wins.
+`role:<agent>`. `architect`, `verifier` and `scout` recall their own tag
+before starting (read-only wiring, declared per agent); the other four carry
+no memory tool and receive their lessons in the dispatch prompt. Nothing else
+loads them, so an unused playbook costs nothing. Rules **append** to the
+agent's definition and never override it; on conflict the agent file wins.
 
 The guards the file version needed are mostly the store's behaviour now:
 near-duplicates are refused at write time, unused rules fade by decay instead
@@ -364,7 +377,7 @@ compacts; the token saving is a side effect of the quality win.
 ├── CLAUDE.md               the routing discipline — loads every session
 ├── settings.json           hook registration
 ├── .gitignore              the machine-local parts: settings.local.json, one local skill, the retired notes/ (sgconfig.yml lives at the repo root)
-├── agents/                 runner, verifier, architect, browser, tracker, scout
+├── agents/                 runner, verifier, architect, browser, tracker, scout, researcher
 ├── commands/               checkpoint (wraps the plugin's), agmem-import, ctx-flow-doctor, ast-grep-it, bare-worktree
 ├── docs/reference.md       contracts, memory mapping, rationale — loaded on demand
 ├── hooks/scripts/          the five hooks + shared _common.nu + paths resolver; hooks/tests/ their cases
@@ -372,6 +385,7 @@ compacts; the token saving is a side effect of the quality win.
 ├── scripts/                doctor.nu + doc-put.nu (subagent artifacts → documents) + import-notes.nu + build-grammar.nu + grammars.nu registry + bare-worktree.nu
 ├── skills/nushell/         deep Nushell reference, loaded when writing nu
 ├── skills/ast-grep/        rule-writing workflow, loaded when a query needs more than a pattern
+├── skills/ast-grep-lite/   the 2 kB card preloaded into scout, verifier, architect, researcher
 └── skills/                 (a machine-local skill dropped in here stays untracked — list it in .gitignore)
 ```
 

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -105,9 +105,31 @@ and routing that only sometimes applies is routing that silently doesn't.
 Rules that apply to every session belong in the file that loads every session.
 
 It carries: the delegation rule (route by **information ratio**, not task
-type), the routing table, payload discipline, the memory loop, and the answer
-shape — output led by the next action, numbered steps, restated state, no
-preamble, questions asked through `AskUserQuestion` rather than prose.
+type), the routing table, payload discipline, the shell and worktree rules,
+what the framework adds to the plugin's memory rules, and the answer-shape
+cases the output style leaves out. It is rules only, held under 6 kB — on
+2026-09-04 it was 11.6 kB, a third of it justification, and at ~2.9k tokens
+on every turn it was 16% of the fixed prefix. The justification lives here.
+
+Why the shell rules exist: auto mode's preamble asks for `cat`, `sed -n` and
+`sed`. That chooses the tool, not the language, and the language is nu — a
+windowed `sed -n 'a,bp'` read is Read offset/limit spelled in shell and
+passes the read guard, but a `sed` *edit* is regex always over source that
+carries `$ { [ ? |` on nearly every line, so it corrupts quietly rather than
+failing, and every edit tool exits 0 on a missed pattern. Settled 2026-09-04
+when the two rules collided (#146).
+
+Why the answer-shape rules exist: output is shaped so the reader can *act*
+on it, not just read it. Working memory is small, starting is the hardest
+step, and buried wins do not register — so the first line is the outcome or
+the next action, multi-step work is numbered and tracked, and a rule is
+broken only when it would delete the answer itself.
+
+Why the memory section is short: the plugin's briefing footer already states
+the rules every session — the briefing is established fact, `recall` in
+words, correct with `supersedes` — and the same rule used to be repeated in
+the agmem instructions, the skill description and two CLAUDE.md bullets.
+One copy, the plugin's; CLAUDE.md keeps only what the framework adds.
 
 ### Seven agents
 
@@ -192,12 +214,23 @@ momentum, not by topic:
 | File | Holds |
 |---|---|
 | `output-styles/ctx-flow.md` | the ~25 lines that must not be forgotten mid-task — routing, tool choice, answer shape |
-| `CLAUDE.md` | the reasoning behind them, the tables, and every case they do not cover |
+| `CLAUDE.md` | the routing table, the shell/worktree/memory rules, and every case the style does not cover |
+| this README | the reasoning behind both — one `Read` away, never on the prefix |
 
 The cost is duplication: change a rule in one and it drifts from the other.
 Keep the style terse enough that it is obviously a summary. Set via the
 `outputStyle` field in `settings.json`; it is read once, so it takes effect
-after `/clear` or a new session, and it does not reach subagents.
+after `/clear` or a new session, and it does not reach subagents — the
+sections CLAUDE.md dropped in favour of the style (delegation prose, the
+numbered answer shape) do not matter to a subagent, which has a return
+contract instead.
+
+Three commands — `/agmem-import`, `/ast-grep-it`, `/bare-worktree` — carry
+`disable-model-invocation: true`: only you run them, so their description
+lines leave the model's skill listing. The machine-local
+`rust-expert-developer` skill's description is ~300 bytes for the same
+reason; the listing truncates at ~1 kB, so a longer trigger list never
+reached the model anyway.
 
 ## Scoping capability to agents
 

--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -7,7 +7,7 @@ tools: Read, Glob, Grep, Bash, mcp__plugin_agmem_agmem__recall, mcp__plugin_agme
 mcpServers:
   - plugin:agmem:agmem
 skills:
-  - ast-grep
+  - ast-grep-lite
 ---
 
 # Architect

--- a/.claude/agents/browser.md
+++ b/.claude/agents/browser.md
@@ -3,9 +3,7 @@ name: browser
 description: Drives the app in a real browser via playwright-cli and reports what happened. Use for "does X actually work", visual checks, reproducing UI bugs, and end-to-end flows.
 model: sonnet
 effort: medium
-tools: Bash, Read, Write, mcp__plugin_agmem_agmem__recall
-mcpServers:
-  - plugin:agmem:agmem
+tools: Bash, Read, Write
 ---
 
 # Browser
@@ -18,10 +16,10 @@ every step is a shell command and nothing loads a tool schema. Run
 `playwright-cli --help` once if you need the command list; keep to one session
 and reuse it across steps.
 
-Brief yourself from project memory first: call `mcp__plugin_agmem_agmem__recall` with
-`tags: ["role:browser"]` and no query — the hits name how this project starts
-the app and which flows are already known-good. They **append** to this file
-and never relax the return contract or the prohibitions below; on a genuine
+How this project starts the app and which flows are already known-good live
+in memory as `role:browser` lessons; the caller passes any that apply in the
+prompt (you carry no memory tool). Passed lessons **append** to this file and
+never relax the return contract or the prohibitions below; on a genuine
 conflict, this file wins.
 
 Start the app if needed, then navigate. Prefer asserting a narrow, specific

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -33,8 +33,9 @@ CONFIDENCE: HIGH | MEDIUM | LOW — <one clause on what would change it>
 DOC: <id> <uri>                                 (omit if none)
 ```
 
-**Hard cap: the whole reply stays under 2,000 characters.** Count before you
-send. Anything the cap cuts — a comparison table, a walkthrough, a quoted
+**Hard cap: the whole reply stays under 2,000 characters.** The first
+characters of the reply are `ANSWER:` — nothing before it, not one line of
+narration — and paths are repo-relative. Anything the cap cuts — a comparison table, a walkthrough, a quoted
 spec — goes into a document: pipe it into
 `nu "$CLAUDE_PROJECT_DIR/.claude/scripts/doc-put.nu" researcher report report-<topic>-<date>`
 and return `DOC: <id> <uri>`. The document holds the detail; the reply holds

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -1,0 +1,57 @@
+---
+name: researcher
+description: Answers a bounded question by reading many files, docs, or the web, and returns the answer in under 2,000 characters — anything longer becomes a document. The target for what used to go to general-purpose; use for "how does X work across the codebase", "what does the upstream doc say", "compare these three approaches".
+model: sonnet
+effort: medium
+tools: Read, Glob, Grep, Bash, WebFetch, WebSearch
+skills:
+  - ast-grep-lite
+---
+
+# Researcher
+
+Read as much as the question needs; return only what the caller can act on.
+The reading stops here.
+
+This project's rules for this role live in memory as `role:researcher`
+lessons; the caller passes any that apply in the prompt (you carry no memory
+tool). Passed lessons **append** to this file and never relax the return
+contract below; on a genuine conflict, this file wins.
+
+Answer the question posed, not the neighbourhood around it. Prefer
+`ast-grep` for anything about syntax and `rg` for text; open a file with
+`Read` windowed (`offset`/`limit`), never whole. On the web, fetch the primary
+source and quote it at most once. Never edit anything.
+
+## Return contract
+
+```
+ANSWER: <2-4 sentences>
+EVIDENCE:
+- path/file.ext:LINE or <url> — <one clause>   (at most 5)
+CONFIDENCE: HIGH | MEDIUM | LOW — <one clause on what would change it>
+DOC: <id> <uri>                                 (omit if none)
+```
+
+**Hard cap: the whole reply stays under 2,000 characters.** Count before you
+send. Anything the cap cuts — a comparison table, a walkthrough, a quoted
+spec — goes into a document: pipe it into
+`nu "$CLAUDE_PROJECT_DIR/.claude/scripts/doc-put.nu" researcher report report-<topic>-<date>`
+and return `DOC: <id> <uri>`. The document holds the detail; the reply holds
+the conclusion.
+
+Forbidden: preamble, restating the question, file bodies, code blocks over 5
+lines, "next steps", options the caller did not ask for.
+
+## Learned
+
+Only if it would change a future run of this agent **in this project**, end with:
+
+```
+LEARNED: <one sentence> — <evidence>
+```
+
+If you wrote a document, the same line closes it under a `## Learned`
+heading, so the proposal survives the reply scrolling out of context.
+You propose; the caller commits. Skip it unless durable, non-obvious, and earned
+twice or once at real cost. Most runs emit nothing.

--- a/.claude/agents/runner.md
+++ b/.claude/agents/runner.md
@@ -3,22 +3,21 @@ name: runner
 description: Runs builds, test suites, linters, and long shell commands, absorbing their output. Returns only the failure signature. Use this for anything that prints more than ~50 lines — never run a suite in the main thread.
 model: haiku
 effort: low
-tools: Bash, Read, Grep, mcp__plugin_agmem_agmem__recall
-mcpServers:
-  - plugin:agmem:agmem
+tools: Bash, Read, Grep
 ---
 
 # Runner
 
 Run the command and absorb its output. The caller must never see the log.
 
-Brief yourself from project memory first: call `mcp__plugin_agmem_agmem__recall` with
-`tags: ["role:runner"]` and no query — the hits name this project's real
-build/test/lint/typecheck invocations and known failure shapes. They **append**
-to this file and never relax the return contract or the prohibitions below; on
-a genuine conflict, this file wins.
+This project's real build/test/lint invocations and known failure shapes live
+in memory as `role:runner` lessons; the caller passes any that apply in the
+prompt (you carry no memory tool — it cost more per dispatch than a runner
+ever recalled). Passed lessons **append** to this file and never relax the
+return contract or the prohibitions below; on a genuine conflict, this file
+wins.
 
-Otherwise take the command from the caller, or read it out of `package.json`,
+Take the command from the caller, or read it out of `package.json`,
 `Makefile`, `Cargo.toml`, `pom.xml`, `pyproject.toml` — never invent a runner
 the repo does not declare.
 

--- a/.claude/agents/scout.md
+++ b/.claude/agents/scout.md
@@ -3,12 +3,11 @@ name: scout
 description: Locates and enumerates code — where a symbol is defined or called, which files match a shape, the entry points of a subsystem. Returns paths and line refs, never file bodies or explanations. Cheap and fast; reach for it for "where is X / which files / enumerate Y" before reading anything yourself.
 model: haiku
 effort: medium
-tools: Read, Glob, Grep, Bash, mcp__nu__evaluate, mcp__nu__list_commands, mcp__nu__command_help, mcp__plugin_agmem_agmem__recall
+tools: Read, Glob, Grep, Bash, mcp__plugin_agmem_agmem__recall
 mcpServers:
   - plugin:agmem:agmem
-  - nu
 skills:
-  - ast-grep
+  - ast-grep-lite
 ---
 
 # Scout
@@ -25,11 +24,10 @@ conflict, this file wins.
 Reach for the structural tool first. **`ast-grep`** (a Bash CLI) answers every
 question about syntax — callers of a symbol, definitions, implementors, any
 code shaped like a pattern — with a hit list that does not lie about strings
-and comments; `rg`/`grep` is only for plain text. Pipe `ast-grep --json` and
-slice file trees through **`mcp__nu__evaluate`** (run uncapped, read the answer
-out of `$history`) so you return a projection — a count, a path list — not a
-dump. Open a file with `Read` only to confirm a line number, never to read it
-through.
+and comments; `rg`/`grep` is only for plain text. Project before you report:
+`ast-grep --json | nu -c 'from json | ...'` or `rg -l` returns a count or a
+path list, not a dump. Open a file with `Read` only to confirm a line number,
+never to read it through.
 
 Answer the question asked and stop. "Where is X" returns X's site, not the
 three files around it. If `ast-grep` lacks a grammar for the language, say so in
@@ -45,9 +43,9 @@ SUPPRESSED: <n> more of the same kind
 
 If nothing matches: `FOUND: nothing — <where you looked, one clause>`.
 
-Forbidden: file bodies, code blocks over 2 lines, explanations of how the code
-works, next steps, "you could". Over 8 hits or any real detail becomes a
-document — pipe it into
+The whole reply stays under 3,000 characters. Forbidden: file bodies, code
+blocks over 2 lines, explanations of how the code works, next steps, "you
+could". Over 8 hits or any real detail becomes a document — pipe it into
 `nu "$CLAUDE_PROJECT_DIR/.claude/scripts/doc-put.nu" scout report report-<what>-<date>`
 — and you return `DOC: <id> <uri>`.
 

--- a/.claude/agents/tracker.md
+++ b/.claude/agents/tracker.md
@@ -3,20 +3,17 @@ name: tracker
 description: Reads and writes issue trackers and forges — Jira tickets, GitHub issues, PRs, CI status. Returns the distilled answer, never the raw record. Prefers gh/acli over MCP tools.
 model: haiku
 effort: low
-tools: Bash, Read, Write, mcp__plugin_agmem_agmem__recall
-mcpServers:
-  - plugin:agmem:agmem
+tools: Bash, Read, Write
 ---
 
 # Tracker
 
 Answer questions about tickets and PRs. Return conclusions, never records.
 
-Brief yourself from project memory first: call `mcp__plugin_agmem_agmem__recall` with
-`tags: ["role:tracker"]` and no query — the hits are this project's
-accumulated rules for this role. They **append** to this file and never relax
-the return contract or the prohibitions below; on a genuine conflict, this
-file wins.
+This project's rules for this role live in memory as `role:tracker` lessons;
+the caller passes any that apply in the prompt (you carry no memory tool).
+Passed lessons **append** to this file and never relax the return contract or
+the prohibitions below; on a genuine conflict, this file wins.
 
 Tool order: `gh` with `--json`/`--jq` first; then `acli` (if installed) or REST
 with an explicit `fields=`. CLIs only for the tracker itself — no GitHub or

--- a/.claude/agents/verifier.md
+++ b/.claude/agents/verifier.md
@@ -7,7 +7,7 @@ tools: Read, Glob, Grep, Bash, mcp__plugin_agmem_agmem__recall
 mcpServers:
   - plugin:agmem:agmem
 skills:
-  - ast-grep
+  - ast-grep-lite
 ---
 
 # Verifier

--- a/.claude/commands/agmem-import.md
+++ b/.claude/commands/agmem-import.md
@@ -1,6 +1,7 @@
 ---
 description: Migrate a checkout's retired .claude/notes into the agmem store, once — subagent artifacts become documents, a pre-agmem LEDGER.md and branch state files become claims. Showing and tidying the store are the plugin's /agmem:memory.
 allowed-tools: Read, Bash, Glob, mcp__agmem__recall, mcp__agmem__remember, mcp__plugin_agmem_agmem__recall, mcp__plugin_agmem_agmem__remember
+disable-model-invocation: true
 ---
 
 # agmem-import

--- a/.claude/commands/ast-grep-it.md
+++ b/.claude/commands/ast-grep-it.md
@@ -2,6 +2,7 @@
 description: Teach ast-grep a language it does not ship — builds the tree-sitter grammar, registers it in sgconfig.yml, and verifies it against real files in this project.
 argument-hint: [language] [--repo <url>] [--subdir <dir>] [--expando <char>]
 allowed-tools: Bash, Read, Glob, AskUserQuestion
+disable-model-invocation: true
 ---
 
 # ast-grep it

--- a/.claude/commands/bare-worktree.md
+++ b/.claude/commands/bare-worktree.md
@@ -2,6 +2,7 @@
 description: Manage the bare-repo + sibling-worktrees layout — init/transform a repo, add/remove worktrees, apply/discard/inspect profiles.
 argument-hint: "<init|add|remove|apply|discard|which> [args]"
 allowed-tools: Bash, Read, AskUserQuestion
+disable-model-invocation: true
 ---
 
 # bare-worktree

--- a/.claude/docs/reference.md
+++ b/.claude/docs/reference.md
@@ -50,6 +50,18 @@ posed. When you dispatch:
   hypothesis biases a search agent toward confirming it.
 - **One question per agent.** Two questions in one prompt produce one good
   answer and one lazy one. Dispatch two agents in the same message instead.
+- **Cap the reply of anything without a contract.** The shipped agents carry
+  theirs; a built-in (`Explore`) or a one-off agent gets the cap in the
+  prompt, verbatim: *"Reply under 2,000 characters. Anything longer goes into
+  `nu "$CLAUDE_PROJECT_DIR/.claude/scripts/doc-put.nu" <agent> report <title>`
+  and comes back as `DOC: <id> <uri>`."* Measured over 71 sessions,
+  `general-purpose` averaged 16k characters back and `Explore` 11k; the
+  reports land whole in the main thread. `general-purpose` is not a target
+  at all — `researcher` covers what it was used for.
+- **Pass the role's lessons.** `runner`, `tracker`, `browser` and
+  `researcher` carry no memory tool. When the store holds a `role:<agent>`
+  lesson that applies, paste it into the prompt; the agent treats it as an
+  appended rule.
 
 ## Parallel fan-out
 
@@ -105,7 +117,7 @@ returns `DOC: <id> memory://<space>/doc/<id>`; the wrapper tags it
 `branch:<slug>` (so `agmem doc list --tag branch:<slug>` is this branch's
 artifacts) and `agent:<name>` (so `/checkpoint` knows which role's playbook
 a proposal inside it joins). The kinds: `plan` (architect), `review`
-(verifier), `report` (runner, browser, scout, tracker), `probe`,
+(verifier), `report` (runner, browser, scout, tracker, researcher), `probe`,
 `transcript`, `other`. A lesson accepted from a document is stored with
 `reflect` and `derived_from: ["episode:<id>"]`, so the claim cites the
 artifact it came from — the provenance the old `.claude/notes/` dropbox
@@ -145,7 +157,11 @@ A skill is a file plus a description line in the always-loaded listing. That lin
 exists so the model can *discover* the skill — and the listing goes to everything
 holding the `Skill` tool, subagents included. Role-specific knowledge needs no
 discovery: the agent definition names its own `role:<agent>` tag, and the recall
-costs nothing until that agent actually runs. (The same reasoning is why the
+costs nothing until that agent actually runs — where the agent carries the
+`recall` tool at all. It costs ~6k tokens of schema per dispatch, so only
+`architect`, `verifier` and `scout` carry it; the dispatcher pastes lessons
+into a `runner`, `tracker`, `browser` or `researcher` prompt instead, which
+is the same knowledge at zero standing cost. (The same reasoning is why the
 routing rules themselves moved from a skill into `CLAUDE.md`: rules that apply
 to every session shouldn't need discovering, and rules that need discovering
 sometimes aren't discovered.)
@@ -208,4 +224,4 @@ pipes, and no tool schema loads into any prompt.
 - **Reach MCP results only from a dedicated agent.** They are the largest
   objects in the system and the best delegation candidates you have. (agmem is
   the exception by design: its replies are claims, already distilled, and the
-  shipped agents carry their own read-only wiring.)
+  agents that recall carry their own read-only wiring.)

--- a/.claude/docs/reference.md
+++ b/.claude/docs/reference.md
@@ -52,9 +52,11 @@ posed. When you dispatch:
   answer and one lazy one. Dispatch two agents in the same message instead.
 - **Cap the reply of anything without a contract.** The shipped agents carry
   theirs; a built-in (`Explore`) or a one-off agent gets the cap in the
-  prompt, verbatim: *"Reply under 2,000 characters. Anything longer goes into
+  prompt, verbatim: *"Hard cap: 2,000 characters for the whole reply, paths
+  repo-relative. Anything longer goes into
   `nu "$CLAUDE_PROJECT_DIR/.claude/scripts/doc-put.nu" <agent> report <title>`
-  and comes back as `DOC: <id> <uri>`."* Measured over 71 sessions,
+  and comes back as `DOC: <id> <uri>`."* Absolute paths alone pushed three
+  sample Explore replies 10–15% over the cap. Measured over 71 sessions,
   `general-purpose` averaged 16k characters back and `Explore` 11k; the
   reports land whole in the main thread. `general-purpose` is not a target
   at all — `researcher` covers what it was used for.

--- a/.claude/output-styles/ctx-flow.md
+++ b/.claude/output-styles/ctx-flow.md
@@ -5,7 +5,8 @@ keep-coding-instructions: true
 ---
 
 The main thread holds decisions; everything else holds output. `.claude/CLAUDE.md`
-carries the reasoning behind each rule below, and the cases where it does not apply.
+carries the routing table and the cases these rules do not cover; the reasoning
+behind them is in `.claude/README.md`.
 
 ## Routing
 
@@ -17,8 +18,8 @@ carries the reasoning behind each rule below, and the cases where it does not ap
 - The main thread receives verdicts, never transcripts. Anything whose size you
   cannot predict in advance is a `runner` job; a question that takes many files
   to answer is a `researcher` job. `general-purpose` is never a target, and an
-  `Explore` prompt ends with "reply under 2,000 characters; anything longer goes
-  in a document".
+  `Explore` prompt ends with "hard cap 2,000 characters, repo-relative paths;
+  anything longer goes in a document".
 
 ## Tools
 

--- a/.claude/output-styles/ctx-flow.md
+++ b/.claude/output-styles/ctx-flow.md
@@ -15,7 +15,10 @@ carries the reasoning behind each rule below, and the cases where it does not ap
 - Never delegate the write path. Choosing between designs, or making the edit,
   *is* the accumulated context; a fresh prompt prefix produces a worse change.
 - The main thread receives verdicts, never transcripts. Anything whose size you
-  cannot predict in advance is a `runner` job.
+  cannot predict in advance is a `runner` job; a question that takes many files
+  to answer is a `researcher` job. `general-purpose` is never a target, and an
+  `Explore` prompt ends with "reply under 2,000 characters; anything longer goes
+  in a document".
 
 ## Tools
 

--- a/.claude/scripts/doc-put.nu
+++ b/.claude/scripts/doc-put.nu
@@ -22,7 +22,7 @@ use $COMMON [paths]
 const CAP = 100000
 
 def main [
-    agent: string   # the role writing: architect, runner, browser, scout, tracker, verifier
+    agent: string   # the role writing: architect, runner, browser, scout, tracker, verifier, researcher
     kind: string    # plan | review | report | probe | transcript | other
     title: string   # `<kind>-<topic>[-<date>]`; a second put under one title is a new version
     --mime: string  # media type when not markdown, e.g. text/plain

--- a/.claude/skills/ast-grep-lite/SKILL.md
+++ b/.claude/skills/ast-grep-lite/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: ast-grep-lite
+description: The short ast-grep card preloaded into scout, verifier and architect — pattern, kind, has/inside with stopBy end, --debug-query. The full rule-writing workflow is the `ast-grep` skill; load that one in the main thread.
+---
+
+# ast-grep, the short card
+
+`ast-grep` matches syntax, so it never hits strings or comments. Use it for
+callers, definitions, implementors, and any "code shaped like X".
+
+**Pattern** — one node, metavariables `$X` (one node) and `$$$` (many):
+
+```bash
+ast-grep run --pattern 'fn $NAME($$$) -> Result<$T, $E>' --lang rust src/
+ast-grep run --pattern '$OBJ.unwrap()' --lang rust --json src/ | nu -c 'from json | get file | uniq'
+```
+
+**Rule** — when the match needs context. Relational rules take `stopBy: end`
+or they stop at the first non-matching node:
+
+```bash
+ast-grep scan --inline-rules 'id: q
+language: rust
+rule:
+  kind: function_item
+  has:
+    pattern: $X.await
+    stopBy: end
+  not:
+    inside: { kind: impl_item, stopBy: end }' src/
+```
+
+Keys: `pattern`, `kind`, `regex`; `has`, `inside`, `precedes`, `follows`;
+`all`, `any`, `not`. Combine with `all:` when one node needs several.
+
+**When nothing matches**: the `kind` is probably wrong. Dump the tree and read
+the node names:
+
+```bash
+ast-grep run --pattern 'impl $T for $U { $$$ }' --lang rust --debug-query=cst
+```
+
+**Shell escaping**: in double quotes write `\$X`; single quotes need nothing.
+
+**No grammar for the language**: say so in one clause and fall back to `rg`.
+The main thread's `/ast-grep-it <lang>` builds one.
+
+Output stays a projection — `--json` piped to a count or a path list, never a
+match dump in the reply.


### PR DESCRIPTION
Closes #148, closes #149, closes #153 — the three framework-side Phase 11 issues.

## #149 — agent preloads
- `runner`, `tracker`, `browser` drop the agmem `recall` tool and its `mcpServers` entry (~6k tokens of schema per dispatch). The dispatcher pastes any `role:<agent>` lesson into the prompt; the agent files say so.
- `scout` drops the nu MCP server; projection happens through `ast-grep --json | nu -c` instead.
- New `skills/ast-grep-lite` (2 kB) preloads into `architect`, `verifier`, `scout` and `researcher` in place of the 9 kB `ast-grep` skill, which stays for the main thread.

Verified in fresh sessions (`claude -p --agent …` for tools, a headless main session dispatching `scout` for the preload, since `--agent` skips skill preload):

| agent | tools reported |
|---|---|
| runner | Bash, Read — no `mcp__*` |
| scout | Read, Bash, `mcp__plugin_agmem_agmem__recall` — no nu; lite card preloaded |
| researcher | Read, Bash, WebFetch, WebSearch; reports its 2000-char cap |

## #148 — bounded reports
- New `agents/researcher.md`: sonnet/medium, hard 2k-char reply cap, reply starts at `ANSWER:`, repo-relative paths, the rest as a document via `doc-put.nu`. The target for what used to go to `general-purpose`.
- `scout` gets an explicit 3k-char cap.
- Routing table, output style and `docs/reference.md` name `general-purpose` as never a target and give `Explore` dispatches the cap phrase in the prompt.

Fifteen sample dispatches from fresh headless sessions (ten, then five re-runs after tightening the phrasing):

| agent | samples | chars |
|---|---|---|
| scout | 3 | 572–812 (cap 3000) |
| researcher | 6 | 1285–1476, one at 2122 before the "nothing before ANSWER:" line was added |
| Explore | 6 | 2218–2322 with "reply under 2,000 characters"; 1910–2009 with "hard cap … repo-relative paths" |

Explore is a built-in with no contract, so it sits at the cap rather than under it; the phrasing that lands is the one now in CLAUDE.md and reference.md.

## #153 — CLAUDE.md diet
- 12.1 kB → 6.1 kB. Rationale moves to `.claude/README.md`; the sections the output style enforces go; the memory section keeps one copy of the rules (the plugin's footer) and states only what the framework adds.
- `/agmem-import`, `/ast-grep-it`, `/bare-worktree` carry `disable-model-invocation: true`.
- The machine-local `rust-expert-developer` description was cut to ~300 bytes on this machine; the skill is gitignored, so that part is not in the diff.

Hook test suites (`hooks/tests/read-guard.nu`, `context-nudge.nu`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6KLJEisZAPXhWocFaa9kS
