### PR TITLE
chore: release v0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
   "owner": { "name": "Mate Alfoldi" },
   "metadata": {
     "description": "agmem — persistent memory for coding agents over MCP",
-    "version": "0.2.1"
+    "version": "0.3.0"
   },
   "plugins": [
     {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "blake3",
  "jiff",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-embed"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "agmem-core",
  "fastembed",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-server"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "agmem-core",
  "agmem-embed",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-store"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "agmem-core",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -21,9 +21,9 @@ homepage = "https://github.com/AlfoldiMate/agmem"
 # dependency with no version requirement. Local builds resolve by path either
 # way, and a caret requirement stays satisfied across the bumps release-plz
 # makes.
-agmem-core = { path = "crates/agmem-core", version = "0.2.1" }
-agmem-store = { path = "crates/agmem-store", version = "0.2.1" }
-agmem-embed = { path = "crates/agmem-embed", version = "0.2.1" }
+agmem-core = { path = "crates/agmem-core", version = "0.3.0" }
+agmem-store = { path = "crates/agmem-store", version = "0.3.0" }
+agmem-embed = { path = "crates/agmem-embed", version = "0.3.0" }
 
 # MCP + storage + embeddings (pinned per docs/design.md §4.1)
 rmcp = { version = "3.1", features = ["server", "macros", "transport-io"] }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "agmem",
   "displayName": "agmem memory",
   "description": "Persistent cross-session memory for Claude Code: the agmem MCP server, a briefing injected at every session start, checkpoint and tidy commands, and hooks that log what memory was used so the store can learn what helped.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": { "name": "Mate Alfoldi" },
   "homepage": "https://github.com/AlfoldiMate/agmem",
   "repository": "https://github.com/AlfoldiMate/agmem",


### PR DESCRIPTION



## 🤖 New release

* `agmem-core`: 0.2.1 -> 0.3.0
* `agmem-store`: 0.2.1 -> 0.3.0 (✓ API compatible changes)
* `agmem-embed`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `agmem-server`: 0.2.1 -> 0.3.0 (✓ API compatible changes)

### ⚠ `agmem-embed` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/method_parameter_count_changed.ron

Failed in:
  agmem_embed::fastembed::FastembedBackend::new takes 1 parameters in /tmp/release-plz-agmem-core-54jKJe/worktree/target/package/agmem-embed-0.2.1/src/fastembed.rs:59, but now takes 2 parameters in /tmp/.tmpb4GB3b/agmem/crates/agmem-embed/src/fastembed.rs:67
```

<details><summary><i><b>Changelog</b></i></summary><p>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).