### PR TITLE
CoreML execution provider measured behind a feature: slower than the CPU on every shape, dropped (#139)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,7 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace
+      # The CoreML feature (#139) must keep compiling; the model itself never
+      # runs here (#119), and `--accelerator cpu` is what the tests use.
+      - if: runner.os == 'macOS'
+        run: cargo clippy -p agmem-server -p agmem-embed --features coreml --all-targets -- -D warnings

--- a/crates/agmem-embed/Cargo.toml
+++ b/crates/agmem-embed/Cargo.toml
@@ -15,6 +15,11 @@ rerank = []
 # the server links it. Loads the candidates behind `Embedder` with their own
 # prefixes and pooling so the numbers come off the production ORT path.
 candidates = ["dep:ndarray", "dep:serde_json", "dep:ort", "dep:tokenizers"]
+# The CoreML execution provider on macOS (issue #139). ONNX Runtime as pyke
+# ships it for aarch64-apple-darwin already carries the provider; this turns
+# on ort's Rust surface for it and lets `Accelerator::CoreMl` resolve. Off
+# by default: the CPU path is the portable one.
+coreml = ["dep:ort", "ort/coreml"]
 
 [dependencies]
 fastembed = { workspace = true }

--- a/crates/agmem-embed/src/accelerator.rs
+++ b/crates/agmem-embed/src/accelerator.rs
@@ -1,0 +1,181 @@
+//! Where ONNX Runtime runs the model (issue #139).
+//!
+//! One graph, one runtime: an accelerator is an ONNX Runtime *execution
+//! provider* registered on the session, never a second inference engine.
+//! The CPU provider is always there. The CoreML provider exists in every
+//! macOS build of the runtime agmem links, but its Rust surface is behind the
+//! `coreml` cargo feature, so a build without it can only ever resolve to
+//! [`Active::Cpu`].
+//!
+//! `auto` is resolved once, before any model loads, so the daemon, `doctor`
+//! and a spawned child all hold — and print — the same concrete answer.
+
+#[cfg(any(feature = "coreml", feature = "candidates"))]
+use std::path::Path;
+
+use crate::EmbedError;
+
+/// What the configuration asked for.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Accelerator {
+    /// CoreML where the build and the machine both have it, else CPU.
+    #[default]
+    Auto,
+    /// The CPU provider only — the portable default.
+    Cpu,
+    /// The CoreML provider; an error when the build or the machine lacks it.
+    CoreMl,
+}
+
+impl Accelerator {
+    /// The spelling `--accelerator` takes.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Cpu => "cpu",
+            Self::CoreMl => "coreml",
+        }
+    }
+
+    /// The accelerator a spelling names.
+    #[must_use]
+    pub fn parse(spelling: &str) -> Option<Self> {
+        match spelling {
+            "auto" => Some(Self::Auto),
+            "cpu" => Some(Self::Cpu),
+            "coreml" => Some(Self::CoreMl),
+            _ => None,
+        }
+    }
+
+    /// Settle `auto` against this build and this machine.
+    ///
+    /// # Errors
+    /// [`EmbedError::Backend`] when CoreML was asked for by name and this
+    /// build was made without the `coreml` feature, or the runtime reports
+    /// the provider unavailable here.
+    pub fn resolve(self) -> Result<Active, EmbedError> {
+        match self {
+            Self::Cpu => Ok(Active::Cpu),
+            Self::Auto => Ok(if coreml_available() {
+                Active::CoreMl
+            } else {
+                Active::Cpu
+            }),
+            Self::CoreMl if coreml_available() => Ok(Active::CoreMl),
+            Self::CoreMl => Err(EmbedError::Backend {
+                backend: "accelerator",
+                message: if cfg!(feature = "coreml") {
+                    "the CoreML execution provider is not available on this machine".to_owned()
+                } else {
+                    "this build has no CoreML support; build with `--features coreml` on macOS"
+                        .to_owned()
+                },
+            }),
+        }
+    }
+}
+
+/// What the session actually runs on, once `auto` is settled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Active {
+    /// The CPU provider only.
+    Cpu,
+    /// The CoreML provider, with the CPU provider behind it for the ops
+    /// Core ML has no kernel for (embedding lookups, the mask path).
+    CoreMl,
+}
+
+impl Active {
+    /// What `doctor`, the startup log and a latency row print.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Cpu => "cpu",
+            Self::CoreMl => "coreml",
+        }
+    }
+
+    /// The providers to register on a session, in priority order.
+    ///
+    /// Empty for the CPU: ONNX Runtime registers its CPU provider itself.
+    /// For CoreML: the `MLProgram` format (the only one still developed),
+    /// every compute unit so Core ML may place fp16-safe ops on the Neural
+    /// Engine, and a compiled-model cache under `cache_dir` so the
+    /// seconds-long first compile happens once per model, not once per
+    /// process. Registration failure is an error, not a silent fall back
+    /// to the CPU: a row measured under `coreml` must have run on it.
+    #[cfg(any(feature = "coreml", feature = "candidates"))]
+    #[must_use]
+    pub fn execution_providers(
+        self,
+        cache_dir: Option<&Path>,
+    ) -> Vec<ort::ep::ExecutionProviderDispatch> {
+        match self {
+            Self::Cpu => Vec::new(),
+            #[cfg(feature = "coreml")]
+            Self::CoreMl => {
+                use ort::ep::{CoreML, coreml::ComputeUnits, coreml::ModelFormat};
+                let mut ep = CoreML::default()
+                    .with_model_format(ModelFormat::MLProgram)
+                    .with_compute_units(ComputeUnits::All);
+                if let Some(dir) = cache_dir {
+                    let dir = dir.join("coreml");
+                    if std::fs::create_dir_all(&dir).is_ok() {
+                        ep = ep.with_model_cache_dir(dir.display());
+                    }
+                }
+                vec![ep.build().error_on_failure()]
+            }
+            #[cfg(not(feature = "coreml"))]
+            Self::CoreMl => unreachable!("CoreMl never resolves without the coreml feature"),
+        }
+    }
+}
+
+/// Whether the runtime this binary links was compiled with the CoreML
+/// provider *and* the Rust surface for it is in this build.
+#[cfg(feature = "coreml")]
+fn coreml_available() -> bool {
+    use ort::ep::ExecutionProvider as _;
+    ort::ep::CoreML::default().is_available().unwrap_or(false)
+}
+
+#[cfg(not(feature = "coreml"))]
+fn coreml_available() -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spellings_round_trip() {
+        for accelerator in [Accelerator::Auto, Accelerator::Cpu, Accelerator::CoreMl] {
+            assert_eq!(Accelerator::parse(accelerator.as_str()), Some(accelerator));
+        }
+        assert_eq!(Accelerator::parse("gpu"), None);
+    }
+
+    #[test]
+    fn cpu_always_resolves_to_cpu() {
+        assert_eq!(Accelerator::Cpu.resolve().unwrap(), Active::Cpu);
+    }
+
+    #[test]
+    fn auto_never_fails() {
+        // Whichever it lands on, `auto` is the one spelling that must load
+        // on every machine this binary ships to.
+        let _ = Accelerator::Auto.resolve().expect("auto resolves");
+    }
+
+    #[cfg(not(feature = "coreml"))]
+    #[test]
+    fn coreml_by_name_is_refused_without_the_feature() {
+        assert_eq!(Accelerator::Auto.resolve().unwrap(), Active::Cpu);
+        let err = Accelerator::CoreMl.resolve().unwrap_err();
+        assert!(err.to_string().contains("--features coreml"), "{err}");
+    }
+}

