### PR TITLE
chore: release v0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
   "owner": { "name": "Mate Alfoldi" },
   "metadata": {
     "description": "agmem — persistent memory for coding agents over MCP",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "jiff",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-embed"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "agmem-core",
  "fastembed",
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "agmem-core",
  "agmem-embed",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-store"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "agmem-core",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -21,9 +21,9 @@ homepage = "https://github.com/AlfoldiMate/agmem"
 # dependency with no version requirement. Local builds resolve by path either
 # way, and a caret requirement stays satisfied across the bumps release-plz
 # makes.
-agmem-core = { path = "crates/agmem-core", version = "0.3.0" }
-agmem-store = { path = "crates/agmem-store", version = "0.3.0" }
-agmem-embed = { path = "crates/agmem-embed", version = "0.3.0" }
+agmem-core = { path = "crates/agmem-core", version = "0.4.0" }
+agmem-store = { path = "crates/agmem-store", version = "0.4.0" }
+agmem-embed = { path = "crates/agmem-embed", version = "0.4.0" }
 
 # MCP + storage + embeddings (pinned per docs/design.md §4.1)
 rmcp = { version = "3.1", features = ["server", "macros", "transport-io"] }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "agmem",
   "displayName": "agmem memory",
   "description": "Persistent cross-session memory for Claude Code: the agmem MCP server, a briefing injected at every session start, checkpoint and tidy commands, and hooks that log what memory was used so the store can learn what helped.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": { "name": "Mate Alfoldi" },
   "homepage": "https://github.com/AlfoldiMate/agmem",
   "repository": "https://github.com/AlfoldiMate/agmem",


### PR DESCRIPTION



## 🤖 New release

* `agmem-core`: 0.3.0 -> 0.4.0
* `agmem-store`: 0.3.0 -> 0.4.0
* `agmem-embed`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `agmem-server`: 0.3.0 -> 0.4.0

### ⚠ `agmem-embed` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_added.ron

Failed in:
  variant Active:Metal in /tmp/.tmpdNCvmg/agmem/crates/agmem-embed/src/accelerator.rs:108
  variant Active:Metal in /tmp/.tmpdNCvmg/agmem/crates/agmem-embed/src/accelerator.rs:108
  variant Candidate:BgeSmallGgufF16 in /tmp/.tmpdNCvmg/agmem/crates/agmem-embed/src/candidates.rs:79
  variant Candidate:BgeSmallGgufQ8 in /tmp/.tmpdNCvmg/agmem/crates/agmem-embed/src/candidates.rs:82
  variant Candidate:Gemma300MGgufF16 in /tmp/.tmpdNCvmg/agmem/crates/agmem-embed/src/candidates.rs:85
  variant Candidate:Gemma300MGgufQ8 in /tmp/.tmpdNCvmg/agmem/crates/agmem-embed/src/candidates.rs:88
  variant Accelerator:Metal in /tmp/.tmpdNCvmg/agmem/crates/agmem-embed/src/accelerator.rs:34
  variant Accelerator:Metal in /tmp/.tmpdNCvmg/agmem/crates/agmem-embed/src/accelerator.rs:34
```

<details><summary><i><b>Changelog</b></i></summary><p>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).