### PR TITLE
Embedding candidates measured against the store: none clears the bar, Gemma and arctic go to #139 (#133)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,10 @@ target/
 # local embedding model cache
 .fastembed_cache/
 
+# #133 candidate recordings: ~3 MB per candidate, regenerated on demand
+crates/agmem-server/tests/fixtures/eval/candidates/
+# #133 per-candidate run logs; the numbers that matter go in embed-models.md
+docs/eval/embed-models/*/
+
 # surreal sql shell history, dropped wherever the CLI is run
 history.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,8 +53,11 @@ version = "0.2.1"
 dependencies = [
  "agmem-core",
  "fastembed",
+ "ndarray",
+ "ort",
  "serde_json",
  "thiserror",
+ "tokenizers",
  "tokio",
  "tracing",
 ]

--- a/crates/agmem-embed/Cargo.toml
+++ b/crates/agmem-embed/Cargo.toml
@@ -11,12 +11,24 @@ repository.workspace = true
 # The cross-encoder rerank probe (issue #81): measurement surface only —
 # nothing in the server links it.
 rerank = []
+# The #133 embedding-candidate probe: measurement surface only — nothing in
+# the server links it. Loads the candidates behind `Embedder` with their own
+# prefixes and pooling so the numbers come off the production ORT path.
+candidates = ["dep:ndarray", "dep:serde_json", "dep:ort", "dep:tokenizers"]
 
 [dependencies]
 fastembed = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+# fastembed's own ndarray, for the attention mask the last-token pooling reads.
+ndarray = { version = "0.17.2", default-features = false, optional = true }
+serde_json = { workspace = true, optional = true }
+# fastembed's own ort and tokenizers, for the one export it cannot drive
+# itself (Qwen3 wants `position_ids`); the pins match fastembed's so one
+# ONNX Runtime is linked.
+ort = { version = "=2.0.0-rc.13", default-features = false, features = ["ndarray", "std"], optional = true }
+tokenizers = { version = "0.22.2", default-features = false, features = ["onig"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/agmem-embed/src/candidates.rs
+++ b/crates/agmem-embed/src/candidates.rs
@@ -1,0 +1,612 @@
+//! The embedding candidates behind the #133 probe, each loaded behind
+//! [`Embedder`] with its own prefixes and pooling.
+//!
+//! Measurement surface only. Nothing in the server constructs these; the
+//! ignored tests in `tests/candidates.rs` and the candidate branch of the
+//! eval recorder in `tests/fastembed.rs` are the callers, and
+//! `docs/eval/embed-models.md` is where their numbers decide whether the
+//! migration (#138) gets built at all.
+//!
+//! Every candidate runs through the runtime the daemon runs — ONNX Runtime
+//! on CPU — so the vectors measured are the vectors a store would get. Two
+//! are in fastembed's built-in list; arctic-embed-m-v2.0 is a user-defined
+//! fastembed model read from the model cache, which
+//! `scripts/embed-candidates-fetch.nu` fills. Qwen3-Embedding is driven
+//! through `ort` directly: its export takes a `position_ids` input fastembed
+//! never feeds, and it wants last-token pooling fastembed cannot express, so
+//! this module tokenises, runs the session and pools by hand.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use fastembed::{
+    EmbeddingModel, InitOptionsUserDefined, Pooling, QuantizationMode, TextEmbedding,
+    TextInitOptions, TokenizerFiles, UserDefinedEmbeddingModel,
+};
+use ndarray::{Array2, Axis};
+use ort::session::Session;
+use ort::session::builder::GraphOptimizationLevel;
+use ort::value::Value;
+use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams};
+
+use crate::{EmbedError, Embedder};
+
+/// The environment variable that names the candidate a test run measures.
+pub const CANDIDATE_ENV: &str = "AGMEM_CANDIDATE";
+
+/// Token files the user-defined loaders read from the model cache; the same
+/// four fastembed's own hub loader fetches.
+const TOKENIZER_FILES: [&str; 4] = [
+    "tokenizer.json",
+    "config.json",
+    "special_tokens_map.json",
+    "tokenizer_config.json",
+];
+
+/// Qwen3's end-of-sequence token, which its embedding recipe requires as the
+/// last real token of every input — the pooled position — and its pad.
+const QWEN3_EOS: &str = "<|endoftext|>";
+
+/// Longest input, in tokens, for the models this module tokenises itself.
+const MAX_TOKENS: usize = 512;
+
+/// The models under measurement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Candidate {
+    /// The control: what ships today.
+    BgeSmallQ,
+    /// EmbeddingGemma-300M, 8-bit dynamic quantisation, pooled in-graph.
+    Gemma300MQ,
+    /// snowflake-arctic-embed-m-v2.0, int8, CLS pooled.
+    ArcticMV2Int8,
+    /// Qwen3-Embedding-0.6B, int8, last-token pooled.
+    Qwen3Embedding06BInt8,
+}
+
+impl Candidate {
+    /// Every candidate, control first.
+    pub const ALL: [Self; 4] = [
+        Self::BgeSmallQ,
+        Self::Gemma300MQ,
+        Self::ArcticMV2Int8,
+        Self::Qwen3Embedding06BInt8,
+    ];
+
+    /// The id a recording, a latency row and `AGMEM_CANDIDATE` spell.
+    #[must_use]
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::BgeSmallQ => crate::fastembed::MODEL_ID,
+            Self::Gemma300MQ => "embeddinggemma-300m-q",
+            Self::ArcticMV2Int8 => "arctic-embed-m-v2.0-int8",
+            Self::Qwen3Embedding06BInt8 => "qwen3-embedding-0.6b-int8",
+        }
+    }
+
+    /// The candidate an id names.
+    #[must_use]
+    pub fn parse(id: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|candidate| candidate.id() == id)
+    }
+
+    /// The candidate [`CANDIDATE_ENV`] names, if it is set.
+    ///
+    /// # Panics
+    /// When the variable names no known candidate — a typo must not measure
+    /// the control by accident.
+    #[must_use]
+    pub fn from_env() -> Option<Self> {
+        let id = std::env::var(CANDIDATE_ENV).ok()?;
+        Some(Self::parse(&id).unwrap_or_else(|| {
+            let known: Vec<&str> = Self::ALL.iter().map(|c| c.id()).collect();
+            panic!("{CANDIDATE_ENV}={id:?} names no candidate; one of {known:?}")
+        }))
+    }
+
+    /// Full vector width, before any MRL truncation.
+    #[must_use]
+    pub fn dim(self) -> usize {
+        match self {
+            Self::BgeSmallQ => crate::fastembed::DIM,
+            Self::Gemma300MQ | Self::ArcticMV2Int8 => 768,
+            Self::Qwen3Embedding06BInt8 => 1024,
+        }
+    }
+
+    /// What stored text is marked with, per the model's card.
+    fn passage_prefix(self) -> &'static str {
+        match self {
+            Self::BgeSmallQ => "passage: ",
+            Self::Gemma300MQ => "title: none | text: ",
+            Self::ArcticMV2Int8 | Self::Qwen3Embedding06BInt8 => "",
+        }
+    }
+
+    /// What the search side is marked with, per the model's card.
+    fn query_prefix(self) -> &'static str {
+        match self {
+            Self::BgeSmallQ | Self::ArcticMV2Int8 => "query: ",
+            Self::Gemma300MQ => "task: search result | query: ",
+            Self::Qwen3Embedding06BInt8 => {
+                "Instruct: Given a web search query, retrieve relevant passages that answer \
+                 the query\nQuery: "
+            }
+        }
+    }
+
+    /// The Hugging Face repo a user-defined candidate's files come from,
+    /// and the ONNX file inside it; `None` for fastembed's built-ins.
+    #[must_use]
+    pub fn user_defined(self) -> Option<(&'static str, &'static str)> {
+        match self {
+            Self::BgeSmallQ | Self::Gemma300MQ => None,
+            Self::ArcticMV2Int8 => Some((
+                "Snowflake/snowflake-arctic-embed-m-v2.0",
+                "onnx/model_int8.onnx",
+            )),
+            Self::Qwen3Embedding06BInt8 => Some((
+                "onnx-community/Qwen3-Embedding-0.6B-ONNX",
+                "onnx/model_int8.onnx",
+            )),
+        }
+    }
+
+    /// Every file a user-defined candidate needs, relative to its repo.
+    #[must_use]
+    pub fn files(self) -> Vec<&'static str> {
+        let Some((_, onnx)) = self.user_defined() else {
+            return Vec::new();
+        };
+        let mut files = vec![onnx];
+        files.extend(TOKENIZER_FILES);
+        files
+    }
+
+    /// Where a user-defined candidate's files live under the model cache.
+    #[must_use]
+    pub fn dir(self, cache_dir: &Path) -> Option<PathBuf> {
+        self.user_defined()
+            .map(|(repo, _)| cache_dir.join("candidates").join(repo))
+    }
+}
+
+/// The model cache the candidates share: `FASTEMBED_CACHE_DIR` when set,
+/// else the platform data dir's `models`, which is where
+/// `scripts/embed-candidates-fetch.nu` puts the user-defined files.
+#[must_use]
+pub fn cache_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os("FASTEMBED_CACHE_DIR") {
+        return PathBuf::from(dir);
+    }
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_default();
+    let base = if cfg!(target_os = "macos") {
+        home.join("Library/Application Support/dev.agmem.agmem")
+    } else {
+        home.join(".local/share/agmem")
+    };
+    base.join("models")
+}
+
+/// What runs the model.
+enum Engine {
+    /// fastembed's `embed`: tokenising, the session and CLS/mean/in-graph
+    /// pooling all inside the crate.
+    Fastembed(Mutex<TextEmbedding>),
+    /// An `ort` session driven here, for an export fastembed cannot feed.
+    Direct(Mutex<Direct>),
+}
+
+/// One loaded candidate.
+pub struct CandidateBackend {
+    candidate: Candidate,
+    engine: Engine,
+}
+
+impl std::fmt::Debug for CandidateBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CandidateBackend")
+            .field("model", &self.candidate.id())
+            .field("dim", &self.candidate.dim())
+            .field(
+                "engine",
+                &match self.engine {
+                    Engine::Fastembed(_) => "fastembed",
+                    Engine::Direct(_) => "ort",
+                },
+            )
+            .finish()
+    }
+}
+
+impl CandidateBackend {
+    /// Load `candidate` from `cache_dir`: built-ins download once through
+    /// fastembed; user-defined ones read the files the fetch script put
+    /// there and fail naming the missing one.
+    ///
+    /// # Errors
+    /// [`EmbedError::Backend`] when a file is missing or the session will
+    /// not build.
+    pub fn load(candidate: Candidate, cache_dir: &Path) -> Result<Self, EmbedError> {
+        let failed = |message: String| EmbedError::Backend {
+            backend: candidate.id(),
+            message,
+        };
+        let engine = match candidate {
+            Candidate::BgeSmallQ | Candidate::Gemma300MQ => {
+                let builtin = match candidate {
+                    Candidate::BgeSmallQ => EmbeddingModel::BGESmallENV15Q,
+                    _ => EmbeddingModel::EmbeddingGemma300MQ,
+                };
+                let options = TextInitOptions::new(builtin)
+                    .with_cache_dir(cache_dir.to_path_buf())
+                    .with_show_download_progress(false);
+                let model = TextEmbedding::try_new(options).map_err(|e| failed(e.to_string()))?;
+                Engine::Fastembed(Mutex::new(model))
+            }
+            Candidate::ArcticMV2Int8 => {
+                let files = Files::read(candidate, cache_dir)?;
+                let tokenizer_files = files.tokenizer_files();
+                let model = UserDefinedEmbeddingModel::new(files.onnx, tokenizer_files)
+                    .with_quantization(QuantizationMode::Static)
+                    .with_pooling(Pooling::Cls);
+                let options = InitOptionsUserDefined::new().with_max_length(MAX_TOKENS);
+                let model = TextEmbedding::try_new_from_user_defined(model, options)
+                    .map_err(|e| failed(e.to_string()))?;
+                Engine::Fastembed(Mutex::new(model))
+            }
+            Candidate::Qwen3Embedding06BInt8 => {
+                let files = Files::read(candidate, cache_dir)?;
+                Engine::Direct(Mutex::new(Direct::load(files, QWEN3_EOS).map_err(failed)?))
+            }
+        };
+        tracing::info!(
+            model = candidate.id(),
+            dim = candidate.dim(),
+            "loaded candidate"
+        );
+        Ok(Self { candidate, engine })
+    }
+
+    /// The candidate this backend runs.
+    #[must_use]
+    pub fn candidate(&self) -> Candidate {
+        self.candidate
+    }
+
+    /// Embed already-prefixed texts, checking the width.
+    fn embed_all(&self, texts: Vec<String>) -> Result<Vec<Vec<f32>>, EmbedError> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+        let failed = |message: String| EmbedError::Backend {
+            backend: self.candidate.id(),
+            message,
+        };
+        let poisoned = || failed("the model lock was poisoned by an earlier panic".to_owned());
+        let vectors = match &self.engine {
+            Engine::Fastembed(model) => {
+                let mut model = model.lock().map_err(|_| poisoned())?;
+                model
+                    .embed(texts, None)
+                    .map_err(|e| failed(e.to_string()))?
+            }
+            Engine::Direct(direct) => {
+                let mut direct = direct.lock().map_err(|_| poisoned())?;
+                direct.embed(&texts).map_err(failed)?
+            }
+        };
+
+        let dim = self.candidate.dim();
+        if let Some(wrong) = vectors.iter().find(|vector| vector.len() != dim) {
+            return Err(failed(format!(
+                "model returned {}-dimensional vectors, expected {dim}",
+                wrong.len()
+            )));
+        }
+        Ok(vectors)
+    }
+}
+
+impl Embedder for CandidateBackend {
+    fn dim(&self) -> usize {
+        self.candidate.dim()
+    }
+
+    fn model_id(&self) -> &str {
+        self.candidate.id()
+    }
+
+    fn embed_passages(&self, passages: &[String]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        let prefix = self.candidate.passage_prefix();
+        self.embed_all(
+            passages
+                .iter()
+                .map(|passage| format!("{prefix}{passage}"))
+                .collect(),
+        )
+    }
+
+    fn embed_query(&self, query: &str) -> Result<Vec<f32>, EmbedError> {
+        let prefix = self.candidate.query_prefix();
+        let mut vectors = self.embed_all(vec![format!("{prefix}{query}")])?;
+        vectors.pop().ok_or_else(|| EmbedError::Backend {
+            backend: self.candidate.id(),
+            message: "model returned no vector for the query".to_owned(),
+        })
+    }
+}
+
+/// A user-defined candidate's files, read from the cache.
+struct Files {
+    onnx: Vec<u8>,
+    tokenizer: Vec<u8>,
+    config: Vec<u8>,
+    special_tokens_map: Vec<u8>,
+    tokenizer_config: Vec<u8>,
+}
+
+impl Files {
+    fn read(candidate: Candidate, cache_dir: &Path) -> Result<Self, EmbedError> {
+        let dir = candidate.dir(cache_dir).expect("user-defined");
+        let (_, onnx) = candidate.user_defined().expect("user-defined");
+        let read = |file: &str| -> Result<Vec<u8>, EmbedError> {
+            std::fs::read(dir.join(file)).map_err(|e| EmbedError::Backend {
+                backend: candidate.id(),
+                message: format!(
+                    "read {}: {e}; run scripts/embed-candidates-fetch.nu",
+                    dir.join(file).display()
+                ),
+            })
+        };
+        Ok(Self {
+            onnx: read(onnx)?,
+            tokenizer: read("tokenizer.json")?,
+            config: read("config.json")?,
+            special_tokens_map: read("special_tokens_map.json")?,
+            tokenizer_config: read("tokenizer_config.json")?,
+        })
+    }
+
+    fn tokenizer_files(&self) -> TokenizerFiles {
+        TokenizerFiles {
+            tokenizer_file: self.tokenizer.clone(),
+            config_file: self.config.clone(),
+            special_tokens_map_file: self.special_tokens_map.clone(),
+            tokenizer_config_file: self.tokenizer_config.clone(),
+        }
+    }
+}
+
+/// An `ort` session with its tokenizer, for a decoder-style embedder:
+/// `input_ids`, `attention_mask` and — when the graph asks — `position_ids`
+/// in; `last_hidden_state` out, pooled at each row's last attended token.
+struct Direct {
+    session: Session,
+    tokenizer: Tokenizer,
+    wants_position_ids: bool,
+    /// The `past_key_values.<n>.key|value` inputs a decoder export carries,
+    /// each fed an empty cache of `[rows, kv_heads, 0, head_dim]`.
+    past_inputs: Vec<String>,
+    kv_heads: usize,
+    head_dim: usize,
+    /// The graph's own pooled output, when the export carries one.
+    pooled_output: Option<String>,
+    /// The EOS text to append when the tokenizer's post-processor does not.
+    append_eos: Option<&'static str>,
+}
+
+impl Direct {
+    fn load(files: Files, eos: &'static str) -> Result<Self, String> {
+        let mut tokenizer = Tokenizer::from_bytes(&files.tokenizer).map_err(|e| e.to_string())?;
+        let pad_id = tokenizer
+            .token_to_id(eos)
+            .ok_or_else(|| format!("tokenizer has no {eos} token"))?;
+        tokenizer
+            .with_padding(Some(PaddingParams {
+                strategy: PaddingStrategy::BatchLongest,
+                pad_id,
+                pad_token: eos.to_owned(),
+                ..PaddingParams::default()
+            }))
+            .with_truncation(Some(TruncationParams {
+                max_length: MAX_TOKENS,
+                ..TruncationParams::default()
+            }))
+            .map_err(|e| e.to_string())?;
+        let append_eos = (!tokenizer_appends(&files.tokenizer, eos)).then_some(eos);
+
+        let session = Session::builder()
+            .map_err(|e| e.to_string())?
+            .with_optimization_level(GraphOptimizationLevel::Level3)
+            .map_err(|e| e.to_string())?
+            .commit_from_memory(&files.onnx)
+            .map_err(|e| e.to_string())?;
+        let wants_position_ids = session.inputs().iter().any(|i| i.name() == "position_ids");
+        let past_inputs: Vec<String> = session
+            .inputs()
+            .iter()
+            .map(|i| i.name().to_owned())
+            .filter(|name| name.starts_with("past_key_values."))
+            .collect();
+        let config: serde_json::Value =
+            serde_json::from_slice(&files.config).map_err(|e| format!("config.json: {e}"))?;
+        let number = |key: &str| -> Result<usize, String> {
+            config[key]
+                .as_u64()
+                .map(|n| n as usize)
+                .ok_or_else(|| format!("config.json lacks {key}"))
+        };
+        let (kv_heads, head_dim) = if past_inputs.is_empty() {
+            (0, 0)
+        } else {
+            let head_dim = match number("head_dim") {
+                Ok(dim) => dim,
+                Err(_) => number("hidden_size")? / number("num_attention_heads")?,
+            };
+            (number("num_key_value_heads")?, head_dim)
+        };
+        let pooled_output = session
+            .outputs()
+            .iter()
+            .map(|o| o.name().to_owned())
+            .find(|name| name == "sentence_embedding");
+        tracing::info!(
+            inputs = ?session.inputs().iter().map(|i| i.name()).collect::<Vec<_>>(),
+            outputs = ?session.outputs().iter().map(|o| o.name()).collect::<Vec<_>>(),
+            append_eos = append_eos.is_some(),
+            past = past_inputs.len(),
+            kv_heads,
+            head_dim,
+            "direct session"
+        );
+        Ok(Self {
+            session,
+            tokenizer,
+            wants_position_ids,
+            past_inputs,
+            kv_heads,
+            head_dim,
+            pooled_output,
+            append_eos,
+        })
+    }
+
+    fn embed(&mut self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
+        let inputs: Vec<String> = match self.append_eos {
+            Some(eos) => texts.iter().map(|t| format!("{t}{eos}")).collect(),
+            None => texts.to_vec(),
+        };
+        let encodings = self
+            .tokenizer
+            .encode_batch(inputs, true)
+            .map_err(|e| e.to_string())?;
+        let rows = encodings.len();
+        let len = encodings.first().map_or(0, |e| e.get_ids().len());
+        let mut ids = Vec::with_capacity(rows * len);
+        let mut mask = Vec::with_capacity(rows * len);
+        let mut positions = Vec::with_capacity(rows * len);
+        for encoding in &encodings {
+            ids.extend(encoding.get_ids().iter().map(|&x| i64::from(x)));
+            mask.extend(encoding.get_attention_mask().iter().map(|&x| i64::from(x)));
+            positions.extend((0..len as i64).map(|p| p.min(len as i64 - 1)));
+        }
+        let shape = (rows, len);
+        let ids = Array2::from_shape_vec(shape, ids).map_err(|e| e.to_string())?;
+        let mask = Array2::from_shape_vec(shape, mask).map_err(|e| e.to_string())?;
+        let positions = Array2::from_shape_vec(shape, positions).map_err(|e| e.to_string())?;
+
+        let mut session_inputs = ort::inputs![
+            "input_ids" => Value::from_array(ids).map_err(|e| e.to_string())?,
+            "attention_mask" => Value::from_array(mask.clone()).map_err(|e| e.to_string())?,
+        ];
+        if self.wants_position_ids {
+            session_inputs.push((
+                "position_ids".into(),
+                Value::from_array(positions)
+                    .map_err(|e| e.to_string())?
+                    .into(),
+            ));
+        }
+        for name in &self.past_inputs {
+            let empty = ndarray::Array4::<f32>::zeros((rows, self.kv_heads, 0, self.head_dim));
+            session_inputs.push((
+                name.clone().into(),
+                Value::from_array(empty).map_err(|e| e.to_string())?.into(),
+            ));
+        }
+        let outputs = self
+            .session
+            .run(session_inputs)
+            .map_err(|e| e.to_string())?;
+
+        if let Some(name) = &self.pooled_output {
+            let pooled = outputs[name.as_str()]
+                .try_extract_array::<f32>()
+                .map_err(|e| e.to_string())?
+                .into_dimensionality::<ndarray::Ix2>()
+                .map_err(|e| format!("{name} is not 2-D: {e}"))?;
+            return Ok(pooled
+                .outer_iter()
+                .map(|row| normalise(row.to_vec()))
+                .collect());
+        }
+        let hidden = outputs["last_hidden_state"]
+            .try_extract_array::<f32>()
+            .map_err(|e| e.to_string())?
+            .into_dimensionality::<ndarray::Ix3>()
+            .map_err(|e| format!("last_hidden_state is not 3-D: {e}"))?;
+        let mut vectors = Vec::with_capacity(rows);
+        for (row, attended) in mask.outer_iter().enumerate() {
+            let last = attended
+                .iter()
+                .rposition(|&bit| bit == 1)
+                .ok_or_else(|| format!("row {row} attends to no token"))?;
+            vectors.push(normalise(
+                hidden.index_axis(Axis(0), row).row(last).to_vec(),
+            ));
+        }
+        Ok(vectors)
+    }
+}
+
+/// Whether a `tokenizer.json` post-processor already appends `token` to
+/// every sequence, read off the file rather than assumed: appending it
+/// twice would pool the wrong position as surely as leaving it off.
+fn tokenizer_appends(tokenizer_json: &[u8], token: &str) -> bool {
+    fn mentions(value: &serde_json::Value, token: &str) -> bool {
+        match value {
+            serde_json::Value::String(s) => s == token,
+            serde_json::Value::Array(items) => items.iter().any(|item| mentions(item, token)),
+            serde_json::Value::Object(map) => map.values().any(|item| mentions(item, token)),
+            _ => false,
+        }
+    }
+    serde_json::from_slice::<serde_json::Value>(tokenizer_json)
+        .ok()
+        .and_then(|doc| doc.get("post_processor").cloned())
+        .is_some_and(|post| mentions(&post, token))
+}
+
+fn normalise(mut vector: Vec<f32>) -> Vec<f32> {
+    let norm = vector.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in &mut vector {
+            *x /= norm;
+        }
+    }
+    vector
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_id_round_trips() {
+        for candidate in Candidate::ALL {
+            assert_eq!(Candidate::parse(candidate.id()), Some(candidate));
+        }
+        assert_eq!(Candidate::parse("nope"), None);
+    }
+
+    #[test]
+    fn the_built_in_dimensions_match_fastembed() {
+        for (candidate, builtin) in [
+            (Candidate::BgeSmallQ, EmbeddingModel::BGESmallENV15Q),
+            (Candidate::Gemma300MQ, EmbeddingModel::EmbeddingGemma300MQ),
+        ] {
+            let info = TextEmbedding::get_model_info(&builtin).expect("model info");
+            assert_eq!(info.dim, candidate.dim(), "{}", candidate.id());
+        }
+    }
+
+    #[test]
+    fn a_post_processor_that_appends_eos_is_detected() {
+        let with = br#"{"post_processor":{"type":"TemplateProcessing","single":[{"Sequence":{"id":"A"}},{"SpecialToken":{"id":"<|endoftext|>"}}]}}"#;
+        let without = br#"{"post_processor":null}"#;
+        assert!(tokenizer_appends(with, QWEN3_EOS));
+        assert!(!tokenizer_appends(without, QWEN3_EOS));
+    }
+}

--- a/crates/agmem-embed/src/lib.rs
+++ b/crates/agmem-embed/src/lib.rs
@@ -13,6 +13,8 @@
 
 use std::sync::Arc;
 
+#[cfg(feature = "candidates")]
+pub mod candidates;
 pub mod fastembed;
 pub mod noop;
 #[cfg(feature = "rerank")]

--- a/crates/agmem-embed/tests/candidates.rs
+++ b/crates/agmem-embed/tests/candidates.rs
@@ -1,0 +1,276 @@
+//! The #133 candidate probe's two measurements (docs/eval/embed-models.md).
+//!
+//! Both are ignored and keyed by `AGMEM_CANDIDATE`; run them with
+//! `--features candidates --release`, one candidate at a time:
+//!
+//! - `embed_dump` re-embeds every row of a store dump (`AGMEM_DUMP`, the
+//!   JSON array `scripts/pair-rank-probe.py` takes) and writes
+//!   `target/eval/<id>-dump-vectors.json` as `{id: vector}`, which the
+//!   probe's `--vectors` flag swaps in — so its cosine-control AUC becomes
+//!   the candidate's.
+//! - `latency` times one 3-sentence claim, a batch of 16 claims and the first
+//!   60 chunks of the largest fixture document, warm, and appends p50/p95
+//!   rows to `docs/eval/embed-models/latency.json`. The rows carry the
+//!   accelerator so #139's CoreML run lands in the same file.
+
+#![cfg(feature = "candidates")]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use agmem_embed::Embedder;
+use agmem_embed::candidates::{CANDIDATE_ENV, Candidate, CandidateBackend, cache_dir};
+
+/// The store dump the separation sets are read from.
+const DUMP_ENV: &str = "AGMEM_DUMP";
+
+/// Samples per shape after warm-up; `AGMEM_LATENCY_RUNS` overrides it for a
+/// model too slow to sample twenty times.
+const RUNS: usize = 20;
+
+fn runs() -> usize {
+    std::env::var("AGMEM_LATENCY_RUNS")
+        .ok()
+        .and_then(|raw| raw.parse().ok())
+        .unwrap_or(RUNS)
+}
+
+/// The 3-sentence claim of bar item 3 — three sentences, an id, a date, a
+/// number: the shape of what `remember` stores.
+const CLAIM: &str = "The atlas release build targets ubuntu and macos as of PR #212. The \
+                     macos runner was added on 2026-03-14 after the linux-only phase. Builds \
+                     take about 6 minutes on either.";
+
+fn workspace() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn candidate() -> Candidate {
+    Candidate::from_env()
+        .unwrap_or_else(|| panic!("{CANDIDATE_ENV} names the candidate to measure"))
+}
+
+fn load(candidate: Candidate) -> (CandidateBackend, f64) {
+    let started = Instant::now();
+    let backend = CandidateBackend::load(candidate, &cache_dir()).expect("load candidate");
+    let load_ms = started.elapsed().as_secs_f64() * 1e3;
+    eprintln!("{} loaded in {load_ms:.0} ms", candidate.id());
+    (backend, load_ms)
+}
+
+/// Shortest round-tripping decimal per component.
+fn json_vector(vector: &[f32]) -> String {
+    let parts: Vec<String> = vector.iter().map(|x| format!("{x}")).collect();
+    format!("[{}]", parts.join(","))
+}
+
+#[test]
+#[ignore = "re-embeds a store dump with the candidate AGMEM_CANDIDATE names"]
+fn embed_dump() {
+    let candidate = candidate();
+    let dump = std::env::var(DUMP_ENV)
+        .unwrap_or_else(|_| panic!("{DUMP_ENV} points at the store dump JSON"));
+    let rows: Vec<serde_json::Value> =
+        serde_json::from_str(&std::fs::read_to_string(&dump).expect("read dump"))
+            .expect("the dump is a JSON array");
+    let mut ids = Vec::with_capacity(rows.len());
+    let mut texts = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let (Some(id), Some(content)) = (row["id"].as_str(), row["content"].as_str()) else {
+            continue;
+        };
+        ids.push(id.to_owned());
+        texts.push(content.to_owned());
+    }
+    assert!(
+        !texts.is_empty(),
+        "the dump holds no rows with id and content"
+    );
+    // The band pairs (docs/eval/bands/pairs.json) are not store rows; they
+    // ride along under `band:<name>:a|b` so embed-thresholds.py can place
+    // the duplicate gate against them.
+    let bands: Vec<serde_json::Value> = serde_json::from_str(
+        &std::fs::read_to_string(workspace().join("docs/eval/bands/pairs.json"))
+            .expect("read bands"),
+    )
+    .expect("bands parse");
+    for pair in &bands {
+        let name = pair["pair"].as_str().expect("pair name");
+        for side in ["a", "b"] {
+            ids.push(format!("band:{name}:{side}"));
+            texts.push(pair[side].as_str().expect("pair text").to_owned());
+        }
+    }
+
+    let (backend, _) = load(candidate);
+    let started = Instant::now();
+    let mut vectors = Vec::with_capacity(texts.len());
+    // Sliced as the server slices, so a dynamic-quant model sees the batch
+    // size it would see in production rather than the whole dump at once.
+    for slice in texts.chunks(128) {
+        vectors.extend(backend.embed_passages(slice).expect("embed passages"));
+    }
+    let took = started.elapsed().as_secs_f64();
+    let dim = backend.dim();
+    assert!(vectors.iter().all(|vector| vector.len() == dim));
+
+    let by_id: BTreeMap<&str, &Vec<f32>> =
+        ids.iter().map(String::as_str).zip(vectors.iter()).collect();
+    let entries: Vec<String> = by_id
+        .iter()
+        .map(|(id, vector)| {
+            format!(
+                "  {}: {}",
+                serde_json::to_string(id).unwrap(),
+                json_vector(vector)
+            )
+        })
+        .collect();
+    let out_dir = workspace().join("target/eval");
+    std::fs::create_dir_all(&out_dir).expect("create target/eval");
+    let out = out_dir.join(format!("{}-dump-vectors.json", candidate.id()));
+    std::fs::write(&out, format!("{{\n{}\n}}\n", entries.join(",\n"))).expect("write vectors");
+    eprintln!(
+        "{}: {} rows, {dim}d, {took:.1}s → {}",
+        candidate.id(),
+        by_id.len(),
+        out.display()
+    );
+}
+
+/// Median and 95th percentile of `samples`, in milliseconds.
+fn percentiles(mut samples: Vec<f64>) -> (f64, f64) {
+    samples.sort_by(f64::total_cmp);
+    let at = |q: f64| samples[((samples.len() - 1) as f64 * q).round() as usize];
+    (at(0.5), at(0.95))
+}
+
+fn time<F: FnMut()>(mut run: F) -> (f64, f64) {
+    for _ in 0..3 {
+        run();
+    }
+    let samples: Vec<f64> = (0..runs())
+        .map(|_| {
+            let started = Instant::now();
+            run();
+            started.elapsed().as_secs_f64() * 1e3
+        })
+        .collect();
+    percentiles(samples)
+}
+
+fn chip() -> String {
+    std::process::Command::new("sysctl")
+        .args(["-n", "machdep.cpu.brand_string"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_owned())
+        .unwrap_or_else(|| std::env::consts::ARCH.to_owned())
+}
+
+#[test]
+#[ignore = "times the candidate AGMEM_CANDIDATE names on this machine"]
+fn latency() {
+    let candidate = candidate();
+    let accelerator = std::env::var("AGMEM_ACCELERATOR").unwrap_or_else(|_| "cpu".to_owned());
+    let (backend, load_ms) = load(candidate);
+
+    let claims: Vec<String> = (0..16)
+        .map(|i| format!("{CLAIM} Variant {i} of the same claim, so no two batch rows are equal."))
+        .collect();
+    // Sixty chunks of fixture prose, in manifest order: no single fixture
+    // document has that many, so the corpus is walked until it does.
+    let documents_dir = workspace().join("crates/agmem-server/tests/fixtures/eval/documents");
+    let manifest: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(documents_dir.join("manifest.json")).expect("read manifest"),
+    )
+    .expect("manifest parses");
+    let mut chunks: Vec<String> = Vec::new();
+    for entry in manifest.as_array().into_iter().flatten() {
+        let file = entry["file"].as_str().expect("manifest file");
+        let text = std::fs::read_to_string(documents_dir.join(file)).expect("read document");
+        chunks.extend(agmem_core::chunk::chunk(&text));
+        if chunks.len() >= 60 {
+            break;
+        }
+    }
+    chunks.truncate(60);
+    assert_eq!(
+        chunks.len(),
+        60,
+        "the fixture corpus has fewer than 60 chunks"
+    );
+
+    let one = vec![CLAIM.to_owned()];
+    let shapes: Vec<(&str, Vec<String>)> = vec![
+        ("claim", one),
+        ("claims-16", claims),
+        ("document-60-chunks", chunks),
+    ];
+    let mut rows = Vec::new();
+    for (shape, texts) in &shapes {
+        let (p50, p95) = time(|| {
+            backend.embed_passages(texts).expect("embed");
+        });
+        eprintln!(
+            "{} {accelerator} {shape}: p50 {p50:.1} ms, p95 {p95:.1} ms",
+            candidate.id()
+        );
+        rows.push(serde_json::json!({
+            "model": candidate.id(),
+            "accelerator": accelerator,
+            "shape": shape,
+            "p50_ms": (p50 * 10.0).round() / 10.0,
+            "p95_ms": (p95 * 10.0).round() / 10.0,
+            "load_ms": load_ms.round(),
+            "chip": chip(),
+            "profile": if cfg!(debug_assertions) { "debug" } else { "release" },
+            "measured_at": jiff_now(),
+        }));
+    }
+
+    let path = workspace().join("docs/eval/embed-models/latency.json");
+    std::fs::create_dir_all(path.parent().unwrap()).expect("create docs/eval/embed-models");
+    let mut all: Vec<serde_json::Value> = std::fs::read_to_string(&path)
+        .ok()
+        .map(|raw| serde_json::from_str(&raw).expect("latency.json parses"))
+        .unwrap_or_default();
+    // One row per (model, accelerator, shape): a re-run replaces, never stacks.
+    all.retain(|row| {
+        !rows.iter().any(|new| {
+            ["model", "accelerator", "shape"]
+                .iter()
+                .all(|key| row[key] == new[key])
+        })
+    });
+    all.extend(rows);
+    std::fs::write(&path, serde_json::to_string_pretty(&all).unwrap() + "\n").expect("write");
+    eprintln!("→ {}", path.display());
+}
+
+/// RFC3339 minute precision without pulling a date crate into the probe.
+fn jiff_now() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    // Days since epoch → civil date (Howard Hinnant's algorithm).
+    let days = (secs / 86_400) as i64;
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = yoe + era * 400 + i64::from(month <= 2);
+    let rem = secs % 86_400;
+    format!(
+        "{year:04}-{month:02}-{day:02}T{:02}:{:02}Z",
+        rem / 3600,
+        (rem % 3600) / 60
+    )
+}

--- a/crates/agmem-embed/tests/fastembed.rs
+++ b/crates/agmem-embed/tests/fastembed.rs
@@ -156,6 +156,8 @@ fn regenerate_eval_vectors() {
     /// One recording file: passages and queries keyed by text, sorted.
     fn write_recording(
         path: &std::path::Path,
+        model: &str,
+        dim: usize,
         passages: &BTreeMap<String, Vec<f32>>,
         queries: &BTreeMap<String, Vec<f32>>,
     ) {
@@ -169,17 +171,19 @@ fn regenerate_eval_vectors() {
         let passage_entries: Vec<String> = passages.iter().map(entry).collect();
         let query_entries: Vec<String> = queries.iter().map(entry).collect();
         let document = format!(
-            "{{\n  \"model\": \"BGE-small-en-v1.5-q\",\n  \"dim\": {},\n  \
+            "{{\n  \"model\": {},\n  \"dim\": {},\n  \
              \"passages\": {{\n{}\n  }},\n  \"queries\": {{\n{}\n  }}\n}}\n",
-            DIM,
+            serde_json::to_string(model).expect("encode model"),
+            dim,
             passage_entries.join(",\n"),
             query_entries.join(",\n")
         );
+        std::fs::create_dir_all(path.parent().expect("fixture dir")).expect("create fixture dir");
         std::fs::write(path, document).expect("write fixture");
     }
 
     /// Embeds every key of `passages` in place, in one batch.
-    fn fill_passages(embedder: &FastembedBackend, passages: &mut BTreeMap<String, Vec<f32>>) {
+    fn fill_passages(embedder: &dyn Embedder, passages: &mut BTreeMap<String, Vec<f32>>) {
         let texts: Vec<String> = passages.keys().cloned().collect();
         let vectors = embedder.embed_passages(&texts).expect("embed passages");
         for (text, vector) in texts.iter().zip(vectors) {
@@ -255,19 +259,59 @@ fn regenerate_eval_vectors() {
         "the manifest lists no documents"
     );
 
-    let cache = std::env::temp_dir().join("agmem-model-cache");
-    let embedder = FastembedBackend::new(Some(cache)).expect("load model");
+    // The shipped model writes the committed fixtures; under the `candidates`
+    // feature, `AGMEM_CANDIDATE` records the same texts with a #133 candidate
+    // into a gitignored sibling directory the eval reads through
+    // `AGMEM_EVAL_VECTORS_DIR` (docs/eval/embed-models.md).
+    let (embedder, out_dir, model): (Box<dyn Embedder>, std::path::PathBuf, String) =
+        match candidate_recorder() {
+            Some((embedder, id)) => (embedder, eval_dir.join("candidates").join(&id), id),
+            None => {
+                let cache = std::env::temp_dir().join("agmem-model-cache");
+                let embedder = FastembedBackend::new(Some(cache)).expect("load model");
+                (
+                    Box::new(embedder),
+                    eval_dir.clone(),
+                    "BGE-small-en-v1.5-q".to_owned(),
+                )
+            }
+        };
+    let dim = embedder.dim();
 
-    fill_passages(&embedder, &mut passages);
+    fill_passages(embedder.as_ref(), &mut passages);
     for (text, slot) in &mut queries {
         *slot = embedder.embed_query(text).expect("embed query");
     }
-    write_recording(&eval_dir.join("vectors.json"), &passages, &queries);
-
-    fill_passages(&embedder, &mut document_chunks);
     write_recording(
-        &eval_dir.join("documents-vectors.json"),
+        &out_dir.join("vectors.json"),
+        &model,
+        dim,
+        &passages,
+        &queries,
+    );
+
+    fill_passages(embedder.as_ref(), &mut document_chunks);
+    write_recording(
+        &out_dir.join("documents-vectors.json"),
+        &model,
+        dim,
         &document_chunks,
         &BTreeMap::new(),
     );
+    eprintln!("recorded {model} ({dim}d) into {}", out_dir.display());
+}
+
+/// The #133 candidate `AGMEM_CANDIDATE` names, loaded, with its id; `None`
+/// when unset or when the feature is off.
+#[cfg(feature = "candidates")]
+fn candidate_recorder() -> Option<(Box<dyn Embedder>, String)> {
+    use agmem_embed::candidates::{Candidate, CandidateBackend, cache_dir};
+    let candidate = Candidate::from_env()?;
+    let backend = CandidateBackend::load(candidate, &cache_dir()).expect("load candidate");
+    Some((Box::new(backend), candidate.id().to_owned()))
+}
+
+#[cfg(not(feature = "candidates"))]
+fn candidate_recorder() -> Option<(Box<dyn Embedder>, String)> {
+    None
 }

--- a/crates/agmem-server/Cargo.toml
+++ b/crates/agmem-server/Cargo.toml
@@ -12,6 +12,12 @@ homepage.workspace = true
 name = "agmem"
 path = "src/main.rs"
 
+[features]
+# Runtime knobs for the eval harness only (issue #133): the abstention floor
+# from the environment, so a candidate embedder is scored on its own cosine
+# scale. Never on in a release build.
+eval-knobs = []
+
 [dependencies]
 # `schema` puts core's enums, and their variant docs, into the tool schemas
 # agents read.

--- a/crates/agmem-server/src/tools/abstain.rs
+++ b/crates/agmem-server/src/tools/abstain.rs
@@ -45,6 +45,25 @@
 /// out.
 pub(super) const MIN_SIMILARITY: f64 = 0.62;
 
+/// The floor in force: [`MIN_SIMILARITY`], or — only when built with the
+/// `eval-knobs` feature — whatever `AGMEM_ABSTENTION_FLOOR` says. The #133
+/// candidate probe scores embedders on other cosine scales and must not be
+/// cut on BGE's; a release build carries no knob (docs/eval/embed-models.md).
+fn floor() -> f64 {
+    #[cfg(feature = "eval-knobs")]
+    {
+        static FLOOR: std::sync::OnceLock<f64> = std::sync::OnceLock::new();
+        *FLOOR.get_or_init(|| {
+            std::env::var("AGMEM_ABSTENTION_FLOOR")
+                .ok()
+                .map(|raw| raw.parse().expect("AGMEM_ABSTENTION_FLOOR is a float"))
+                .unwrap_or(MIN_SIMILARITY)
+        })
+    }
+    #[cfg(not(feature = "eval-knobs"))]
+    MIN_SIMILARITY
+}
+
 /// The smallest drop in `rrf_normalized` the knee will cut at.
 ///
 /// A floor, not the criterion: min–max normalisation stretches every pool
@@ -105,7 +124,7 @@ pub(super) fn apply<T>(
     // thrown away with the page), and only when the top row itself was
     // measured (an unmeasured top is a text-arm match standing on its own
     // evidence).
-    if signals(top).0.is_some() && best_similarity.is_some_and(|best| best < MIN_SIMILARITY) {
+    if signals(top).0.is_some() && best_similarity.is_some_and(|best| best < floor()) {
         page.clear();
         return Some(Verdict {
             kept: 0,
@@ -147,7 +166,7 @@ pub(super) fn apply<T>(
     // same rule the floor applies: absence of a measurement is not evidence.
     let mut index = 0;
     page.retain(|row| {
-        let expendable = signals(row).0.is_some_and(|sim| sim < MIN_SIMILARITY);
+        let expendable = signals(row).0.is_some_and(|sim| sim < floor());
         let keep = index <= knee || protected(row) || !expendable;
         index += 1;
         keep

--- a/crates/agmem-server/tests/eval.rs
+++ b/crates/agmem-server/tests/eval.rs
@@ -25,7 +25,7 @@ mod scenario;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use agmem_embed::NoopEmbedder;
+use agmem_embed::{Embedder as _, NoopEmbedder};
 use harness::recorded::RecordedEmbedder;
 
 fn eval_doc_path(name: &str) -> PathBuf {
@@ -291,4 +291,39 @@ async fn record_documents() {
     let report = metrics::documents_report(&scenarios, Arc::new(RecordedEmbedder), &corpus).await;
     let block = serde_json::to_string_pretty(&report).expect("serialize");
     record_block(&eval_doc_path("documents.md"), DOCUMENTS_MARKER, &block);
+}
+
+/// The #133 candidate probe's retrieval column (docs/eval/embed-models.md):
+/// the full scorecard, plus the mean `ndcg5` over scenarios, for whatever
+/// recordings `AGMEM_EVAL_VECTORS_DIR` points at. Run twice per candidate —
+/// with `AGMEM_ABSTENTION_FLOOR=0` for pure ranking, and at the candidate's
+/// re-derived floor — under `--features eval-knobs`; without the directory
+/// set it scores the committed BGE recordings, which is the control.
+#[tokio::test]
+#[ignore = "diagnostic: prints the scorecard for the recordings AGMEM_EVAL_VECTORS_DIR names"]
+async fn candidate_scorecard() {
+    let scenarios = scenario::all();
+    let scored = metrics::scorecard(&scenarios, Arc::new(RecordedEmbedder)).await;
+    let ndcg: Vec<f64> = scored
+        .scenarios
+        .values()
+        .map(|score| score.retrieval.ndcg5)
+        .collect();
+    let mean = ndcg.iter().sum::<f64>() / ndcg.len() as f64;
+    let found: u32 = scored.scenarios.values().map(|s| s.retrieval.found).sum();
+    let expected: u32 = scored
+        .scenarios
+        .values()
+        .map(|s| s.retrieval.expected)
+        .sum();
+    eprintln!(
+        "{}",
+        serde_json::to_string_pretty(&scored).expect("serialize")
+    );
+    eprintln!(
+        "SUMMARY model={} dim={} floor={} ndcg5_mean={mean:.4} found={found}/{expected}",
+        RecordedEmbedder.model_id(),
+        RecordedEmbedder.dim(),
+        std::env::var("AGMEM_ABSTENTION_FLOOR").unwrap_or_else(|_| "default".to_owned()),
+    );
 }

--- a/crates/agmem-server/tests/harness/recorded.rs
+++ b/crates/agmem-server/tests/harness/recorded.rs
@@ -41,6 +41,13 @@ const REGENERATE_EVAL: &str =
 /// Set this to grow the protocol recording from the real model.
 const RECORD_ENV: &str = "AGMEM_RECORD_VECTORS";
 
+/// A directory holding `vectors.json` and `documents-vectors.json` recorded
+/// with another model (the #133 candidates, `docs/eval/embed-models.md`).
+/// When set, the committed recordings are not read at all and the protocol
+/// recording is neither consulted nor grown: its texts belong to BGE, and a
+/// candidate has no vector for any of them.
+const VECTORS_DIR_ENV: &str = "AGMEM_EVAL_VECTORS_DIR";
+
 /// The protocol recording, relative to the crate root; read and, under
 /// [`RECORD_ENV`], rewritten at runtime.
 const PROTOCOL_FIXTURE: &str = "tests/fixtures/protocol/vectors.json";
@@ -88,12 +95,26 @@ impl Kind {
 fn eval() -> &'static Recording {
     static EVAL: OnceLock<Recording> = OnceLock::new();
     EVAL.get_or_init(|| {
-        let mut eval: Recording =
-            serde_json::from_str(include_str!("../fixtures/eval/vectors.json"))
-                .expect("fixtures/eval/vectors.json parses");
-        let documents: Recording =
-            serde_json::from_str(include_str!("../fixtures/eval/documents-vectors.json"))
-                .expect("fixtures/eval/documents-vectors.json parses");
+        let (mut eval, documents): (Recording, Recording) = match std::env::var_os(VECTORS_DIR_ENV)
+        {
+            Some(dir) => {
+                let dir = PathBuf::from(dir);
+                let read = |name: &str| -> Recording {
+                    let path = dir.join(name);
+                    let raw = std::fs::read_to_string(&path)
+                        .unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+                    serde_json::from_str(&raw)
+                        .unwrap_or_else(|err| panic!("{} parses: {err}", path.display()))
+                };
+                (read("vectors.json"), read("documents-vectors.json"))
+            }
+            None => (
+                serde_json::from_str(include_str!("../fixtures/eval/vectors.json"))
+                    .expect("fixtures/eval/vectors.json parses"),
+                serde_json::from_str(include_str!("../fixtures/eval/documents-vectors.json"))
+                    .expect("fixtures/eval/documents-vectors.json parses"),
+            ),
+        };
         assert_eq!(
             (&documents.model, documents.dim),
             (&eval.model, eval.dim),
@@ -115,6 +136,14 @@ fn protocol() -> &'static Mutex<Recording> {
     static PROTOCOL: OnceLock<Mutex<Recording>> = OnceLock::new();
     PROTOCOL.get_or_init(|| {
         let recording = match std::fs::read_to_string(protocol_path()) {
+            // Another model's recordings: the protocol file is BGE's, so it
+            // stays unread, and `replay` panics on any text the override lacks.
+            _ if std::env::var_os(VECTORS_DIR_ENV).is_some() => Recording {
+                model: eval().model.clone(),
+                dim: eval().dim,
+                passages: BTreeMap::new(),
+                queries: BTreeMap::new(),
+            },
             Ok(raw) => serde_json::from_str(&raw).expect("fixtures/protocol/vectors.json parses"),
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Recording {
                 model: eval().model.clone(),

--- a/docs/eval/embed-models.md
+++ b/docs/eval/embed-models.md
@@ -1,0 +1,213 @@
+# Embedding candidates against the store (issue #133)
+
+Written before any number was computed. The bar below is the decision; the
+Results section is filled in afterwards and does not move the bar.
+
+## What is being decided
+
+Whether a larger or newer embedding model improves agmem's retrieval and its
+override (supersede) behaviour enough to justify the change. Today:
+`bge-small-en-v1.5-q` via fastembed 6.0.2 / ort 2.0.0-rc.13, 384 dims, CPU
+only. Every threshold in the store — the 0.95 duplicate gate, the 0.75
+supersedes floor, the 0.62 abstention floor, the 0.6/0.25/0.15 rescore
+weights — was tuned on that model's vector space, so a candidate is judged
+on the store's own labelled sets, not on a leaderboard.
+
+## Candidates
+
+| Id | Model | Params | Dims (MRL) | Pooling | Prefixes | Runtime path |
+|---|---|---|---|---|---|---|
+| `bge-small-en-v1.5-q` | control | 33M | 384 | CLS | `passage: ` / `query: ` | fastembed built-in |
+| `embeddinggemma-300m-q` | EmbeddingGemma-300M q8 | 0.3B | 768 → 512/256/128 | in-graph | `title: none \| text: ` / `task: search result \| query: ` | fastembed built-in |
+| `arctic-embed-m-v2.0-int8` | snowflake-arctic-embed-m-v2.0 | 0.3B | 768 → 256 | CLS | none / `query: ` | user-defined ONNX |
+| `qwen3-embedding-0.6b-int8` | Qwen3-Embedding-0.6B int8 | 0.6B | 1024 → 512/256 | last token | none / `Instruct: … Query: ` | user-defined ONNX, pooled by the harness |
+
+Every candidate runs through the same runtime the daemon uses — ONNX
+Runtime on CPU through fastembed — so the vectors measured are the vectors
+the store would get. A Python sentence-transformers harness was rejected
+for that reason: it measures fp32 torch, a different vector space.
+
+## The bar
+
+A candidate replaces the default only if **all** of these hold, on the live
+dogfood store's dump and the eval fixtures:
+
+1. **Separation.** Corrected pairs vs contradictions-list noise, the sets of
+   `pair-rank.md` (78 corrected, 20 noise at the last count): cosine AUC ≥
+   the current cosine AUC + 0.02 on both sets (current: 0.943 on the #54-world
+   set, 0.707 on the current set).
+2. **Retrieval.** `recall` nDCG@5 over the eval scenarios ≥ current + 0.03,
+   measured with the abstention floor at 0 (pure ranking) so a candidate on
+   another cosine scale is not cut by BGE's floor; reported again at the
+   candidate's own re-derived floor.
+3. **Latency.** p50 embed time for one 3-sentence claim ≤ 60 ms on CPU on the
+   M4 Pro (≤ 150 ms on the CI runner class).
+4. **Thresholds.** The duplicate gate, supersede floor and abstention floor
+   re-derived as a table with the margin of each to the nearest wrong-class
+   sample, the shape of #54's analysis; a band that lands inside the noise
+   distribution fails the candidate.
+
+A candidate that fails is recorded below with its numbers and the issue
+closes as measured-and-dropped, like #53 and #84. A candidate that passes
+opens #138 (the migration) — nothing here changes the shipped model.
+
+Caveat on the retrieval column: the eval probe set is anti-lexical by
+design (probes share as few words as possible with their targets), so any
+nDCG gain here overstates the gain on real queries, where BM25 carries part
+of the answer.
+
+## Method
+
+- `crates/agmem-embed/src/candidates.rs` (`--features candidates`) loads each
+  candidate behind the `Embedder` trait with its prefixes and pooling.
+- `scripts/embed-candidates-fetch.nu` fetches the two user-defined ONNX
+  exports and their tokenizer files into the model cache.
+- `cargo test -p agmem-embed --features candidates --release --test candidates
+  -- --ignored` with `AGMEM_CANDIDATE=<id>`: `embed_dump` re-embeds a store
+  dump (`AGMEM_DUMP`) and writes `target/eval/<id>-dump-vectors.json`;
+  `latency` times one claim, 16 claims and a 60-chunk document, appending
+  rows to `docs/eval/embed-models/latency.json`.
+- `AGMEM_CANDIDATE=<id> cargo test -p agmem-embed --features candidates
+  --release --test fastembed -- --ignored regenerate_eval_vectors` records the
+  eval fixtures with the candidate under `tests/fixtures/eval/candidates/<id>/`
+  (gitignored).
+- `AGMEM_EVAL_VECTORS_DIR=<that dir> cargo test -p agmem-server --features
+  eval-knobs --test eval -- --ignored candidate_scorecard` prints the
+  scorecard; `AGMEM_ABSTENTION_FLOOR` sets the floor for the run.
+- `uv run scripts/pair-rank-probe.py DUMP --vectors target/eval/<id>-dump-vectors.json`
+  reports the candidate's cosine AUC on both labelled sets.
+- `uv run scripts/embed-thresholds.py DUMP target/eval/<id>-dump-vectors.json`
+  prints the threshold table, with MRL columns by truncation.
+
+Latency rows carry the chip (`sysctl -n machdep.cpu.brand_string`) and an
+`accelerator` column so #139's CoreML run appends to the same file.
+
+## Results
+
+Run on 2026-09-05 on an **Apple M1 Pro** (the bar names an M4 Pro; none was
+available, so bar 3 is read against the control's own time on this chip as
+well as the absolute number), CPU only, `--release`, ORT 2.0.0-rc.13
+via fastembed 6.0.2 (Qwen3 through `ort` directly: its export needs
+`position_ids` and empty `past_key_values.*` inputs fastembed never feeds).
+Dump: 302 rows, 138 corrected pairs, 20 noise pairs, 8 band pairs; the eval
+scenarios' 18 labelled-relevant probes and 10 unanswerables. Per-candidate
+logs in `docs/eval/embed-models/<id>/` (gitignored); latency rows in
+`docs/eval/embed-models/latency.json`.
+
+### The four bar items
+
+| Id | 1. AUC #54 set / current set (bar ≥ 0.961 / 0.671) | 2. nDCG@5 at floor 0 (bar ≥ 0.654) | 3. p50 one claim (bar ≤ 60 ms) | 4. thresholds | Verdict |
+|---|---|---|---|---|---|
+| `bge-small-en-v1.5-q` (control) | 0.941 / 0.651 | 0.624 | 15.7 ms | shipped | — |
+| `embeddinggemma-300m-q` | 0.963 / **0.867** | **0.655** | 72.6 ms | separable below | FAILS 3 (on this chip) |
+| `arctic-embed-m-v2.0-int8` | 0.965 / 0.833 | **0.655** | 17.0 ms | abstention floor weak | FAILS 4 (abstention) |
+| `qwen3-embedding-0.6b-int8` | 0.963 / 0.767 | 0.615 | ~200 ms (under contention; no clean row) | — | FAILS 2, 3 |
+
+Bar 1 reads: the control's #54-set AUC 0.941 today (0.943 in the issue),
+so the bar is 0.961; every candidate clears it. The current-set bar is
+0.671 (the issue's 0.707 was on 78 pairs; the store now holds 138), and
+every candidate clears that too, EmbeddingGemma by 0.216. Bar 2: the two
+768-d candidates tie at 0.6548 with byte-identical scorecards; a verifier
+replaced one recording with random unit vectors and the score fell to
+0.4166, so the vector arm is live and the tie is genuine agreement on 18
+probes — and +0.031 clears the +0.03 bar by the width of a rounding. Qwen3
+scores under the control.
+
+### Thresholds (bar 4)
+
+Cosine per labelled class, full width. `corrected` must clear the
+supersede floor; `band` (seven contradictions the write gate must let
+through, plus one control) must sit under the duplicate gate; `random` is
+the unrelated floor.
+
+| Class | bge min / p5 / med / p95 / max | Gemma | arctic | Qwen3 |
+|---|---|---|---|---|
+| corrected (138) | 0.827 / 0.907 / 0.962 / 0.994 / 0.999 | 0.505 / 0.678 / 0.833 / 0.974 / 0.999 | 0.477 / 0.626 / 0.810 / 0.957 / 0.981 | 0.496 / 0.599 / 0.752 / 0.859 / 0.929 |
+| noise (20) | 0.947 / 0.947 / 0.949 / 0.960 / 0.970 | 0.585 / 0.599 / 0.711 / 0.785 / 0.823 | 0.598 / 0.645 / 0.706 / 0.760 / 0.808 | 0.580 / 0.599 / 0.687 / 0.771 / 0.777 |
+| random (2000) | 0.697 / 0.776 / 0.858 / 0.915 / 0.970 | 0.089 / 0.214 / 0.387 / 0.558 / 0.743 | 0.083 / 0.219 / 0.372 / 0.542 / 0.706 | 0.289 / 0.380 / 0.485 / 0.611 / 0.733 |
+| same-entity (500) | 0.734 / 0.791 / 0.865 / 0.916 / 0.948 | 0.113 / 0.264 / 0.415 / 0.584 / 0.697 | 0.097 / 0.261 / 0.399 / 0.569 / 0.693 | 0.294 / 0.386 / 0.502 / 0.631 / 0.710 |
+| band (8) | 0.898 / 0.906 / 0.948 / 0.969 / 0.974 | 0.596 / 0.654 / 0.828 / 0.918 / 0.921 | 0.454 / 0.560 / 0.795 / 0.854 / 0.862 | 0.641 / 0.651 / 0.782 / 0.820 / 0.823 |
+
+What the shipped constants do on each space:
+
+- **Duplicate gate 0.95.** On BGE it blocks 3 of the 8 band contradictions
+  (max 0.974) and 67 % of the corrected pairs sit over it — the write gate
+  is refusing revisions. On Gemma the band tops out at 0.921 and 11 % of
+  corrected pairs exceed 0.95; on arctic 0.862 and 6 %; on Qwen3 0.823 and
+  0 %. Every candidate lets every contradiction through the gate.
+- **Supersede floor 0.75.** On BGE it admits 100 % of corrected pairs and
+  98 % of random ones — it sits inside the unrelated distribution (random
+  median 0.858), which is why the contradictions list is paraphrase noise.
+  On Gemma it admits 82 % of corrected and 0.00 % of random; the widest
+  separable placement is around 0.70 (random p99.9 0.69, corrected p5
+  0.68 — a 5 % tail of corrected pairs overlaps the extreme random tail
+  on every candidate). On arctic 72 % / 0.00 %; on Qwen3 51 % / 0.00 %.
+- **Abstention floor 0.62** (`calibrate_abstention` under the candidate's
+  recordings): on Gemma the 10 unanswerables' best similarity runs
+  0.044–0.187 and the 14 relevant probes' 0.148–0.749, so a floor of 0.14
+  abstains on 6 of 10 with no relevant page lost — the same 6-of-n shape as
+  BGE's 0.62 — and 0.19 catches 9 of 10 at the cost of one probe. On
+  arctic (unanswerables 0.050–0.224, probes 0.114–0.698) a floor of 0.10
+  catches 3 of 10 losing none; catching 8 costs two probes. On the scorecard, Gemma at
+  floor 0.14 abstains on 5 of 10 with 0 false abstentions and keeps nDCG@5
+  0.6548; arctic at 0.10 fires on 1 of 10 (the floor rule needs the top
+  row measured, which drops two of the three low cases) with 0 false and
+  0.6548; the control at its shipped 0.62 fires on 6 of 10 with 0 false at
+  0.6303.
+- **MRL truncation** (thresholds at 512/256/128 in the logs): Gemma's AUC
+  goes 0.867 → 0.856 → 0.848 → 0.853, arctic's 0.833 → 0.831 → 0.818 →
+  0.791, Qwen3's 0.767 → 0.735 → 0.716 → 0.663. Gemma at 256 d keeps
+  0.848, still 0.18 over the bar, at two-thirds of BGE's storage.
+
+### Latency (bar 3)
+
+| Id | one claim p50 / p95 | 16 claims | 60 document chunks |
+|---|---|---|---|
+| `bge-small-en-v1.5-q` | 15.7 / 16.4 ms | 128 ms | 3.9 s |
+| `embeddinggemma-300m-q` | 72.6 / 73.0 ms | 962 ms | 34.0 s |
+| `arctic-embed-m-v2.0-int8` | 17.0 / 17.8 ms | 202 ms | 6.1 s |
+| `qwen3-embedding-0.6b-int8` | ~193–206 ms (contended run; the clean rerun was cut short) | ~2.5 s | not measured |
+
+One claim, 16 claims and 60 chunks, p50 over 20 warm runs, one process at
+a time on an otherwise idle machine. Gemma's batches are the surprise:
+dynamic quantisation makes fastembed embed a batch in one ORT call, and
+that call scales worse than linearly — a 60-chunk document costs 34 s
+against BGE's 3.9 s and arctic's 6.1 s, which `remember` with a document
+attached would feel. Arctic sits within 10 % of BGE on the single claim
+and within 1.6× on batches.
+
+Qwen3-0.6B at int8 embedded the 318-row dump in 309 s, about one second
+per claim; it is out on bar 3 by a factor of three and on bar 2 as well.
+
+### Verdict
+
+**No candidate clears all four bar items, so nothing replaces the default
+from this run.**
+
+- **EmbeddingGemma-300M-q** is the quality winner on every axis the store
+  cares about — corrected-vs-noise AUC +0.216 over the control on the
+  current set, the write gate no longer blocking revisions, a supersede
+  floor that finally sits outside the unrelated distribution — and misses
+  the latency line: 72.6 ms for one claim on an M1 Pro against a 60 ms bar
+  written for an M4 Pro, 4.6× the control on the same chip, and 7–9× the
+  control on batches, where its dynamic quantisation forbids sub-batching.
+  The single-claim number may pass on the M4 Pro the bar names; the batch
+  cost will not. #139 should measure Gemma on the CoreML EP, since an
+  accelerator is exactly what a fixed-cost 300M encoder wants.
+- **arctic-embed-m-v2.0-int8** passes bars 1, 2 and 3 (17.0 ms for one
+  claim, 1.08× the control; 1.6× on batches) and fails bar 4 only on the
+  abstention floor: no placement fires on more than 1 of 10 unanswerables
+  without losing a relevant page, where BGE fires on 6 and Gemma on 5. Its supersede floor and duplicate gate
+  are as clean as Gemma's. If #139 does not rescue Gemma, arctic is the
+  fallback to re-measure with more abstain scenarios.
+- **Qwen3-Embedding-0.6B int8** is dropped: below the control on retrieval
+  and three times over the latency bar on CPU.
+
+The issue closes as measured-and-not-switched; #138 (the migration) stays
+open because a switch is now plausible, and #139 measures Gemma and arctic
+both on the CoreML EP. Whether arctic's abstention column should block a
+model that wins every other column is a call for the issue thread, not
+this doc: the column is one the harness already calls weak on the control
+(two unanswerables sit inside BGE's relevant band, `abstain.rs`). The re-derived constants for Gemma, if it ships: duplicate gate
+0.95 keeps (band max 0.921 — a margin of 0.03, thinner than BGE's but on
+the right side), supersede floor 0.70, abstention floor 0.14.

--- a/docs/eval/embed-models/latency.json
+++ b/docs/eval/embed-models/latency.json
@@ -1,0 +1,101 @@
+[
+  {
+    "accelerator": "cpu",
+    "chip": "Apple M1 Pro",
+    "load_ms": 597.0,
+    "measured_at": "2026-09-05T13:20Z",
+    "model": "embeddinggemma-300m-q",
+    "p50_ms": 72.6,
+    "p95_ms": 73.0,
+    "profile": "release",
+    "shape": "claim"
+  },
+  {
+    "accelerator": "cpu",
+    "chip": "Apple M1 Pro",
+    "load_ms": 597.0,
+    "measured_at": "2026-09-05T13:20Z",
+    "model": "embeddinggemma-300m-q",
+    "p50_ms": 962.0,
+    "p95_ms": 1055.0,
+    "profile": "release",
+    "shape": "claims-16"
+  },
+  {
+    "accelerator": "cpu",
+    "chip": "Apple M1 Pro",
+    "load_ms": 597.0,
+    "measured_at": "2026-09-05T13:32Z",
+    "model": "embeddinggemma-300m-q",
+    "p50_ms": 34018.3,
+    "p95_ms": 36016.5,
+    "profile": "release",
+    "shape": "document-60-chunks"
+  },
+  {
+    "accelerator": "cpu",
+    "chip": "Apple M1 Pro",
+    "load_ms": 644.0,
+    "measured_at": "2026-09-05T13:33Z",
+    "model": "arctic-embed-m-v2.0-int8",
+    "p50_ms": 17.0,
+    "p95_ms": 17.8,
+    "profile": "release",
+    "shape": "claim"
+  },
+  {
+    "accelerator": "cpu",
+    "chip": "Apple M1 Pro",
+    "load_ms": 644.0,
+    "measured_at": "2026-09-05T13:33Z",
+    "model": "arctic-embed-m-v2.0-int8",
+    "p50_ms": 201.9,
+    "p95_ms": 205.3,
+    "profile": "release",
+    "shape": "claims-16"
+  },
+  {
+    "accelerator": "cpu",
+    "chip": "Apple M1 Pro",
+    "load_ms": 644.0,
+    "measured_at": "2026-09-05T13:35Z",
+    "model": "arctic-embed-m-v2.0-int8",
+    "p50_ms": 6111.9,
+    "p95_ms": 6298.3,
+    "profile": "release",
+    "shape": "document-60-chunks"
+  },
+  {
+    "accelerator": "cpu",
+    "chip": "Apple M1 Pro",
+    "load_ms": 64.0,
+    "measured_at": "2026-09-05T13:35Z",
+    "model": "bge-small-en-v1.5-q",
+    "p50_ms": 15.7,
+    "p95_ms": 16.4,
+    "profile": "release",
+    "shape": "claim"
+  },
+  {
+    "accelerator": "cpu",
+    "chip": "Apple M1 Pro",
+    "load_ms": 64.0,
+    "measured_at": "2026-09-05T13:35Z",
+    "model": "bge-small-en-v1.5-q",
+    "p50_ms": 127.8,
+    "p95_ms": 128.4,
+    "profile": "release",
+    "shape": "claims-16"
+  },
+  {
+    "accelerator": "cpu",
+    "chip": "Apple M1 Pro",
+    "load_ms": 64.0,
+    "measured_at": "2026-09-05T13:37Z",
+    "model": "bge-small-en-v1.5-q",
+    "p50_ms": 3893.1,
+    "p95_ms": 3923.6,
+    "profile": "release",
+    "shape": "document-60-chunks"
+  }
+]

--- a/scripts/embed-candidates-fetch.nu
+++ b/scripts/embed-candidates-fetch.nu
@@ -1,0 +1,68 @@
+#!/usr/bin/env nu
+
+# Fetch the user-defined #133 candidates into the model cache (docs/eval/embed-models.md).
+#
+# fastembed's hub client is not re-exported, so the two ONNX exports it has no
+# built-in entry for — arctic-embed-m-v2.0 and Qwen3-Embedding-0.6B — are
+# pulled here, file by file, into `<cache>/candidates/<repo>/`, where
+# `agmem_embed::candidates::CandidateBackend::load` reads them. The built-in
+# candidates (bge-small, EmbeddingGemma) download through fastembed itself on
+# first use and need nothing from this script.
+#
+#     nu scripts/embed-candidates-fetch.nu
+#     nu scripts/embed-candidates-fetch.nu --cache /tmp/agmem-model-cache
+#
+# Idempotent: a file already present with a non-zero size is skipped. About
+# 950 MB in total. Set HF_TOKEN for a gated repo.
+
+const REPOS = [
+    [repo, files];
+    ["Snowflake/snowflake-arctic-embed-m-v2.0" ["onnx/model_int8.onnx" "tokenizer.json" "config.json" "special_tokens_map.json" "tokenizer_config.json"]]
+    ["onnx-community/Qwen3-Embedding-0.6B-ONNX" ["onnx/model_int8.onnx" "tokenizer.json" "config.json" "special_tokens_map.json" "tokenizer_config.json"]]
+]
+
+def main [
+    --cache: string = ""    # FASTEMBED_CACHE_DIR; defaults to the platform model cache
+] {
+    let cache = if ($cache | is-empty) { default-model-cache } else { $cache }
+    let headers = if ($env.HF_TOKEN? | is-empty) { [] } else { [Authorization $"Bearer ($env.HF_TOKEN)"] }
+    for row in $REPOS {
+        let dir = [$cache "candidates" $row.repo] | path join
+        for file in $row.files {
+            let target = [$dir $file] | path join
+            mkdir ($target | path dirname)
+            if (($target | path exists) and ((ls $target | get 0.size) > 0b)) {
+                print $"skip ($row.repo)/($file) — present, (ls $target | get 0.size)"
+                continue
+            }
+            let url = $"https://huggingface.co/($row.repo)/resolve/main/($file)"
+            print $"get  ($row.repo)/($file)"
+            http get --raw --headers $headers $url | save -f --raw $target
+            print $"     ((ls $target | get 0.size))"
+        }
+        # An `.onnx_data` sibling, when the export keeps its weights outside
+        # the graph; both int8 exports are single files, so a 404 here is the
+        # expected answer and `try` swallows it.
+        let data = [$dir "onnx/model_int8.onnx_data"] | path join
+        if not ($data | path exists) {
+            let url = $"https://huggingface.co/($row.repo)/resolve/main/onnx/model_int8.onnx_data"
+            let present = (try { http head $url; true } catch { false })
+            if $present {
+                print $"get  ($row.repo)/onnx/model_int8.onnx_data"
+                http get --raw --headers $headers $url | save -f --raw $data
+            }
+        }
+    }
+    print $"cache: ($cache)"
+}
+
+# The daemon's own model cache, so the candidates sit beside bge-small.
+def default-model-cache [] {
+    if ($env.FASTEMBED_CACHE_DIR? | is-not-empty) { return $env.FASTEMBED_CACHE_DIR }
+    let base = if $nu.os-info.name == "macos" {
+        [$nu.home-dir "Library" "Application Support" "dev.agmem.agmem"] | path join
+    } else {
+        [$nu.home-dir ".local" "share" "agmem"] | path join
+    }
+    $base | path join "models"
+}

--- a/scripts/embed-candidates-run.nu
+++ b/scripts/embed-candidates-run.nu
@@ -1,0 +1,91 @@
+#!/usr/bin/env nu
+
+# The whole #133 pipeline for one candidate (docs/eval/embed-models.md):
+# dump vectors, eval recordings, latency, the pair-rank AUC, the threshold
+# table and the scorecard at floor 0 and at the default floor. Logs land in
+# docs/eval/embed-models/<id>/; the summary lines are printed at the end.
+#
+#     nu scripts/embed-candidates-run.nu <candidate-id> --dump /tmp/probe-dump.json
+#     nu scripts/embed-candidates-run.nu --all --dump /tmp/probe-dump.json
+#
+# Needs the models fetched (scripts/embed-candidates-fetch.nu) and a store
+# dump (docs/eval/pair-rank.md, Inputs). Release builds; the first run
+# compiles.
+
+const IDS = ["bge-small-en-v1.5-q" "embeddinggemma-300m-q" "arctic-embed-m-v2.0-int8" "qwen3-embedding-0.6b-int8"]
+
+def main [
+    id?: string          # one candidate id
+    --all                # every candidate, control first
+    --dump: string       # the store dump JSON
+    --skip-latency       # leave the latency rows alone (they need a quiet machine)
+] {
+    if ($dump | is-empty) { error make {msg: "--dump is required"} }
+    let ids = if $all { $IDS } else if ($id | is-empty) { error make {msg: "give an id or --all"} } else { [$id] }
+    let root = (git rev-parse --show-toplevel | str trim)
+    for id in $ids {
+        let out = [$root "docs/eval/embed-models" $id] | path join
+        mkdir $out
+        print $"== ($id)"
+        let vectors = [$root "target/eval" $"($id)-dump-vectors.json"] | path join
+        let fixtures = [$root "crates/agmem-server/tests/fixtures/eval/candidates" $id] | path join
+
+        step $out "embed-dump" {
+            with-env {AGMEM_CANDIDATE: $id, AGMEM_DUMP: $dump} {
+                cargo test -p agmem-embed --features candidates --release --test candidates -- --ignored --nocapture embed_dump
+            }
+        }
+        step $out "regenerate" {
+            with-env {AGMEM_CANDIDATE: $id} {
+                cargo test -p agmem-embed --features candidates --release --test fastembed -- --ignored --nocapture regenerate_eval_vectors
+            }
+        }
+        if not $skip_latency {
+            step $out "latency" {
+                with-env {AGMEM_CANDIDATE: $id} {
+                    cargo test -p agmem-embed --features candidates --release --test candidates -- --ignored --nocapture latency
+                }
+            }
+        }
+        step $out "pair-rank" {
+            cd $out
+            uv run ([$root "scripts/pair-rank-probe.py"] | path join) $dump --vectors $vectors
+        }
+        step $out "thresholds" {
+            uv run ([$root "scripts/embed-thresholds.py"] | path join) $dump $vectors --dims 512,256,128
+        }
+        for floor in ["0" "default"] {
+            let knobs = if $floor == "default" { {AGMEM_EVAL_VECTORS_DIR: $fixtures} } else { {AGMEM_EVAL_VECTORS_DIR: $fixtures, AGMEM_ABSTENTION_FLOOR: $floor} }
+            step $out $"scorecard-floor-($floor)" {
+                with-env $knobs {
+                    cargo test -p agmem-server --features eval-knobs --release --test eval -- --ignored --nocapture candidate_scorecard
+                }
+            }
+        }
+        print (summary $out)
+    }
+}
+
+# Run one step, keep its whole output, print only its status.
+def step [out: string, name: string, run: closure] {
+    let log = [$out $"($name).log"] | path join
+    let result = (do $run | complete)
+    ($result.stdout + "\n" + $result.stderr) | save -f $log
+    print $"   ($name): exit ($result.exit_code) → ($log | path basename)"
+    if $result.exit_code != 0 {
+        print ($result.stderr | lines | last 15 | str join "\n")
+    }
+}
+
+# The lines the doc's Results table is filled from.
+def summary [out: string] {
+    let grab = {|file, pattern| (try { open --raw ([$out $file] | path join) } catch { "" }) | lines | where $it =~ $pattern }
+    [
+        (do $grab "embed-dump.log" 'rows, \d+d')
+        (do $grab "latency.log" 'p50')
+        (do $grab "pair-rank.log" 'cosine \(control\)')
+        (do $grab "thresholds.log" '^(supersede floor|duplicate gate|corrected vs noise|==)')
+        (do $grab "scorecard-floor-0.log" '^SUMMARY')
+        (do $grab "scorecard-floor-default.log" '^SUMMARY')
+    ] | flatten | str join "\n"
+}

--- a/scripts/embed-thresholds.py
+++ b/scripts/embed-thresholds.py
@@ -1,0 +1,193 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["numpy"]
+# ///
+"""Issue #133's threshold table: where do the store's labelled pair classes
+land in a candidate model's cosine space, and how much margin do the write
+gate and the supersede floor keep? The bar is in docs/eval/embed-models.md.
+
+    uv run scripts/embed-thresholds.py DUMP [VECTORS] [--dims 512,256]
+
+DUMP is the store dump pair-rank-probe.py takes. VECTORS is the `{id:
+vector}` file `embed_dump` (crates/agmem-embed/tests/candidates.rs) wrote
+for a candidate; omit it to table the dump's own (BGE) vectors, which is the
+control. `--dims` adds MRL columns: the same vectors truncated to each width
+and renormalised, which is what a model that supports Matryoshka truncation
+would store.
+
+Five classes, all fixed on the dump — never on the vectors under test:
+
+- corrected     every superseded row against its successor: the pairs the
+                supersede floor must admit (they are the same fact, revised)
+- noise         the shipped contradictions list, top 20 by the dump's cosine
+                among live same-entity pairs: paraphrase noise the band holds
+- band          docs/eval/bands/pairs.json, seven contradictions and one
+                control, embedded by `embed_dump` under `band:<name>:a|b`
+                — the pairs the 0.95 duplicate gate must *not* block
+- random        2,000 random live pairs: the unrelated floor
+- same-entity   500 random live pairs sharing an entity but not linked:
+                related, not revised
+
+The abstention floor is not here: it separates query-vs-page similarities,
+which only the eval harness measures (`calibrate_abstention` under
+`AGMEM_EVAL_VECTORS_DIR`).
+"""
+
+import json
+import sys
+
+import numpy as np
+
+NOISE_SPACE = "agmem"
+COS_FLOOR = 0.75
+LIST_CAP = 20
+DUP_GATE = 0.95
+SUPERSEDE_FLOOR = 0.75
+RANDOM_PAIRS = 2000
+SAME_ENTITY_PAIRS = 500
+QUANTILES = (0.0, 0.05, 0.5, 0.95, 1.0)
+
+
+def link_id(value):
+    return value.split(":", 1)[1].strip("⟨⟩") if value else None
+
+
+def unit(vectors):
+    vectors = np.asarray(vectors, dtype=np.float64)
+    return vectors / np.linalg.norm(vectors, axis=-1, keepdims=True)
+
+
+def truncate(vectors, dim):
+    return unit(vectors[:, :dim]) if dim else vectors
+
+
+def load_sets(rows, dump_vectors):
+    """Pairs of row ids per class, fixed on the dump's own vectors."""
+    by_id = {r["id"]: r for r in rows}
+    live = [r for r in rows if r["space"] == NOISE_SPACE and r.get("embedding") and not r.get("invalid_at")]
+    ids = [r["id"] for r in live]
+    index = {rid: i for i, rid in enumerate(ids)}
+    v = unit([dump_vectors[rid] for rid in ids])
+    sim = v @ v.T
+
+    corrected = []
+    for r in rows:
+        if r.get("invalid_reason") != "superseded":
+            continue
+        successor = by_id.get(link_id(r.get("superseded_by")))
+        if successor and r.get("embedding") and successor.get("embedding"):
+            corrected.append((r["id"], successor["id"]))
+
+    def linked(a, b):
+        return link_id(a.get("superseded_by")) == b["id"] or link_id(b.get("superseded_by")) == a["id"]
+
+    band_pairs, same_entity = [], []
+    for i in range(len(live)):
+        for j in range(i + 1, len(live)):
+            a, b = live[i], live[j]
+            shared = {e.lower() for e in a["entities"]} & {e.lower() for e in b["entities"]}
+            if not shared or linked(a, b):
+                continue
+            same_entity.append((a["id"], b["id"]))
+            if sim[i, j] >= COS_FLOOR:
+                band_pairs.append((a["id"], b["id"], float(sim[i, j])))
+    band_pairs.sort(key=lambda p: -p[2])
+    noise = [(a, b) for a, b, _ in band_pairs[:LIST_CAP]]
+
+    rng = np.random.default_rng(133)
+    random_pairs = []
+    while len(random_pairs) < RANDOM_PAIRS:
+        i, j = rng.integers(0, len(ids), 2)
+        if i != j:
+            random_pairs.append((ids[i], ids[j]))
+    rng.shuffle(same_entity)
+    return {
+        "corrected": corrected,
+        "noise": noise,
+        "random": random_pairs,
+        "same-entity": [tuple(p) for p in same_entity[:SAME_ENTITY_PAIRS]],
+    }, index
+
+
+def cosines(pairs, vectors):
+    a = unit([vectors[x] for x, _ in pairs])
+    b = unit([vectors[y] for _, y in pairs])
+    return np.einsum("ij,ij->i", a, b)
+
+
+def quantiles(values):
+    return [float(np.quantile(values, q)) for q in QUANTILES] if len(values) else [float("nan")] * len(QUANTILES)
+
+
+def table(sets, vectors, label):
+    print(f"\n== {label}")
+    print(f"{'class':<14}{'n':>6}  {'min':>7}{'p5':>7}{'median':>8}{'p95':>7}{'max':>7}")
+    measured = {}
+    for name, pairs in sets.items():
+        if not pairs:
+            print(f"{name:<14}{0:>6}  (empty)")
+            continue
+        c = cosines(pairs, vectors)
+        measured[name] = c
+        q = quantiles(c)
+        print(f"{name:<14}{len(c):>6}  " + "".join(f"{x:>7.3f}" for x in q[:2]) + f"{q[2]:>8.3f}" + "".join(f"{x:>7.3f}" for x in q[3:]))
+    return measured
+
+
+def margins(measured):
+    """How the current constants sit against each class, and the widest
+    separable placement for each threshold on this model."""
+    c = measured
+    print()
+    if "corrected" in c and "random" in c:
+        floor_room = float(np.quantile(c["corrected"], 0.05)) - float(np.quantile(c["random"], 0.999))
+        admitted = float(np.mean(c["corrected"] >= SUPERSEDE_FLOOR))
+        leaked = float(np.mean(c["random"] >= SUPERSEDE_FLOOR))
+        print(f"supersede floor {SUPERSEDE_FLOOR}: admits {admitted:.0%} of corrected, leaks {leaked:.2%} of random;"
+              f" gap corrected.p5 − random.p99.9 = {floor_room:+.3f}"
+              + ("  (no separable band: the floor sits inside the unrelated distribution)" if floor_room <= 0 else ""))
+        lo, hi = float(np.quantile(c["random"], 0.999)), float(np.quantile(c["corrected"], 0.05))
+        if hi > lo:
+            print(f"  widest floor on this model: {(lo + hi) / 2:.3f} (band {lo:.3f}–{hi:.3f})")
+    if "band" in c and "corrected" in c:
+        blocked = float(np.mean(c["band"] >= DUP_GATE))
+        print(f"duplicate gate {DUP_GATE}: blocks {blocked:.0%} of the band contradictions "
+              f"(max {float(c['band'].max()):.3f}); corrected pairs over the gate: {float(np.mean(c['corrected'] >= DUP_GATE)):.0%}")
+        top = float(c["band"].max())
+        print(f"  a gate that admits every band contradiction sits above {top:.3f}")
+    if "noise" in c and "corrected" in c:
+        pos, neg = c["corrected"], c["noise"]
+        auc = float(np.mean([p > n for p in pos for n in neg]) + 0.5 * np.mean([p == n for p in pos for n in neg]))
+        print(f"corrected vs noise, cosine AUC {auc:.3f} (current set; pair-rank-probe.py has the permutation p)")
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    dims = []
+    if "--dims" in sys.argv:
+        dims = [int(d) for d in sys.argv[sys.argv.index("--dims") + 1].split(",")]
+    rows = json.load(open(args[0]))
+    dump_vectors = {r["id"]: r["embedding"] for r in rows if r.get("embedding")}
+    sets, _ = load_sets(rows, dump_vectors)
+
+    if len(args) > 1:
+        vectors = json.load(open(args[1]))
+        label = args[1].rsplit("/", 1)[-1].removesuffix("-dump-vectors.json")
+        band = [(f"band:{n}:a", f"band:{n}:b") for n in sorted({k.split(":")[1] for k in vectors if k.startswith("band:")})]
+        sets["band"] = band
+    else:
+        vectors, label = dump_vectors, "dump (control)"
+    missing = [x for pairs in sets.values() for p in pairs for x in p if x not in vectors]
+    if missing:
+        sys.exit(f"vectors lack {len(missing)} ids, e.g. {missing[0]}")
+
+    widths = [None] + [d for d in dims if d < len(next(iter(vectors.values())))]
+    print(f"rows {len(rows)}; " + ", ".join(f"{k} {len(v)}" for k, v in sets.items()))
+    for width in widths:
+        truncated = {k: unit(np.asarray(v)[:width]) for k, v in vectors.items()} if width else vectors
+        measured = table(sets, truncated, f"{label}" + (f" @ {width}d" if width else ""))
+        margins(measured)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pair-rank-probe.py
+++ b/scripts/pair-rank-probe.py
@@ -6,11 +6,17 @@
 pairs above the paraphrase noise that fills `consolidate`'s contradictions
 list? The bar was written before this ran: docs/eval/pair-rank.md.
 
-    uv run scripts/pair-rank-probe.py DUMP
+    uv run scripts/pair-rank-probe.py DUMP [--vectors FILE]
 
 DUMP is a JSON array of memory rows from a *copy* of the store, as the doc
 shows (the same dump nli-gate-probe.py takes, plus created_at, tags and
 writer). numpy only: the point of the probe is that no model is involved.
+
+`--vectors FILE` (issue #133) swaps every row's `embedding` for the one FILE
+maps its id to — a candidate model's, written by `embed_dump` in
+`crates/agmem-embed/tests/candidates.rs` — *after* the labelled sets are
+fixed on the dump's own vectors, so the sets stay the shipped ones and only
+the `cosine (control)` numbers move: they become the candidate's AUC.
 
 Every feature reads three fields — content, entities, created_at — through
 `View`, which refuses anything else. The labels (invalid_reason,
@@ -286,6 +292,8 @@ def time_matched(pos, wide_neg, rng):
 
 def main():
     rows = json.load(open(sys.argv[1]))
+    vectors_path = sys.argv[sys.argv.index("--vectors") + 1] if "--vectors" in sys.argv else None
+    suffix = f"-{vectors_path.rsplit('/', 1)[-1].removesuffix('-dump-vectors.json')}" if vectors_path else ""
     by_id = {r["id"]: r for r in rows}
     now = datetime.now(timezone.utc)
     rng = np.random.default_rng(53)
@@ -306,6 +314,17 @@ def main():
     neg_t54 = [(a, b) for a, b, _ in cands_t54[:LIST_CAP]]
     neg_now = [(a, b) for a, b, _ in cands_now[:LIST_CAP]]
 
+    # The sets are fixed; from here on the cosine feature reads the candidate.
+    if vectors_path:
+        swapped = json.load(open(vectors_path))
+        missing = [r["id"] for r in rows if r.get("embedding") and r["id"] not in swapped]
+        if missing:
+            sys.exit(f"{vectors_path} lacks vectors for {len(missing)} embedded rows, e.g. {missing[0]}")
+        for r in rows:
+            if r["id"] in swapped:
+                r["embedding"] = swapped[r["id"]]
+        print(f"cosine feature reads {vectors_path} ({len(swapped[rows[0]['id']]) if rows[0]['id'] in swapped else '?'}d)")
+
     # Document frequency over the whole space in the dump, live or not: the
     # positives include closed rows, and one pool for both sides keeps the
     # rarity of an entity from depending on which set a pair came from.
@@ -322,7 +341,7 @@ def main():
     top_df = sorted(df.items(), key=lambda kv: -kv[1])[:5]
     print("entity DF, top 5: " + ", ".join(f"{e}={n}" for e, n in top_df))
 
-    report = {"run_at": now.isoformat(), "as_of": T54.isoformat(), "hub_only_share": hub_share_now, "sets": []}
+    report = {"run_at": now.isoformat(), "as_of": T54.isoformat(), "hub_only_share": hub_share_now, "vectors": vectors_path, "sets": []}
     score_set("T54", pos_t54, neg_t54, df, pool_size, rng, report)
     current = score_set("current", pos_all, neg_now, df, pool_size, rng, report)
 
@@ -344,16 +363,16 @@ def main():
         evicted = sum((a["id"], b["id"]) not in old_ids for a, b, _ in new_top)
         report["evicted_from_cosine_top20"] = evicted
         print(f"\nblend order evicts {evicted} of cosine's top {LIST_CAP}")
-        with open("pair-rank-top20.json", "w") as out:
+        with open(f"pair-rank-top20{suffix}.json", "w") as out:
             json.dump(
                 [{"a": a["content"], "b": b["content"], "cosine": s, "label": None} for a, b, s in new_top],
                 out, indent=1, ensure_ascii=False,
             )
-        print("reordered top 20 written to pair-rank-top20.json — hand-label `label` as true/false")
+        print(f"reordered top 20 written to pair-rank-top20{suffix}.json — hand-label `label` as true/false")
 
-    with open("pair-rank-scores.json", "w") as out:
+    with open(f"pair-rank-scores{suffix}.json", "w") as out:
         json.dump(report, out, indent=1)
-    print("report written to pair-rank-scores.json")
+    print(f"report written to pair-rank-scores{suffix}.json")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #133 as measured-and-not-switched. Full record with the bar, the method and every number: `docs/eval/embed-models.md`.

## What was measured

Four models on the store's own labelled sets and the eval fixtures, all through ONNX Runtime on CPU (the runtime the daemon runs), on an Apple M1 Pro (the bar names an M4 Pro; none was available):

| Candidate | AUC current set (bar ≥ 0.671) | nDCG@5 (bar ≥ 0.654) | one claim (bar ≤ 60 ms) | thresholds | verdict |
|---|---|---|---|---|---|
| bge-small-en-v1.5-q (control) | 0.651 | 0.624 | 15.7 ms | shipped | — |
| EmbeddingGemma-300M-q | **0.867** | **0.655** | 72.6 ms; 34 s per 60-chunk document | separable; floor 0.14 fires 5/10 | fails latency |
| arctic-embed-m-v2.0 int8 | 0.833 | **0.655** | 17.0 ms; 6.1 s per document | abstention floor fires 1/10 | fails abstention |
| Qwen3-Embedding-0.6B int8 | 0.767 | 0.615 | ~200 ms | — | fails retrieval, latency |

Both 768-d candidates move every threshold: the write gate stops blocking revisions (band max 0.921 / 0.862 vs BGE's 0.974) and the supersede floor finally sits outside the unrelated distribution (random leak 0 % vs 98 % on BGE).

## What ships

Measurement surface only; nothing in the server changes behaviour:

- `crates/agmem-embed/src/candidates.rs` behind `--features candidates`, with Qwen3 on a direct `ort` session (its export needs `position_ids` and empty KV caches fastembed never feeds).
- Ignored tests: `embed_dump`, `latency` (rows in `docs/eval/embed-models/latency.json`, with an `accelerator` column for #139), and `regenerate_eval_vectors` under `AGMEM_CANDIDATE`.
- agmem-server `eval-knobs` feature: `AGMEM_ABSTENTION_FLOOR` in `tools/abstain.rs`; `AGMEM_EVAL_VECTORS_DIR` in the recorded embedder; ignored `candidate_scorecard`.
- `scripts/pair-rank-probe.py --vectors`, `scripts/embed-thresholds.py`, `scripts/embed-candidates-fetch.nu`, `scripts/embed-candidates-run.nu`.

## Follow-ups

- #139 measures Gemma and arctic on the CoreML EP; the latency rows append to the same file.
- Whether arctic's abstention column should block a model that wins every other column is a call for the #133 thread.
- #138 stays open: a switch is now plausible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018chPKULzdrM3hh9VqTRjne
