### PR TITLE
chore: release v0.2.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
   "owner": { "name": "Mate Alfoldi" },
   "metadata": {
     "description": "agmem — persistent memory for coding agents over MCP",
-    "version": "0.2.1"
+    "version": "0.2.2"
   },
   "plugins": [
     {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "blake3",
  "jiff",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-embed"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agmem-core",
  "fastembed",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-server"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agmem-core",
  "agmem-embed",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-store"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "agmem-core",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -21,9 +21,9 @@ homepage = "https://github.com/AlfoldiMate/agmem"
 # dependency with no version requirement. Local builds resolve by path either
 # way, and a caret requirement stays satisfied across the bumps release-plz
 # makes.
-agmem-core = { path = "crates/agmem-core", version = "0.2.1" }
-agmem-store = { path = "crates/agmem-store", version = "0.2.1" }
-agmem-embed = { path = "crates/agmem-embed", version = "0.2.1" }
+agmem-core = { path = "crates/agmem-core", version = "0.2.2" }
+agmem-store = { path = "crates/agmem-store", version = "0.2.2" }
+agmem-embed = { path = "crates/agmem-embed", version = "0.2.2" }
 
 # MCP + storage + embeddings (pinned per docs/design.md §4.1)
 rmcp = { version = "3.1", features = ["server", "macros", "transport-io"] }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "agmem",
   "displayName": "agmem memory",
   "description": "Persistent cross-session memory for Claude Code: the agmem MCP server, a briefing injected at every session start, checkpoint and tidy commands, and hooks that log what memory was used so the store can learn what helped.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": { "name": "Mate Alfoldi" },
   "homepage": "https://github.com/AlfoldiMate/agmem",
   "repository": "https://github.com/AlfoldiMate/agmem",


### PR DESCRIPTION



## 🤖 New release

* `agmem-core`: 0.2.1 -> 0.2.2
* `agmem-store`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `agmem-embed`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `agmem-server`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).