--- a/crates/agmem-embed/src/candidates.rs
+++ b/crates/agmem-embed/src/candidates.rs
@@ -15,6 +15,12 @@
 //! through `ort` directly: its export takes a `position_ids` input fastembed
 //! never feeds, and it wants last-token pooling fastembed cannot express, so
 //! this module tokenises, runs the session and pools by hand.
+//!
+//! The fp32 siblings of the three encoder candidates exist for #139: Core
+//! ML has no kernel for the dynamic-quantisation ops (`MatMulInteger`,
+//! `DynamicQuantizeLinear`), so a quantised graph on the CoreML provider is
+//! a CPU graph with extra partition boundaries, and only the fp32 exports
+//! can measure what the accelerator does.
 
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -29,6 +35,7 @@ use ort::session::builder::GraphOptimizationLevel;
 use ort::value::Value;
 use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams};
 
+use crate::accelerator::Active;
 use crate::{EmbedError, Embedder};
 
 /// The environment variable that names the candidate a test run measures.
@@ -61,15 +68,24 @@ pub enum Candidate {
     ArcticMV2Int8,
     /// Qwen3-Embedding-0.6B, int8, last-token pooled.
     Qwen3Embedding06BInt8,
+    /// The control's fp32 export (#139: the accelerator measurement).
+    BgeSmallF32,
+    /// EmbeddingGemma-300M, fp32 (#139).
+    Gemma300MF32,
+    /// snowflake-arctic-embed-m-v2.0, fp32, CLS pooled (#139).
+    ArcticMV2F32,
 }
 
 impl Candidate {
     /// Every candidate, control first.
-    pub const ALL: [Self; 4] = [
+    pub const ALL: [Self; 7] = [
         Self::BgeSmallQ,
         Self::Gemma300MQ,
         Self::ArcticMV2Int8,
         Self::Qwen3Embedding06BInt8,
+        Self::BgeSmallF32,
+        Self::Gemma300MF32,
+        Self::ArcticMV2F32,
     ];
 
     /// The id a recording, a latency row and `AGMEM_CANDIDATE` spell.
@@ -80,6 +96,9 @@ impl Candidate {
             Self::Gemma300MQ => "embeddinggemma-300m-q",
             Self::ArcticMV2Int8 => "arctic-embed-m-v2.0-int8",
             Self::Qwen3Embedding06BInt8 => "qwen3-embedding-0.6b-int8",
+            Self::BgeSmallF32 => "bge-small-en-v1.5",
+            Self::Gemma300MF32 => "embeddinggemma-300m",
+            Self::ArcticMV2F32 => "arctic-embed-m-v2.0",
         }
     }
 
@@ -107,8 +126,8 @@ impl Candidate {
     #[must_use]
     pub fn dim(self) -> usize {
         match self {
-            Self::BgeSmallQ => crate::fastembed::DIM,
-            Self::Gemma300MQ | Self::ArcticMV2Int8 => 768,
+            Self::BgeSmallQ | Self::BgeSmallF32 => crate::fastembed::DIM,
+            Self::Gemma300MQ | Self::Gemma300MF32 | Self::ArcticMV2Int8 | Self::ArcticMV2F32 => 768,
             Self::Qwen3Embedding06BInt8 => 1024,
         }
     }
@@ -116,17 +135,19 @@ impl Candidate {
     /// What stored text is marked with, per the model's card.
     fn passage_prefix(self) -> &'static str {
         match self {
-            Self::BgeSmallQ => "passage: ",
-            Self::Gemma300MQ => "title: none | text: ",
-            Self::ArcticMV2Int8 | Self::Qwen3Embedding06BInt8 => "",
+            Self::BgeSmallQ | Self::BgeSmallF32 => "passage: ",
+            Self::Gemma300MQ | Self::Gemma300MF32 => "title: none | text: ",
+            Self::ArcticMV2Int8 | Self::ArcticMV2F32 | Self::Qwen3Embedding06BInt8 => "",
         }
     }
 
     /// What the search side is marked with, per the model's card.
     fn query_prefix(self) -> &'static str {
         match self {
-            Self::BgeSmallQ | Self::ArcticMV2Int8 => "query: ",
-            Self::Gemma300MQ => "task: search result | query: ",
+            Self::BgeSmallQ | Self::BgeSmallF32 | Self::ArcticMV2Int8 | Self::ArcticMV2F32 => {
+                "query: "
+            }
+            Self::Gemma300MQ | Self::Gemma300MF32 => "task: search result | query: ",
             Self::Qwen3Embedding06BInt8 => {
                 "Instruct: Given a web search query, retrieve relevant passages that answer \
                  the query\nQuery: "
@@ -139,11 +160,14 @@ impl Candidate {
     #[must_use]
     pub fn user_defined(self) -> Option<(&'static str, &'static str)> {
         match self {
-            Self::BgeSmallQ | Self::Gemma300MQ => None,
+            Self::BgeSmallQ | Self::Gemma300MQ | Self::BgeSmallF32 | Self::Gemma300MF32 => None,
             Self::ArcticMV2Int8 => Some((
                 "Snowflake/snowflake-arctic-embed-m-v2.0",
                 "onnx/model_int8.onnx",
             )),
+            Self::ArcticMV2F32 => {
+                Some(("Snowflake/snowflake-arctic-embed-m-v2.0", "onnx/model.onnx"))
+            }
             Self::Qwen3Embedding06BInt8 => Some((
                 "onnx-community/Qwen3-Embedding-0.6B-ONNX",
                 "onnx/model_int8.onnx",
@@ -225,45 +249,68 @@ impl CandidateBackend {
     /// fastembed; user-defined ones read the files the fetch script put
     /// there and fail naming the missing one.
     ///
+    /// `accelerator` is the execution provider every engine registers, so a
+    /// row measured under `coreml` ran on it whichever path loads the model.
+    ///
     /// # Errors
     /// [`EmbedError::Backend`] when a file is missing or the session will
     /// not build.
-    pub fn load(candidate: Candidate, cache_dir: &Path) -> Result<Self, EmbedError> {
+    pub fn load(
+        candidate: Candidate,
+        cache_dir: &Path,
+        accelerator: Active,
+    ) -> Result<Self, EmbedError> {
         let failed = |message: String| EmbedError::Backend {
             backend: candidate.id(),
             message,
         };
+        let providers = accelerator.execution_providers(Some(cache_dir));
         let engine = match candidate {
-            Candidate::BgeSmallQ | Candidate::Gemma300MQ => {
+            Candidate::BgeSmallQ
+            | Candidate::Gemma300MQ
+            | Candidate::BgeSmallF32
+            | Candidate::Gemma300MF32 => {
                 let builtin = match candidate {
                     Candidate::BgeSmallQ => EmbeddingModel::BGESmallENV15Q,
+                    Candidate::BgeSmallF32 => EmbeddingModel::BGESmallENV15,
+                    Candidate::Gemma300MF32 => EmbeddingModel::EmbeddingGemma300M,
                     _ => EmbeddingModel::EmbeddingGemma300MQ,
                 };
                 let options = TextInitOptions::new(builtin)
                     .with_cache_dir(cache_dir.to_path_buf())
-                    .with_show_download_progress(false);
+                    .with_show_download_progress(false)
+                    .with_execution_providers(providers);
                 let model = TextEmbedding::try_new(options).map_err(|e| failed(e.to_string()))?;
                 Engine::Fastembed(Mutex::new(model))
             }
-            Candidate::ArcticMV2Int8 => {
+            Candidate::ArcticMV2Int8 | Candidate::ArcticMV2F32 => {
                 let files = Files::read(candidate, cache_dir)?;
                 let tokenizer_files = files.tokenizer_files();
+                let quantization = match candidate {
+                    Candidate::ArcticMV2Int8 => QuantizationMode::Static,
+                    _ => QuantizationMode::None,
+                };
                 let model = UserDefinedEmbeddingModel::new(files.onnx, tokenizer_files)
-                    .with_quantization(QuantizationMode::Static)
+                    .with_quantization(quantization)
                     .with_pooling(Pooling::Cls);
-                let options = InitOptionsUserDefined::new().with_max_length(MAX_TOKENS);
+                let options = InitOptionsUserDefined::new()
+                    .with_max_length(MAX_TOKENS)
+                    .with_execution_providers(providers);
                 let model = TextEmbedding::try_new_from_user_defined(model, options)
                     .map_err(|e| failed(e.to_string()))?;
                 Engine::Fastembed(Mutex::new(model))
             }
             Candidate::Qwen3Embedding06BInt8 => {
                 let files = Files::read(candidate, cache_dir)?;
-                Engine::Direct(Mutex::new(Direct::load(files, QWEN3_EOS).map_err(failed)?))
+                Engine::Direct(Mutex::new(
+                    Direct::load(files, QWEN3_EOS, &providers).map_err(failed)?,
+                ))
             }
         };
         tracing::info!(
             model = candidate.id(),
             dim = candidate.dim(),
+            accelerator = accelerator.as_str(),
             "loaded candidate"
         );
         Ok(Self { candidate, engine })
@@ -398,7 +445,11 @@ struct Direct {
 }
 
 impl Direct {
-    fn load(files: Files, eos: &'static str) -> Result<Self, String> {
+    fn load(
+        files: Files,
+        eos: &'static str,
+        providers: &[ort::ep::ExecutionProviderDispatch],
+    ) -> Result<Self, String> {
         let mut tokenizer = Tokenizer::from_bytes(&files.tokenizer).map_err(|e| e.to_string())?;
         let pad_id = tokenizer
             .token_to_id(eos)
@@ -420,6 +471,8 @@ impl Direct {
         let session = Session::builder()
             .map_err(|e| e.to_string())?
             .with_optimization_level(GraphOptimizationLevel::Level3)
+            .map_err(|e| e.to_string())?
+            .with_execution_providers(providers)
             .map_err(|e| e.to_string())?
             .commit_from_memory(&files.onnx)
             .map_err(|e| e.to_string())?;

--- a/crates/agmem-embed/src/fastembed.rs
+++ b/crates/agmem-embed/src/fastembed.rs
@@ -10,6 +10,7 @@ use std::sync::Mutex;
 
 use fastembed::{EmbeddingModel, TextEmbedding, TextInitOptions};
 
+use crate::accelerator::{Accelerator, Active};
 use crate::{EmbedError, Embedder};
 
 /// What the store records in `meta.embedder_model`.
@@ -32,6 +33,8 @@ pub struct FastembedBackend {
     /// Embedding is CPU-bound anyway; parallelism belongs in the batch, not
     /// in the number of loaded models.
     model: Mutex<TextEmbedding>,
+    /// Where the session runs, settled from the configuration at load.
+    accelerator: Active,
 }
 
 /// `TextEmbedding` is not `Debug`, and a loaded session has nothing worth
@@ -41,6 +44,7 @@ impl std::fmt::Debug for FastembedBackend {
         f.debug_struct("FastembedBackend")
             .field("model", &MODEL_ID)
             .field("dim", &DIM)
+            .field("accelerator", &self.accelerator.as_str())
             .finish()
     }
 }
@@ -54,21 +58,42 @@ impl FastembedBackend {
     /// either the crate would cache into `./.fastembed_cache`, relative to
     /// whatever directory the agent happened to launch the server from.
     ///
+    /// `accelerator` names the execution provider; `auto` settles here, once,
+    /// so what this backend reports is what its session runs on.
+    ///
     /// # Errors
-    /// [`EmbedError::Backend`] when the model cannot be fetched or loaded.
-    pub fn new(fallback_cache_dir: Option<PathBuf>) -> Result<Self, EmbedError> {
+    /// [`EmbedError::Backend`] when the model cannot be fetched or loaded, or
+    /// CoreML was asked for by name and is not there.
+    pub fn new(
+        fallback_cache_dir: Option<PathBuf>,
+        accelerator: Accelerator,
+    ) -> Result<Self, EmbedError> {
+        let active = accelerator.resolve()?;
         // Download progress bars are not ours to print: stdout is the MCP wire.
         let mut options = TextInitOptions::new(MODEL).with_show_download_progress(false);
-        if std::env::var_os("FASTEMBED_CACHE_DIR").is_none()
-            && let Some(dir) = fallback_cache_dir
+        let cache_dir = match std::env::var_os("FASTEMBED_CACHE_DIR") {
+            Some(dir) => Some(PathBuf::from(dir)),
+            None => fallback_cache_dir,
+        };
+        if let Some(dir) = &cache_dir {
+            options = options.with_cache_dir(dir.clone());
+        }
+        #[cfg(feature = "coreml")]
         {
-            options = options.with_cache_dir(dir);
+            options =
+                options.with_execution_providers(active.execution_providers(cache_dir.as_deref()));
         }
 
-        tracing::info!(model = MODEL_ID, dim = DIM, "loading embedding model");
+        tracing::info!(
+            model = MODEL_ID,
+            dim = DIM,
+            accelerator = active.as_str(),
+            "loading embedding model"
+        );
         let model = TextEmbedding::try_new(options).map_err(failed)?;
         Ok(Self {
             model: Mutex::new(model),
+            accelerator: active,
         })
     }
 
@@ -104,6 +129,10 @@ impl Embedder for FastembedBackend {
 
     fn model_id(&self) -> &str {
         MODEL_ID
+    }
+
+    fn accelerator(&self) -> &str {
+        self.accelerator.as_str()
     }
 
     fn embed_passages(&self, passages: &[String]) -> Result<Vec<Vec<f32>>, EmbedError> {

--- a/crates/agmem-embed/src/lib.rs
+++ b/crates/agmem-embed/src/lib.rs
@@ -13,6 +13,7 @@
 
 use std::sync::Arc;
 
+pub mod accelerator;
 #[cfg(feature = "candidates")]
 pub mod candidates;
 pub mod fastembed;
@@ -20,6 +21,7 @@ pub mod noop;
 #[cfg(feature = "rerank")]
 pub mod rerank;
 
+pub use accelerator::{Accelerator, Active};
 pub use noop::NoopEmbedder;
 
 /// Turns text into vectors, one backend at a time.
@@ -37,6 +39,14 @@ pub trait Embedder: Send + Sync + 'static {
     /// Stable model identifier, recorded in `meta` so a later run cannot
     /// silently mix vector spaces.
     fn model_id(&self) -> &str;
+
+    /// The execution provider the model runs on — `cpu` unless a backend
+    /// registered another (`docs/design.md` §4; issue #139). Printed by
+    /// `doctor` and the startup log; never stored, since the vectors are
+    /// the same modulo accelerator drift the fixtures check.
+    fn accelerator(&self) -> &str {
+        "cpu"
+    }
 
     /// Embed documents for storage, in input order.
     ///

--- a/crates/agmem-embed/tests/candidates.rs
+++ b/crates/agmem-embed/tests/candidates.rs
@@ -19,8 +19,8 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use agmem_embed::Embedder;
 use agmem_embed::candidates::{CANDIDATE_ENV, Candidate, CandidateBackend, cache_dir};
+use agmem_embed::{Accelerator, Active, Embedder};
 
 /// The store dump the separation sets are read from.
 const DUMP_ENV: &str = "AGMEM_DUMP";
@@ -51,9 +51,20 @@ fn candidate() -> Candidate {
         .unwrap_or_else(|| panic!("{CANDIDATE_ENV} names the candidate to measure"))
 }
 
+/// The execution provider `AGMEM_ACCELERATOR` names (`auto|cpu|coreml`),
+/// settled; `cpu` when unset, so an old invocation measures what it did.
+fn accelerator() -> Active {
+    let spelling = std::env::var("AGMEM_ACCELERATOR").unwrap_or_else(|_| "cpu".to_owned());
+    Accelerator::parse(&spelling)
+        .unwrap_or_else(|| panic!("AGMEM_ACCELERATOR={spelling:?}: one of auto, cpu, coreml"))
+        .resolve()
+        .expect("resolve the accelerator")
+}
+
 fn load(candidate: Candidate) -> (CandidateBackend, f64) {
     let started = Instant::now();
-    let backend = CandidateBackend::load(candidate, &cache_dir()).expect("load candidate");
+    let backend =
+        CandidateBackend::load(candidate, &cache_dir(), accelerator()).expect("load candidate");
     let load_ms = started.elapsed().as_secs_f64() * 1e3;
     eprintln!("{} loaded in {load_ms:.0} ms", candidate.id());
     (backend, load_ms)
@@ -174,7 +185,7 @@ fn chip() -> String {
 #[ignore = "times the candidate AGMEM_CANDIDATE names on this machine"]
 fn latency() {
     let candidate = candidate();
-    let accelerator = std::env::var("AGMEM_ACCELERATOR").unwrap_or_else(|_| "cpu".to_owned());
+    let accelerator = accelerator().as_str();
     let (backend, load_ms) = load(candidate);
 
     let claims: Vec<String> = (0..16)

--- a/crates/agmem-embed/tests/fastembed.rs
+++ b/crates/agmem-embed/tests/fastembed.rs
@@ -21,7 +21,8 @@ fn related_sentences_land_closer_than_unrelated_ones() {
     // A cache under the temp dir, not `./.fastembed_cache` in whatever
     // directory the test runner happened to start in.
     let cache = std::env::temp_dir().join("agmem-model-cache");
-    let embedder = FastembedBackend::new(Some(cache)).expect("load model");
+    let embedder =
+        FastembedBackend::new(Some(cache), agmem_embed::Accelerator::Cpu).expect("load model");
     assert_eq!(embedder.dim(), DIM);
 
     let passages = vec![
@@ -73,7 +74,8 @@ fn regenerate_knn_fixture() {
     }
 
     let cache = std::env::temp_dir().join("agmem-model-cache");
-    let embedder = FastembedBackend::new(Some(cache)).expect("load model");
+    let embedder =
+        FastembedBackend::new(Some(cache), agmem_embed::Accelerator::Cpu).expect("load model");
 
     let rows = [
         "The user formats Python with black.",
@@ -268,7 +270,8 @@ fn regenerate_eval_vectors() {
             Some((embedder, id)) => (embedder, eval_dir.join("candidates").join(&id), id),
             None => {
                 let cache = std::env::temp_dir().join("agmem-model-cache");
-                let embedder = FastembedBackend::new(Some(cache)).expect("load model");
+                let embedder = FastembedBackend::new(Some(cache), agmem_embed::Accelerator::Cpu)
+                    .expect("load model");
                 (
                     Box::new(embedder),
                     eval_dir.clone(),
@@ -307,11 +310,66 @@ fn regenerate_eval_vectors() {
 fn candidate_recorder() -> Option<(Box<dyn Embedder>, String)> {
     use agmem_embed::candidates::{Candidate, CandidateBackend, cache_dir};
     let candidate = Candidate::from_env()?;
-    let backend = CandidateBackend::load(candidate, &cache_dir()).expect("load candidate");
+    let backend = CandidateBackend::load(candidate, &cache_dir(), agmem_embed::Active::Cpu)
+        .expect("load candidate");
     Some((Box::new(backend), candidate.id().to_owned()))
 }
 
 #[cfg(not(feature = "candidates"))]
 fn candidate_recorder() -> Option<(Box<dyn Embedder>, String)> {
     None
+}
+
+/// The #139 drift check: the accelerated session must reproduce the CPU
+/// vectors closely enough that no threshold moves. Every fixture text —
+/// passages and queries alike — is embedded on both providers, and the
+/// smallest cosine between the pairs has to clear the bar in
+/// `docs/eval/coreml-ep.md`.
+#[cfg(feature = "coreml")]
+#[test]
+#[ignore = "runs the real model on the CoreML execution provider"]
+fn coreml_vectors_match_cpu() {
+    use agmem_embed::Accelerator;
+
+    const BAR: f32 = 0.999;
+
+    let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../agmem-server/tests/fixtures/eval/vectors.json");
+    let recording: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&fixture).expect("read vectors.json"))
+            .expect("vectors.json parses");
+    let texts = |section: &str| -> Vec<String> {
+        recording[section]
+            .as_object()
+            .expect(section)
+            .keys()
+            .cloned()
+            .collect()
+    };
+    let passages = texts("passages");
+    let queries = texts("queries");
+    assert!(!passages.is_empty() && !queries.is_empty(), "empty fixture");
+
+    let cache = std::env::temp_dir().join("agmem-model-cache");
+    let cpu = FastembedBackend::new(Some(cache.clone()), Accelerator::Cpu).expect("load on cpu");
+    let coreml = FastembedBackend::new(Some(cache), Accelerator::CoreMl).expect("load on coreml");
+    assert_eq!(coreml.accelerator(), "coreml");
+
+    let mut cosines: Vec<f32> = Vec::with_capacity(passages.len() + queries.len());
+    let a = cpu.embed_passages(&passages).expect("cpu passages");
+    let b = coreml.embed_passages(&passages).expect("coreml passages");
+    cosines.extend(a.iter().zip(&b).map(|(x, y)| cosine(x, y)));
+    for query in &queries {
+        let x = cpu.embed_query(query).expect("cpu query");
+        let y = coreml.embed_query(query).expect("coreml query");
+        cosines.push(cosine(&x, &y));
+    }
+
+    let min = cosines.iter().copied().fold(f32::INFINITY, f32::min);
+    let mean = cosines.iter().sum::<f32>() / cosines.len() as f32;
+    eprintln!(
+        "coreml vs cpu over {} texts: min cosine {min:.6}, mean {mean:.6}",
+        cosines.len()
+    );
+    assert!(min >= BAR, "min cosine {min:.6} is under the {BAR} bar");
 }

--- a/crates/agmem-embed/tests/rerank.rs
+++ b/crates/agmem-embed/tests/rerank.rs
@@ -143,7 +143,8 @@ fn record_rerank_scores() {
         );
     }
     let embedder =
-        agmem_embed::fastembed::FastembedBackend::new(Some(cache)).expect("load the embedder");
+        agmem_embed::fastembed::FastembedBackend::new(Some(cache), agmem_embed::Accelerator::Cpu)
+            .expect("load the embedder");
     let embeds: Vec<f64> = (0..5)
         .map(|_| {
             let start = Instant::now();

--- a/crates/agmem-server/Cargo.toml
+++ b/crates/agmem-server/Cargo.toml
@@ -17,6 +17,10 @@ path = "src/main.rs"
 # from the environment, so a candidate embedder is scored on its own cosine
 # scale. Never on in a release build.
 eval-knobs = []
+# macOS acceleration through ONNX Runtime's CoreML execution provider
+# (issue #139): `--accelerator auto|coreml` can then resolve to it. Off by
+# default; the CPU path is what every platform ships.
+coreml = ["agmem-embed/coreml"]
 
 [dependencies]
 # `schema` puts core's enums, and their variant docs, into the tool schemas

--- a/crates/agmem-server/src/config.rs
+++ b/crates/agmem-server/src/config.rs
@@ -56,6 +56,12 @@ pub struct Cli {
     #[arg(long, env = "AGMEM_EMBEDDER", value_enum, default_value_t = EmbedderKind::Fastembed)]
     pub embedder: EmbedderKind,
 
+    /// Where ONNX Runtime runs the model (#139). `auto` picks CoreML on a
+    /// macOS build made with `--features coreml` and the CPU everywhere
+    /// else; `coreml` insists and fails when it is not there.
+    #[arg(long, env = "AGMEM_ACCELERATOR", value_enum, default_value_t = AcceleratorKind::Auto)]
+    pub accelerator: AcceleratorKind,
+
     /// Which tools the MCP session serves. `core` (the default) leaves out
     /// the maintenance pair, `consolidate` and `forget`, which the shell
     /// serves as `agmem consolidate` and `agmem forget` (#150); `all` lists
@@ -380,6 +386,36 @@ impl EmbedderKind {
     }
 }
 
+/// Execution-provider selector (#139): the clap face of
+/// [`agmem_embed::Accelerator`], so `--help` lists the spellings and a
+/// spawned daemon is started with the same one.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+pub enum AcceleratorKind {
+    /// CoreML where the build and the machine have it, else the CPU.
+    #[default]
+    Auto,
+    /// The CPU provider only — the portable default.
+    Cpu,
+    /// The CoreML provider; refuses to start when it is not available.
+    Coreml,
+}
+
+impl AcceleratorKind {
+    /// The embed crate's view of the same choice.
+    pub fn into_embed(self) -> agmem_embed::Accelerator {
+        match self {
+            Self::Auto => agmem_embed::Accelerator::Auto,
+            Self::Cpu => agmem_embed::Accelerator::Cpu,
+            Self::Coreml => agmem_embed::Accelerator::CoreMl,
+        }
+    }
+
+    /// The spelling `--accelerator` takes, for a spawned daemon's argv.
+    pub fn as_str(self) -> &'static str {
+        self.into_embed().as_str()
+    }
+}
+
 /// Which tools a session serves over MCP (#150).
 ///
 /// Every tool costs an agent context on every turn, and the maintenance pair
@@ -496,6 +532,9 @@ pub struct Config {
     pub db_pass: Option<String>,
     pub space: SpaceName,
     pub embedder: EmbedderKind,
+    /// Where the model runs (#139); process-local like `embedder`, so it
+    /// rides the spawn argv and not the handshake.
+    pub accelerator: AcceleratorKind,
     /// Which tools this session lists and serves — [`ToolGroup::Core`]
     /// unless `AGMEM_TOOLS=all`. Travels the daemon handshake like
     /// `tool_desc`, and the one-shots force `All` for their own session.
@@ -651,6 +690,7 @@ impl Cli {
             db_pass: self.db_pass,
             space,
             embedder: self.embedder,
+            accelerator: self.accelerator,
             tools: self.tools,
             pool: self.pool,
             max_k: self.max_k,

--- a/crates/agmem-server/src/daemon/client.rs
+++ b/crates/agmem-server/src/daemon/client.rs
@@ -389,6 +389,8 @@ fn spawn(cfg: &Config, takeover: Takeover) -> anyhow::Result<Child> {
         .arg(&cfg.db_url)
         .arg("--embedder")
         .arg(cfg.embedder.as_str())
+        .arg("--accelerator")
+        .arg(cfg.accelerator.as_str())
         .arg("--idle-timeout")
         .arg(cfg.idle_timeout.to_string())
         .arg("--log")

--- a/crates/agmem-server/src/daemon/serve.rs
+++ b/crates/agmem-server/src/daemon/serve.rs
@@ -96,6 +96,7 @@ async fn serve(cfg: Config) -> anyhow::Result<()> {
         schema,
         embedder = embedder.model_id(),
         dim = embedder.dim(),
+        accelerator = embedder.accelerator(),
         pruned,
         checks = checks.len(),
         socket = %path.display(),

--- a/crates/agmem-server/src/doctor.rs
+++ b/crates/agmem-server/src/doctor.rs
@@ -122,9 +122,10 @@ async fn check_store(cfg: &Config) -> u32 {
         }
         Ok(embedder) => {
             eprintln!(
-                "  ok    embedder             {} ({}d)",
+                "  ok    embedder             {} ({}d, {})",
                 embedder.model_id(),
-                embedder.dim()
+                embedder.dim(),
+                embedder.accelerator()
             );
             if let Some(db) = &opened {
                 match agmem_store::migrate::ensure_embedder(db, embedder.model_id(), embedder.dim())
@@ -254,9 +255,10 @@ fn embedder_only(cfg: &Config) -> u32 {
         }
         Ok(embedder) => {
             eprintln!(
-                "  ok    embedder             {} ({}d)",
+                "  ok    embedder             {} ({}d, {})",
                 embedder.model_id(),
-                embedder.dim()
+                embedder.dim(),
+                embedder.accelerator()
             );
             0
         }

--- a/crates/agmem-server/src/embedder.rs
+++ b/crates/agmem-server/src/embedder.rs
@@ -15,6 +15,7 @@ pub fn build(cfg: &Config) -> anyhow::Result<Arc<dyn Embedder>> {
     match cfg.embedder {
         EmbedderKind::Fastembed => Ok(Arc::new(agmem_embed::fastembed::FastembedBackend::new(
             Some(model_cache_dir(cfg)),
+            cfg.accelerator.into_embed(),
         )?)),
         EmbedderKind::None => Ok(Arc::new(NoopEmbedder)),
     }

--- a/crates/agmem-server/src/main.rs
+++ b/crates/agmem-server/src/main.rs
@@ -92,6 +92,7 @@ async fn in_process(cfg: config::Config) -> anyhow::Result<()> {
         schema,
         embedder = embedder.model_id(),
         dim = embedder.dim(),
+        accelerator = embedder.accelerator(),
         pruned,
         "store ready"
     );

--- a/crates/agmem-server/src/reindex.rs
+++ b/crates/agmem-server/src/reindex.rs
@@ -63,9 +63,10 @@ pub async fn run(cfg: &Config) -> anyhow::Result<()> {
     // anything is cleared, so a missing model costs nothing.
     let embedder = crate::embedder::build(cfg)?;
     eprintln!(
-        "  ok    embedder             {} ({}d)",
+        "  ok    embedder             {} ({}d, {})",
         embedder.model_id(),
-        embedder.dim()
+        embedder.dim(),
+        embedder.accelerator()
     );
 
     let report = execute(&db, embedder).await?;

--- a/crates/agmem-server/tests/harness/recorded.rs
+++ b/crates/agmem-server/tests/harness/recorded.rs
@@ -168,8 +168,11 @@ fn live() -> Option<&'static agmem_embed::fastembed::FastembedBackend> {
     LIVE.get_or_init(|| {
         std::env::var_os(RECORD_ENV)?;
         let cache = std::env::temp_dir().join("agmem-model-cache");
-        let backend = agmem_embed::fastembed::FastembedBackend::new(Some(cache))
-            .expect("load the real model");
+        let backend = agmem_embed::fastembed::FastembedBackend::new(
+            Some(cache),
+            agmem_embed::Accelerator::Cpu,
+        )
+        .expect("load the real model");
         // The eval recording spells the id as the backend did when it was
         // made; the vectors, not the letter case, are the contract.
         assert_eq!(

--- a/crates/agmem-server/tests/knn_probe.rs
+++ b/crates/agmem-server/tests/knn_probe.rs
@@ -379,7 +379,8 @@ async fn a_store_on_disk_reads_the_same_cold() {
 #[ignore = "loads the real embedding model"]
 async fn a_cold_vector_arm_reads_as_a_warm_one_does() {
     let cache = std::env::temp_dir().join("agmem-model-cache");
-    let embedder = FastembedBackend::new(Some(cache)).expect("load model");
+    let embedder =
+        FastembedBackend::new(Some(cache), agmem_embed::Accelerator::Cpu).expect("load model");
     let directory = tempfile::tempdir().expect("tempdir");
 
     let mut faults: Vec<String> = Vec::new();

--- a/docs/design.md
+++ b/docs/design.md
@@ -1192,6 +1192,7 @@ rather than details:
 | `--db-user`, `--db-pass` / `AGMEM_DB_USER`, `AGMEM_DB_PASS` | none | Root signin for a remote `--db`, as a pair; embedded engines have no signin |
 | `--space` / `AGMEM_SPACE` | derived: git project name, else cwd name, else `default` | Current space for this server instance; an explicit value pins it (#44). Derivation uses the git *common* dir's parent, so every worktree of a repo shares one space, and never lands on the reserved `user` |
 | `--embedder` / `AGMEM_EMBEDDER` | `fastembed` | The local ONNX model, the only supported backend (`none` is a hidden test-only value) |
+| `--accelerator` / `AGMEM_ACCELERATOR` | `auto` | ONNX Runtime execution provider: `cpu`, or `coreml` on a macOS build with `--features coreml` (#139, measured and dropped — `docs/eval/coreml-ep.md`; the feature is off in releases, so `auto` is the CPU everywhere) |
 | `--pool`, `--max-k` / `AGMEM_POOL`, `AGMEM_MAX_K` | 64 / 50 | Retrieval pool and k ceiling |
 | `--tools` / `AGMEM_TOOLS` | `core` | Which tools a session serves: `core` removes `consolidate` and `forget` from the router (neither listed nor callable), `all` serves every tool. Travels the daemon handshake per session; one-shots ask for `all` on their own (#150) |
 | `AGMEM_TOOL_DESC_<TOOL>` | built-in | Override a tool description (steering lever) |

--- a/docs/eval/coreml-ep.md
+++ b/docs/eval/coreml-ep.md
@@ -1,0 +1,156 @@
+# macOS acceleration through the CoreML execution provider (issue #139)
+
+Written before any number was computed. The bar below is the decision; the
+Results section is filled in afterwards and does not move the bar.
+
+## What is being decided
+
+Whether registering ONNX Runtime's CoreML execution provider on the embedding
+session — same graph, same runtime, one more provider ahead of the CPU one —
+buys enough latency or energy on Apple silicon to ship behind a feature.
+Nothing else is on the table: no second inference runtime (llama.cpp, candle,
+MLX), by the user's decision on 2026-09-03, and no change to the portable
+CPU default on any platform.
+
+The provider is already in the binary. pyke's only prebuilt ONNX Runtime for
+`aarch64-apple-darwin` (ort-sys 2.0.0-rc.13, ORT 1.28.0) is the `+coreml`
+build, and it is what every macOS agmem links today. The `coreml` cargo
+feature turns on `ort`'s Rust surface for it; `--accelerator auto|cpu|coreml`
+(`AGMEM_ACCELERATOR`) chooses at start-up, `auto` settling to CoreML only on
+a build with the feature and a machine where the runtime reports it.
+
+## What Core ML can and cannot take
+
+Core ML's MLProgram op set covers MatMul/Gemm, LayerNormalization, Softmax,
+Gelu/Erf — the transformer body — and lacks Gather, Where, Expand, Equal,
+Range, the fused `com.microsoft` attention ops, and every dynamic-quantisation
+op (`MatMulInteger`, `DynamicQuantizeLinear`). Consequences:
+
+- The embedding lookups and the attention-mask path stay on the CPU, so a
+  BERT graph splits into at least 2–3 partitions with a copy at each
+  boundary (onnxruntime#28022: 14 partitions turned 27 ms into 42 ms).
+- **A quantised graph on the CoreML provider is a CPU graph with extra
+  boundaries.** The shipped `bge-small-en-v1.5-q` and the two 768-d `-q` /
+  `-int8` candidates can be *run* under `coreml` — and the row is recorded,
+  because a slowdown there is what a user of the feature would get — but
+  only the fp32 exports (`bge-small-en-v1.5`, `embeddinggemma-300m`,
+  `arctic-embed-m-v2.0`) measure what the accelerator does.
+- The Neural Engine is fp16-only. `ComputeUnits::All` lets Core ML place
+  fp16-safe ops there; EmbeddingGemma's card forbids fp16, so it is a GPU
+  candidate at best.
+- ORT's own level-2/3 fusions produce CPU-only contrib ops; they run after
+  partitioning on the nodes the CPU kept, so they should not steal nodes
+  from Core ML — but onnxruntime#28183 measured a 6× slowdown from exactly
+  such a fusion. fastembed hard-codes `Level3`; if the CoreML rows are slower
+  than the CPU rows on fp32, the first suspect is this, and the check is a
+  direct `ort` session at `Level1` (the shape `candidates.rs` already uses
+  for Qwen3), not a production change.
+
+## The bar
+
+The feature ships enabled in the macOS release, with `auto` as the default,
+only if **both** of these hold, measured on the fp32 export of the shipped
+model's architecture (`bge-small-en-v1.5`) on Apple silicon:
+
+1. **Speed or power.** p50 for one 3-sentence claim on `coreml` ≤ 0.7× the
+   same model's p50 on `cpu`, **or** energy per claim (`powermetrics`,
+   package power over a 60-second loop) ≤ 0.3× the CPU run's.
+2. **Drift.** Cosine between the `coreml` vector and the `cpu` vector ≥
+   0.999 on every text of the eval fixture (`vectors.json`: all passages
+   and queries). fp16 on the Neural Engine is the expected cause of a miss;
+   the fallback is `CPUAndGPU`, re-measured against the same bar.
+
+Fails both halves of 1, or fails 2 with the fallback → the issue closes as
+measured-and-dropped; the feature stays in the tree, off by default, as a
+measurement surface like `candidates`, and the CPU path stays. Passes →
+the release build turns the feature on for `aarch64-apple-darwin` and
+`doctor` prints the active provider (it does already).
+
+Separately recorded, not part of the bar: the same rows for
+`embeddinggemma-300m` and `arctic-embed-m-v2.0`, the two #133 candidates
+that failed only on latency and abstention. If the accelerator brings
+Gemma's 72.6 ms claim under the #133 bar of 60 ms, that is a #138 input,
+not a #139 verdict.
+
+## Method
+
+- `cargo test -p agmem-embed --features candidates,coreml --release --test
+  candidates -- --ignored --nocapture latency` with `AGMEM_CANDIDATE=<id>`
+  and `AGMEM_ACCELERATOR=cpu|coreml`, for the four `-q`/`-int8` ids and the
+  three fp32 ids. Rows go to `docs/eval/embed-models/latency.json`, one per
+  (model, accelerator, shape); a re-run replaces. The fp32 `cpu` rows are the
+  denominators of bar item 1.
+- `cargo test -p agmem-embed --features coreml --release --test fastembed --
+  --ignored --nocapture coreml_vectors_match_cpu` is bar item 2.
+- `agmem --doctor --accelerator coreml` shows the provider load end-to-end.
+- Energy: `sudo powermetrics --samplers cpu_power,gpu_power,ane_power -i 1000
+  -n 60` alongside a 60-second embed loop, once per accelerator; by hand,
+  since it needs root.
+
+## Results
+
+Run on 2026-09-05/06 on an **Apple M1 Pro** (the issue names an M4 Pro; none
+was available), macOS 27, `--release`, ORT 1.28.0 via ort 2.0.0-rc.13 /
+fastembed 6.0.2, CoreML provider as `MLProgram` + `ComputeUnits::All`, ORT
+graph optimisation at fastembed's `Level3`. Rows in
+`docs/eval/embed-models/latency.json`; the CoreML rows for the document
+shape are absent because neither run finished (below).
+
+### Bar item 2 — drift: **pass**
+
+`coreml_vectors_match_cpu` over the 90 fixture texts (80 passages, 10
+queries) of `bge-small-en-v1.5-q`: min cosine 0.999999, mean 1.000000. The
+quantised graph keeps its matmuls on the CPU, so this is the expected
+near-identity rather than evidence about fp16 on the Neural Engine; the fp32
+drift was not measured separately once item 1 had failed.
+
+### Bar item 1 — speed: **fail**
+
+| Model | Shape | cpu p50 | coreml p50 | ratio (bar ≤ 0.7) |
+|---|---|---|---|---|
+| `bge-small-en-v1.5` (fp32) | one claim | 11.9 ms | 22.0 ms | **1.85×** |
+| `bge-small-en-v1.5` (fp32) | 16 claims | 136.0 ms | 306.6 ms | 2.25× |
+| `bge-small-en-v1.5` (fp32) | 60-chunk document | 4850 ms | killed (SIGKILL) | — |
+| `bge-small-en-v1.5-q` (shipped) | one claim | 15.7 ms | 25.3 ms | 1.61× |
+| `bge-small-en-v1.5-q` (shipped) | 16 claims | 127.8 ms | 175.5 ms | 1.37× |
+| `bge-small-en-v1.5-q` (shipped) | 60-chunk document | 3893 ms | killed (SIGKILL) | — |
+
+Load time went from 64 ms to 3.6–5.9 s (the Core ML compile; the model
+cache under `<models>/coreml` did not shorten it on the second run, so the
+cache key ORT wants in the model's metadata is missing from these exports).
+
+The document shape is the finding that matters beyond the bar: on both
+graphs the CoreML session ran past 10 minutes at ~3 GB resident and was
+killed by the system. fastembed pads to the longest row of each batch, so
+the 60 chunks arrive as a fresh input shape, and Core ML re-specialises the
+compiled program per shape; a real `remember` of a long document would hang
+the daemon. `with_static_input_shapes` plus padding to fixed buckets would
+remove that, at the cost of padding every claim to the bucket — and item 1
+already fails on the single-claim shape that would benefit least.
+
+Two incidental observations. On this chip the fp32 `bge-small-en-v1.5` is
+*faster* on the CPU than the shipped int8 export for one claim (11.9 vs
+15.7 ms) and equal at 16, which is a #138-adjacent note, not a #139 result.
+And EmbeddingGemma / arctic were not run: an accelerator that slows the
+architecture it was meant to help has nothing to offer the models that
+failed #133 on latency.
+
+### Not measured
+
+Energy (`powermetrics`) needs root and was not run. It is the one half of
+bar item 1 that could still pass; the reopen condition below covers it.
+
+### Verdict
+
+**Measured and dropped.** The `coreml` feature stays in the tree, off by
+default, as a measurement surface like `candidates`; `--accelerator` keeps
+its three spellings so the switch is one flag when the runtime changes.
+Nothing in a release build changes. Reopen when one of these holds:
+
+- ONNX Runtime's CoreML provider gains the ops that keep BERT's embedding
+  and mask path on the CPU (Gather, Where, Expand, Equal), or a
+  Core-ML-native export of the model exists for a runtime agmem already
+  links.
+- A `powermetrics` run on Apple silicon shows package energy per claim
+  under 0.3× the CPU run *and* a static-shape session with bucketed padding
+  stops the document-shape hang.

--- a/docs/eval/embed-models/latency.json
+++ b/docs/eval/embed-models/latency.json
@@ -97,5 +97,82 @@
     "p95_ms": 3923.6,
     "profile": "release",
     "shape": "document-60-chunks"
+  },
+  {
+    "accelerator": "cpu",
+    "chip": "Apple M1 Pro",
+    "load_ms": 23774.0,
+    "measured_at": "2026-09-05T22:09Z",
+    "model": "bge-small-en-v1.5",
+    "p50_ms": 11.9,
+    "p95_ms": 14.4,
+    "profile": "release",
+    "shape": "claim"
+  },
+  {
+    "accelerator": "cpu",
+    "chip": "Apple M1 Pro",
+    "load_ms": 23774.0,
+    "measured_at": "2026-09-05T22:09Z",
+    "model": "bge-small-en-v1.5",
+    "p50_ms": 136.0,
+    "p95_ms": 141.4,
+    "profile": "release",
+    "shape": "claims-16"
+  },
+  {
+    "accelerator": "cpu",
+    "chip": "Apple M1 Pro",
+    "load_ms": 23774.0,
+    "measured_at": "2026-09-05T22:11Z",
+    "model": "bge-small-en-v1.5",
+    "p50_ms": 4850.4,
+    "p95_ms": 5307.6,
+    "profile": "release",
+    "shape": "document-60-chunks"
+  },
+  {
+    "model": "bge-small-en-v1.5-q",
+    "accelerator": "coreml",
+    "shape": "claim",
+    "p50_ms": 25.3,
+    "p95_ms": 26.6,
+    "load_ms": 3587.0,
+    "chip": "Apple M1 Pro",
+    "profile": "release",
+    "measured_at": "2026-09-06T00:00"
+  },
+  {
+    "model": "bge-small-en-v1.5-q",
+    "accelerator": "coreml",
+    "shape": "claims-16",
+    "p50_ms": 175.5,
+    "p95_ms": 182.0,
+    "load_ms": 3587.0,
+    "chip": "Apple M1 Pro",
+    "profile": "release",
+    "measured_at": "2026-09-06T00:00"
+  },
+  {
+    "model": "bge-small-en-v1.5",
+    "accelerator": "coreml",
+    "shape": "claim",
+    "p50_ms": 22.0,
+    "p95_ms": 24.2,
+    "load_ms": 5923.0,
+    "chip": "Apple M1 Pro",
+    "profile": "release",
+    "measured_at": "2026-09-06T00:00"
+  },
+  {
+    "model": "bge-small-en-v1.5",
+    "accelerator": "coreml",
+    "shape": "claims-16",
+    "p50_ms": 306.6,
+    "p95_ms": 313.5,
+    "load_ms": 5923.0,
+    "chip": "Apple M1 Pro",
+    "profile": "release",
+    "measured_at": "2026-09-06T00:00"
   }
 ]

--- a/scripts/embed-candidates-fetch.nu
+++ b/scripts/embed-candidates-fetch.nu
@@ -13,11 +13,12 @@
 #     nu scripts/embed-candidates-fetch.nu --cache /tmp/agmem-model-cache
 #
 # Idempotent: a file already present with a non-zero size is skipped. About
-# 950 MB in total. Set HF_TOKEN for a gated repo.
+# 2.2 GB in total — arctic's fp32 `onnx/model.onnx` (#139, the CoreML
+# measurement) is the largest. Set HF_TOKEN for a gated repo.
 
 const REPOS = [
     [repo, files];
-    ["Snowflake/snowflake-arctic-embed-m-v2.0" ["onnx/model_int8.onnx" "tokenizer.json" "config.json" "special_tokens_map.json" "tokenizer_config.json"]]
+    ["Snowflake/snowflake-arctic-embed-m-v2.0" ["onnx/model_int8.onnx" "onnx/model.onnx" "tokenizer.json" "config.json" "special_tokens_map.json" "tokenizer_config.json"]]
     ["onnx-community/Qwen3-Embedding-0.6B-ONNX" ["onnx/model_int8.onnx" "tokenizer.json" "config.json" "special_tokens_map.json" "tokenizer_config.json"]]
 ]
 


### PR DESCRIPTION
Closes #139 as measured-and-dropped. The record with the bar, the method and every number: `docs/eval/coreml-ep.md`.

## What was measured

pyke's only prebuilt ONNX Runtime for `aarch64-apple-darwin` is the `+coreml` build, so the provider was already in every macOS binary; this adds the Rust surface (`--features coreml`) and a switch (`--accelerator auto|cpu|coreml`, `AGMEM_ACCELERATOR`), then measures it on an Apple M1 Pro:

| Model | Shape | cpu p50 | coreml p50 | ratio (bar ≤ 0.7) |
|---|---|---|---|---|
| bge-small-en-v1.5 (fp32) | one claim | 11.9 ms | 22.0 ms | **1.85×** |
| bge-small-en-v1.5 (fp32) | 16 claims | 136.0 ms | 306.6 ms | 2.25× |
| bge-small-en-v1.5 (fp32) | 60-chunk document | 4.85 s | killed after 10 min at ~3 GB | — |
| bge-small-en-v1.5-q (shipped) | one claim | 15.7 ms | 25.3 ms | 1.61× |
| bge-small-en-v1.5-q (shipped) | 16 claims | 127.8 ms | 175.5 ms | 1.37× |

Drift passes (min cosine 0.999999 over the 90 fixture texts). Energy (`powermetrics`, needs root) was not measured; it is the one half of the bar left open and is the reopen condition in the doc, together with a static-shape session for the document hang.

## What ships

Nothing in a release build changes behaviour: the feature is off, and `auto` resolves to the CPU without it.

- `crates/agmem-embed/src/accelerator.rs` — `Accelerator {Auto,Cpu,CoreMl}` → `Active`, the CoreML EP (`MLProgram`, all compute units, compiled-model cache under `<models>/coreml`).
- `Embedder::accelerator()`; `FastembedBackend::new(cache, accelerator)`; `doctor`, `--reindex` and the startup log print `(<dim>d, <accelerator>)`.
- `AcceleratorKind` in `config.rs`, forwarded on the daemon spawn argv.
- Candidate probe: fp32 exports `bge-small-en-v1.5`, `embeddinggemma-300m`, `arctic-embed-m-v2.0`; every loader takes the provider; the fetch script pulls arctic's `onnx/model.onnx`.
- Ignored `coreml_vectors_match_cpu` (bar 0.999); CI clippy with `--features coreml` on the macOS runner, model never run.

## Incidental

On the M1 Pro the fp32 bge-small is faster on the CPU than the shipped int8 export for one claim (11.9 vs 15.7 ms) and equal at sixteen. A #138 note, not a #139 result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018chPKULzdrM3hh9VqTRjne
