### PR TITLE
Model change as a migration: the configured model wins, a mismatched store is moved on open and re-embedded in the background, agmem reindex does it now (#138)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Every flag has an environment variable. `agmem --help` has the exact spellings.
 | `--db` / `AGMEM_DB` | `surrealkv://<data>/agmem.db` | Engine. `mem://` for scratch, `ws://host` to share |
 | `--space` / `AGMEM_SPACE` | derived from cwd | This instance's space |
 | `--embedder` / `AGMEM_EMBEDDER` | `llama` | The local llama.cpp runtime, the only backend |
-| `--model` / `AGMEM_MODEL` | `embeddinggemma-300m` | Or `bge-small-en-v1.5`, the light option. Changing it on a store with vectors needs `--reindex` |
+| `--model` / `AGMEM_MODEL` | `embeddinggemma-300m` | Or `bge-small-en-v1.5`, the light option. The configured model wins: a store holding another model's vectors is moved on open and re-embedded in the background |
 | `--accelerator` / `AGMEM_ACCELERATOR` | `auto` | `metal` on Apple silicon, `cpu` anywhere, or to opt out |
 | `--pool` / `AGMEM_POOL` | 64 | Candidate pool before rescoring |
 | `--max-k` / `AGMEM_MAX_K` | 50 | Ceiling for `recall`'s `k` |
@@ -345,7 +345,7 @@ Every flag has an environment variable. `agmem --help` has the exact spellings.
 | `AGMEM_TOOL_DESC_<TOOL>` | built-in wording | Replace one tool's description, per server, no rebuild |
 | `AGMEM_MODEL_DIR` | `<data>/models` | Where the model weights live |
 | `--doctor` | | Self-check, then exit. Counts documents per space |
-| `--reindex` | | Re-embed every row under the configured embedder. The one way to change models |
+| `reindex` subcommand | | Re-embed every row now, with no session attached; `--model` picks the target for this run. Refuses while a daemon serves the store |
 
 A tool description is most of what decides whether an agent reaches for
 memory. `AGMEM_TOOL_DESC_RECALL` and friends replace one outright, and
@@ -369,10 +369,15 @@ effect of the built-in wording and the harness that measures it.
   Hugging Face into `<data dir>/models`. Behind a proxy, copy that directory
   from a machine that has it, or point `AGMEM_MODEL_DIR` at one that does.
   `--model bge-small-en-v1.5` is 36 MB.
-- **A different model.** A store written with one model refuses to open under
-  a different one; `--reindex` converts it. Stores from before v0.3 were
-  embedded with bge on ONNX Runtime and need `--reindex` once. There is no
-  model-less mode: recall is BM25 *and* vectors.
+- **A different model.** The configured model wins. A store written with
+  another model — every store from before v0.3, which holds bge on ONNX
+  Runtime — is moved on the next start: vectors cleared, indexes resized,
+  and the rows re-embedded in the background while the store already
+  serves. Until the last row is done, every tool result ends with a line
+  saying how many are left; recall sees them through BM25 meanwhile. To do
+  it in one sitting instead, `agmem reindex` (with `--model` to pick the
+  target) — it needs the store to itself, so end the sessions first. There
+  is no model-less mode: recall is BM25 *and* vectors.
 - **Starting over.** Delete the data directory. Keep `models/` to skip the
   download.
 

--- a/crates/agmem-embed/src/lib.rs
+++ b/crates/agmem-embed/src/lib.rs
@@ -46,6 +46,15 @@ pub trait Embedder: Send + Sync + 'static {
     /// silently mix vector spaces.
     fn model_id(&self) -> &str;
 
+    /// The exact weights behind [`Self::model_id`] — the pinned hub commit
+    /// for a GGUF model — recorded beside the id (issue #138) so that a
+    /// release moving the pin reads as a vector-space change. `None` for a
+    /// backend whose weights have no such identity (test doubles); the
+    /// store then keys on the id and the width alone.
+    fn revision(&self) -> Option<&str> {
+        None
+    }
+
     /// The cosine bands this backend's vectors are read against: the write
     /// gate, the correction band, the cluster bar and the abstention floor
     /// are all model-specific numbers (issue #138), and the tools take them

--- a/crates/agmem-embed/src/llama.rs
+++ b/crates/agmem-embed/src/llama.rs
@@ -213,6 +213,10 @@ impl Embedder for LlamaEmbedder {
         self.spec.id
     }
 
+    fn revision(&self) -> Option<&str> {
+        Some(self.spec.revision())
+    }
+
     fn thresholds(&self) -> Thresholds {
         self.spec.thresholds
     }

--- a/crates/agmem-embed/src/model.rs
+++ b/crates/agmem-embed/src/model.rs
@@ -25,6 +25,12 @@ pub enum Source {
         repo: &'static str,
         /// The file inside it.
         file: &'static str,
+        /// The repo commit the file is fetched at. Pinned so that the
+        /// weights behind an id are one set of bytes: a store records this
+        /// beside the id (issue #138), and a release that moves the pin is
+        /// then a vector-space change the store can see, instead of a
+        /// silent drift between what was embedded and what embeds queries.
+        revision: &'static str,
     },
 }
 
@@ -43,7 +49,8 @@ pub struct ModelSpec {
     /// What the store records in `meta.embedder_model`. Names the weights
     /// *and* their quantisation: a Q8_0 GGUF and an int8 ONNX export of the
     /// same model embed into spaces that agree to four decimals, and that is
-    /// still two spaces.
+    /// still two spaces. The prefixes and the pooling are properties of the
+    /// id too — a change to either is a new id, not a new field.
     pub id: &'static str,
     /// Vector width; what the store defines its HNSW indexes with.
     pub dim: usize,
@@ -57,6 +64,16 @@ pub struct ModelSpec {
     pub thresholds: Thresholds,
     /// Where the weights come from.
     pub source: Source,
+}
+
+impl ModelSpec {
+    /// The exact weights behind [`Self::id`]: the source's pinned revision.
+    /// Recorded in `meta.embedder_revision` next to the id and the width.
+    #[must_use]
+    pub fn revision(&self) -> &'static str {
+        let Source::Gguf { revision, .. } = self.source;
+        revision
+    }
 }
 
 /// The models `--model` can name.
@@ -95,6 +112,17 @@ impl Model {
         }
     }
 
+    /// The model whose spec carries `id` — what a store's
+    /// `meta.embedder_model` names, if this binary can still run it. `None`
+    /// for a retired id such as the pre-v0.3 `bge-small-en-v1.5-q` (bge on
+    /// ONNX Runtime), which no release since can load.
+    #[must_use]
+    pub fn from_id(id: &str) -> Option<Self> {
+        [Self::Gemma300M, Self::BgeSmall]
+            .into_iter()
+            .find(|model| model.spec().id == id)
+    }
+
     /// Everything true of this model.
     #[must_use]
     pub fn spec(self) -> ModelSpec {
@@ -114,6 +142,7 @@ impl Model {
                 source: Source::Gguf {
                     repo: "ggml-org/embeddinggemma-300M-GGUF",
                     file: "embeddinggemma-300M-Q8_0.gguf",
+                    revision: "0f741b5a6585bd53aeb15cd1372c56f2a0f65e12",
                 },
             },
             Self::BgeSmall => ModelSpec {
@@ -126,6 +155,7 @@ impl Model {
                 source: Source::Gguf {
                     repo: "CompendiumLabs/bge-small-en-v1.5-gguf",
                     file: "bge-small-en-v1.5-q8_0.gguf",
+                    revision: "d32f8c040ea3b516330eeb75b72bcc2d3a780ab7",
                 },
             },
         }
@@ -163,14 +193,20 @@ pub fn model_dir(fallback: Option<PathBuf>) -> PathBuf {
 ///
 /// The Hugging Face cache layout is kept (`models--owner--name/snapshots/
 /// <commit>/<file>`): a second agmem, or any other tool using the hub
-/// cache, then shares the download instead of repeating it, and the commit
-/// in the path is the revision a later store check can record.
+/// cache, then shares the download instead of repeating it. The commit is
+/// the spec's pinned revision, never the repo's head, so two machines that
+/// fetched on different days hold the same bytes.
 ///
 /// # Errors
 /// [`EmbedError::Backend`] when the file is not there and cannot be
-/// fetched — no network, an unwritable dir, a repo that moved.
+/// fetched — no network, an unwritable dir, a repo that moved or was
+/// force-pushed over the pinned commit.
 pub fn fetch(spec: &ModelSpec, model_dir: &Path) -> Result<PathBuf, EmbedError> {
-    let Source::Gguf { repo, file } = spec.source;
+    let Source::Gguf {
+        repo,
+        file,
+        revision,
+    } = spec.source;
     let failed = |message: String| EmbedError::Backend {
         backend: spec.id,
         message,
@@ -181,9 +217,14 @@ pub fn fetch(spec: &ModelSpec, model_dir: &Path) -> Result<PathBuf, EmbedError> 
         .with_progress(false)
         .build()
         .map_err(|e| failed(format!("hub client: {e}")))?;
-    api.model(repo.to_owned()).get(file).map_err(|e| {
+    let pinned = hf_hub::Repo::with_revision(
+        repo.to_owned(),
+        hf_hub::RepoType::Model,
+        revision.to_owned(),
+    );
+    api.repo(pinned).get(file).map_err(|e| {
         failed(format!(
-            "fetch {repo}/{file} into {}: {e}",
+            "fetch {repo}/{file} at {revision} into {}: {e}",
             model_dir.display()
         ))
     })
@@ -197,11 +238,17 @@ mod tests {
     fn spellings_round_trip() {
         for model in [Model::Gemma300M, Model::BgeSmall] {
             assert_eq!(Model::parse(model.as_str()), Some(model));
+            assert_eq!(Model::from_id(model.spec().id), Some(model));
         }
         assert_eq!(
             Model::parse("bge-small-en-v1.5-q8_0"),
             None,
             "ids are not spellings"
+        );
+        assert_eq!(
+            Model::from_id("bge-small-en-v1.5-q"),
+            None,
+            "the pre-v0.3 ONNX id is retired: no model here runs it"
         );
     }
 
@@ -214,8 +261,13 @@ mod tests {
             assert!(spec.dim > 0);
             assert!(spec.passage_prefix.ends_with(' '));
             assert!(spec.query_prefix.ends_with(' '));
-            let Source::Gguf { file, .. } = spec.source;
+            let Source::Gguf { file, revision, .. } = spec.source;
             assert!(file.ends_with(".gguf"));
+            assert_eq!(spec.revision(), revision);
+            assert!(
+                revision.len() == 40 && revision.bytes().all(|b| b.is_ascii_hexdigit()),
+                "a pin is a full commit hash, not a branch name: {revision}"
+            );
         }
     }
 

--- a/crates/agmem-server/src/config.rs
+++ b/crates/agmem-server/src/config.rs
@@ -56,8 +56,9 @@ pub struct Cli {
     #[arg(long, env = "AGMEM_EMBEDDER", value_enum, default_value_t = EmbedderKind::Llama)]
     pub embedder: EmbedderKind,
 
-    /// Embedding model. Changing it on a store that holds vectors is a
-    /// migration (`--reindex`); a mismatch refuses to start.
+    /// Embedding model. The configured model wins: a store holding another
+    /// model's vectors is moved on open and re-embedded in the background
+    /// (issue #138); `agmem reindex` does the same in one sitting.
     #[arg(long, env = "AGMEM_MODEL", value_enum, default_value_t = ModelKind::Embeddinggemma300m)]
     pub model: ModelKind,
 
@@ -99,11 +100,11 @@ pub struct Cli {
     #[arg(long)]
     pub doctor: bool,
 
-    /// Re-embed the store with the configured backend and exit — the
-    /// sanctioned way to change embedding model or width. No env var: a
-    /// maintenance pass that rewrites every vector should not be switchable
-    /// by a stray export.
-    #[arg(long)]
+    /// The spelling `agmem reindex` replaced (v0.3.1). Kept one release so
+    /// a script or a doctor line from before still runs; hidden so nobody
+    /// learns it. No env var: a maintenance pass that rewrites every vector
+    /// should not be switchable by a stray export.
+    #[arg(long, hide = true)]
     pub reindex: bool,
 
     /// Open the store in this process instead of through the shared daemon.
@@ -167,6 +168,23 @@ pub enum CliCommand {
     /// `forget` tool from the shell; by-query forgetting stays on MCP, where
     /// a dry run can be held against the call that follows it.
     Forget(ForgetArgs),
+
+    /// Re-embed every row under the configured model — or under `--model`
+    /// for this run — and exit. What the server does in the background
+    /// after a model change, done now, in one sitting, with no session
+    /// attached. Needs the store to itself: refuses while a daemon serves.
+    Reindex(ReindexArgs),
+}
+
+/// What `agmem reindex` takes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Args)]
+pub struct ReindexArgs {
+    /// The model to move the store to, for this run. Without it the
+    /// configured model (`--model` / `AGMEM_MODEL`) is the target, which
+    /// makes a bare `agmem reindex` the way to finish an interrupted
+    /// background re-embed.
+    #[arg(long, value_enum)]
+    pub model: Option<ModelKind>,
 }
 
 /// What `agmem consolidate` passes to `consolidate`.

--- a/crates/agmem-server/src/daemon/serve.rs
+++ b/crates/agmem-server/src/daemon/serve.rs
@@ -20,7 +20,8 @@ use tokio::time::Instant;
 use crate::config::Config;
 use crate::daemon::{Ack, Handshake, Refusal, socket_path};
 use crate::service::AgmemService;
-use crate::{doctor, embedder, lock};
+use crate::startup::{self, VectorState};
+use crate::{doctor, lock, reindex};
 
 /// How long a retiring daemon keeps serving the sessions already attached
 /// before it exits (issue #112). Long enough for a tool call in flight to
@@ -60,17 +61,21 @@ async fn serve(cfg: Config) -> anyhow::Result<()> {
     let path = socket_path(&cfg.data_dir)?;
     // The lock is what makes "one owner" true; the socket only advertises it.
     // Holding it here is also what makes the unlink below safe — no other
-    // daemon can be alive to have the socket we are about to replace.
+    // daemon can be alive to have the socket we are about to replace. A
+    // daemon is embedded by definition (`daemon::wanted`), so the lock is
+    // taken unconditionally here rather than through `startup::open`'s
+    // remote-engine exception.
     let _lock = lock::acquire(&cfg.data_dir)?;
     restrict(&cfg.data_dir);
 
-    let db = agmem_store::db::connect_with(&cfg.db_url, cfg.db_credentials()).await?;
-    let schema = agmem_store::migrate::ensure(&db).await?;
-    let embedder = embedder::build(&cfg)?;
-    agmem_store::migrate::ensure_embedder(&db, embedder.model_id(), embedder.dim()).await?;
-    // A daemon is where the sweep belongs: it is the process a machine starts
-    // once, and the sessions attaching to it never start anything.
-    let pruned = crate::startup::prune(&db).await;
+    let startup::Opened {
+        db,
+        embedder,
+        vectors,
+        schema,
+        pruned,
+        lock: _,
+    } = startup::open_locked(&cfg).await?;
     // The checks `--doctor` cannot run while a daemon holds the store, run by
     // the process that holds it (issue #112). They go to the log, not to the
     // exit code: the schema and the embedder are up, so the store can serve,
@@ -98,10 +103,22 @@ async fn serve(cfg: Config) -> anyhow::Result<()> {
         dim = embedder.dim(),
         accelerator = embedder.accelerator(),
         pruned,
+        pending = vectors.pending(),
         checks = checks.len(),
         socket = %path.display(),
         "shared store ready"
     );
+    // The daemon holds the store, so the daemon finishes its vectors (issue
+    // #138): a store moved to the configured model on open, or left with
+    // rows to embed by an earlier interruption, is drained here while every
+    // session it serves watches the count go down.
+    if vectors.pending() > 0 {
+        tokio::spawn(reindex::drain(
+            db.clone(),
+            Arc::clone(&embedder),
+            vectors.clone(),
+        ));
+    }
     if cfg.took_over {
         // The sessions that were on the old daemon are pumping a closed
         // socket: their memory tools are gone until they start again. This
@@ -129,10 +146,15 @@ async fn serve(cfg: Config) -> anyhow::Result<()> {
         tokio::select! {
             accepted = accept_on(listener.as_ref()), if listener.is_some() => {
                 let (stream, _) = accepted.context("accepting on the agmem socket")?;
-                let (db, embedder, daemon, retiring) =
-                    (db.clone(), Arc::clone(&embedder), Arc::clone(&daemon), Arc::clone(&retiring));
+                let (db, embedder, vectors, daemon, retiring) = (
+                    db.clone(),
+                    Arc::clone(&embedder),
+                    vectors.clone(),
+                    Arc::clone(&daemon),
+                    Arc::clone(&retiring),
+                );
                 sessions.spawn(async move {
-                    match session(stream, db, embedder, &daemon, &retiring).await {
+                    match session(stream, db, embedder, vectors, &daemon, &retiring).await {
                         Ok(end) => end,
                         Err(error) => {
                             tracing::warn!(error = %format!("{error:#}"), "session ended badly");
@@ -306,6 +328,7 @@ async fn session(
     stream: UnixStream,
     db: Db,
     embedder: Arc<dyn Embedder>,
+    vectors: VectorState,
     daemon: &Config,
     retiring: &AtomicBool,
 ) -> anyhow::Result<SessionEnd> {
@@ -368,7 +391,7 @@ async fn session(
         tools: asked.tools,
         ..daemon.clone()
     };
-    let service = AgmemService::new(db, embedder, Arc::new(session));
+    let service = AgmemService::new(db, embedder, Arc::new(session), vectors);
 
     // rmcp gets the *buffered* reader, not the raw half. `read_line` reads
     // ahead, so a client that put `initialize` in the same write as the

--- a/crates/agmem-server/src/doctor.rs
+++ b/crates/agmem-server/src/doctor.rs
@@ -122,16 +122,12 @@ async fn check_store(cfg: &Config) -> u32 {
         }
         Ok(embedder) => {
             eprintln!(
-                "  ok    embedder             {} ({}d, {})",
-                embedder.model_id(),
-                embedder.dim(),
-                embedder.accelerator()
+                "  ok    embedder             {}",
+                describe(embedder.as_ref())
             );
             if let Some(db) = &opened {
-                match agmem_store::migrate::ensure_embedder(db, embedder.model_id(), embedder.dim())
-                    .await
-                {
-                    Ok(()) => eprintln!("  ok    embedder vs store    same model and width"),
+                match embedder_vs_store(db, embedder.as_ref()).await {
+                    Ok(detail) => eprintln!("  ok    embedder vs store    {detail}"),
                     Err(err) => {
                         failures += 1;
                         eprintln!("  FAIL  embedder vs store    {err}");
@@ -148,15 +144,66 @@ async fn check_store(cfg: &Config) -> u32 {
     failures
 }
 
+/// `<id> (<dim>d, <accelerator>, rev <short>)` — the embedder line.
+fn describe(embedder: &dyn Embedder) -> String {
+    format!(
+        "{} ({}d, {}{})",
+        embedder.model_id(),
+        embedder.dim(),
+        embedder.accelerator(),
+        embedder
+            .revision()
+            .map(|rev| format!(", rev {}", agmem_store::error::short_revision(rev)))
+            .unwrap_or_default()
+    )
+}
+
+/// Whether the store's recorded vector space is the configured model's, and
+/// what the next start will do about it if not (issue #138).
+///
+/// Never a failure on its own: the configured model wins, so a store that
+/// holds another model's vectors is not broken, it is scheduled — the next
+/// start moves it and re-embeds in the background. Only the engine refusing
+/// to answer is a FAIL.
+async fn embedder_vs_store(db: &Db, embedder: &dyn Embedder) -> Result<String, String> {
+    let stored = agmem_store::migrate::stored_embedder(db)
+        .await
+        .map_err(|err| err.to_string())?;
+    Ok(match stored {
+        None => format!(
+            "nothing recorded yet; the first start records {}",
+            embedder.model_id()
+        ),
+        Some(stored)
+            if stored.matches(embedder.model_id(), embedder.dim(), embedder.revision()) =>
+        {
+            "agrees".to_owned()
+        }
+        Some(stored) => format!(
+            "store holds {} ({}d{}); the next start moves it to {} ({}d) and re-embeds every \
+             row in the background — or run `agmem reindex` now",
+            stored.model,
+            stored.dim,
+            stored
+                .revision
+                .as_deref()
+                .map(|rev| format!(", rev {}", agmem_store::error::short_revision(rev)))
+                .unwrap_or_default(),
+            embedder.model_id(),
+            embedder.dim()
+        ),
+    })
+}
+
 /// Rows the vector half of retrieval cannot reach.
 ///
-/// A `--reindex` killed between its reset and the end of its embed loop
-/// leaves exactly this: rows with no vector, under a `meta` that already
-/// names the new model — so the guard above is satisfied and a vector recall
-/// silently misses them. Nothing else notices, which is why this is a check
-/// and not a log line. Rows written in BM25-only mode look identical and have
-/// the same remedy, so the message names it rather than guessing which
-/// happened.
+/// A re-embed interrupted between its reset and the end of its loop leaves
+/// exactly this: rows with no vector, under a `meta` that already names the
+/// new model — so the guard above is satisfied and a vector recall silently
+/// misses them. Rows written in BM25-only mode look identical. Neither is a
+/// failure since #138: the next start finishes them in the background, and
+/// every tool result says so until then. The line still names the count,
+/// because it is the one number that says whether recall is whole.
 async fn check_vector_coverage(db: &Db) -> u32 {
     match vector_coverage(db).await {
         Ok(detail) => {
@@ -174,9 +221,9 @@ async fn check_vector_coverage(db: &Db) -> u32 {
 async fn vector_coverage(db: &Db) -> Result<String, String> {
     match agmem_store::repo::reindex::pending_count(db).await {
         Ok(0) => Ok("every row carries a vector".to_owned()),
-        Ok(pending) => Err(format!(
-            "{pending} row(s) carry no vector, so a vector recall cannot reach them; run \
-             `agmem --reindex`"
+        Ok(pending) => Ok(format!(
+            "{pending} row(s) still to embed; the next start finishes them in the background, \
+             or run `agmem reindex` now"
         )),
         Err(err) => Err(err.to_string()),
     }
@@ -255,10 +302,8 @@ fn embedder_only(cfg: &Config) -> u32 {
         }
         Ok(embedder) => {
             eprintln!(
-                "  ok    embedder             {} ({}d, {})",
-                embedder.model_id(),
-                embedder.dim(),
-                embedder.accelerator()
+                "  ok    embedder             {}",
+                describe(embedder.as_ref())
             );
             0
         }

--- a/crates/agmem-server/src/main.rs
+++ b/crates/agmem-server/src/main.rs
@@ -19,9 +19,7 @@ use std::sync::Arc;
 #[cfg(unix)]
 use agmem_server::daemon;
 use agmem_server::service::{self, AgmemService};
-use agmem_server::{
-    config, doc, doctor, embedder, hook, lock, oneshot, reindex, startup, telemetry,
-};
+use agmem_server::{config, doc, doctor, hook, oneshot, reindex, startup, telemetry};
 use clap::Parser;
 
 #[tokio::main]
@@ -41,14 +39,15 @@ async fn main() -> anyhow::Result<()> {
 
     // Before the daemon branch: reindexing rewrites every vector in the
     // store, which is the one thing that must not be handed to a process
-    // already serving sessions from it.
+    // already serving sessions from it. `--reindex` is the old spelling.
     if cfg.reindex {
-        return reindex::run(&cfg).await;
+        return reindex::run(&cfg, config::ReindexArgs::default()).await;
     }
 
     // One-shot subcommands print their answer and exit. They route through
     // the daemon the way a session would (or open the store where a session
-    // would), so they never contend with a running daemon for the store.
+    // would), so they never contend with a running daemon for the store —
+    // except `reindex`, which refuses to run while one is up.
     match cfg.command.clone() {
         Some(config::CliCommand::Context(args)) => return oneshot::context(cfg, args).await,
         Some(config::CliCommand::Hook(args)) => return hook::run(cfg, args.event).await,
@@ -57,6 +56,7 @@ async fn main() -> anyhow::Result<()> {
             return oneshot::consolidate(cfg, args).await;
         }
         Some(config::CliCommand::Forget(args)) => return oneshot::forget(cfg, args).await,
+        Some(config::CliCommand::Reindex(args)) => return reindex::run(&cfg, args).await,
         None => {}
     }
 
@@ -74,33 +74,37 @@ async fn main() -> anyhow::Result<()> {
 /// Own the store and serve one session over stdio — agmem's original shape,
 /// still what runs behind `--no-daemon` and behind a remote engine.
 async fn in_process(cfg: config::Config) -> anyhow::Result<()> {
-    // Embedded engines require the single-writer lock for the whole process
-    // lifetime (design §5.1 step 3); remote engines skip it.
-    let lock = if cfg.db_is_remote() {
-        None
-    } else {
-        Some(lock::acquire(&cfg.data_dir)?)
-    };
-
-    let db = agmem_store::db::connect_with(&cfg.db_url, cfg.db_credentials()).await?;
-    let schema = agmem_store::migrate::ensure(&db).await?;
-    let embedder = embedder::build(&cfg)?;
-    agmem_store::migrate::ensure_embedder(&db, embedder.model_id(), embedder.dim()).await?;
-    let pruned = startup::prune(&db).await;
-    agmem_store::repo::ensure_space(&db, &cfg.space).await?;
+    let startup::Opened {
+        db,
+        embedder,
+        vectors,
+        schema,
+        pruned,
+        lock,
+    } = startup::open(&cfg).await?;
     tracing::info!(
         schema,
         embedder = embedder.model_id(),
         dim = embedder.dim(),
         accelerator = embedder.accelerator(),
         pruned,
+        pending = vectors.pending(),
         "store ready"
     );
+    // This process holds the store, so this process finishes its vectors
+    // (issue #138); the session it serves sees the count go down.
+    if vectors.pending() > 0 {
+        tokio::spawn(reindex::drain(
+            db.clone(),
+            Arc::clone(&embedder),
+            vectors.clone(),
+        ));
+    }
 
     // From here stdout belongs to the transport (design §5.1 step 8). The
     // lock is held until this returns, which is what keeps a second agmem off
     // an embedded store for as long as this one is serving.
-    service::serve_stdio(AgmemService::new(db, embedder, Arc::new(cfg))).await?;
+    service::serve_stdio(AgmemService::new(db, embedder, Arc::new(cfg), vectors)).await?;
     drop(lock);
     Ok(())
 }

--- a/crates/agmem-server/src/oneshot.rs
+++ b/crates/agmem-server/src/oneshot.rs
@@ -28,9 +28,9 @@ use rmcp::model::{CallToolResult, ContentBlock};
 use serde_json::{Value, json};
 
 use crate::config::{Config, ConsolidateArgs, ContextArgs, ForgetArgs, ToolGroup};
+use crate::lock;
 use crate::service::AgmemService;
 use crate::tools::context::{self, ContextParams};
-use crate::{embedder, lock};
 
 /// Print the context block for `cfg` and exit — the whole subcommand.
 ///
@@ -96,19 +96,26 @@ pub(crate) async fn daemon_session(
 pub(crate) async fn open_direct(
     cfg: &Config,
 ) -> anyhow::Result<(AgmemService, Option<lock::DataDirLock>)> {
-    let lock = if cfg.db_is_remote() {
-        None
-    } else {
-        Some(lock::acquire(&cfg.data_dir)?)
-    };
-    let db = agmem_store::db::connect_with(&cfg.db_url, cfg.db_credentials()).await?;
-    agmem_store::migrate::ensure(&db).await?;
-    let embedder = embedder::build(cfg)?;
-    agmem_store::migrate::ensure_embedder(&db, embedder.model_id(), embedder.dim()).await?;
-    let pruned = crate::startup::prune(&db).await;
-    agmem_store::repo::ensure_space(&db, &cfg.space).await?;
-    tracing::debug!(pruned, "store opened for a one-shot");
-    Ok((AgmemService::new(db, embedder, Arc::new(cfg.clone())), lock))
+    let crate::startup::Opened {
+        db,
+        embedder,
+        vectors,
+        pruned,
+        lock,
+        ..
+    } = crate::startup::open(cfg).await?;
+    // A one-shot answers and exits; rows it finds pending stay pending, for
+    // the next daemon (or `agmem reindex`) to finish. Its answer still says
+    // how many there are.
+    tracing::debug!(
+        pruned,
+        pending = vectors.pending(),
+        "store opened for a one-shot"
+    );
+    Ok((
+        AgmemService::new(db, embedder, Arc::new(cfg.clone()), vectors),
+        lock,
+    ))
 }
 
 /// Ask a shared daemon, as a real MCP client on the session socket.

--- a/crates/agmem-server/src/reindex.rs
+++ b/crates/agmem-server/src/reindex.rs
@@ -1,29 +1,49 @@
-//! `--reindex`: move a store into the configured embedder's vector space
-//! (design §5.5, issue #28).
+//! Re-embedding a store into the configured model's vector space (design
+//! §5.5, issues #28 and #138).
 //!
-//! The one sanctioned way to change embedding model or width. Everything else
-//! refuses: `migrate::ensure_embedder` compares the configured backend
-//! against the pair recorded in `meta` and errors rather than let two models'
-//! vectors share one index.
+//! Two doors onto one loop. [`drain`] is the background one: the server's
+//! startup moved a mismatched store (or found rows without a vector) and
+//! the process that holds the store finishes the job while it serves.
+//! [`run`] is `agmem reindex`, the deliberate one: with no session attached,
+//! re-embed everything now — optionally under another `--model` — and exit.
+//! Both write the new space into `meta` before the first vector, so a run
+//! interrupted halfway resumes rather than starts over: the rows without a
+//! vector are the only record that it is unfinished.
 //!
-//! It runs instead of serving, and never through the daemon. It holds the
-//! single-writer lock for the whole pass, which a live daemon already owns, so
-//! an attempt made while sessions are attached fails naming that pid instead
-//! of becoming the second writer.
+//! `agmem reindex` never runs through the daemon. It needs the store to
+//! itself, which a live daemon already owns, so it refuses while one answers
+//! on the socket — naming the pid — rather than become the second writer.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use agmem_embed::Embedder;
 use agmem_store::db::Db;
 use agmem_store::{migrate, repo};
 
-use crate::config::Config;
+use crate::config::{Config, ReindexArgs};
+use crate::startup::VectorState;
 
-/// Passages per embed call.
+/// Passages per embed call in the offline pass.
 ///
 /// Not tuned: large enough that the round trips disappear against inference,
 /// small enough that the progress line moves on any store worth watching.
 const BATCH: usize = 128;
+
+/// Passages per embed call in the background drain.
+///
+/// Small on purpose: the model serialises on one worker thread, so a live
+/// query arriving mid-batch waits for the batch ahead of it. Sixteen rows
+/// is ~0.2 s on Metal and a second or two on a CPU-only host.
+pub const DRAIN_BATCH: usize = 16;
+
+/// How long the drain waits after a failed batch before trying again.
+const DRAIN_RETRY: Duration = Duration::from_secs(5);
+
+/// Consecutive failed batches after which the drain stops and leaves the
+/// rest to `agmem reindex` — a model that answers nothing is not going to
+/// start answering by being asked again.
+const DRAIN_GIVE_UP: u32 = 5;
 
 /// What one run did.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -39,13 +59,38 @@ pub struct Report {
     pub moved: bool,
 }
 
-/// Take the store, re-embed it, report on stderr.
+/// `agmem reindex`: take the store, re-embed it, report on stderr.
+///
+/// `--model` on the subcommand names the space to move into for this run
+/// only; without it the configured model is the target, which makes a bare
+/// `agmem reindex` the way to finish what a background drain left.
 ///
 /// # Errors
-/// When the lock is held elsewhere, the store will not open, the embedder
-/// will not load, the backend is dimensionless, or the engine rejects a
-/// statement.
-pub async fn run(cfg: &Config) -> anyhow::Result<()> {
+/// When a daemon is serving the store, the lock is held elsewhere, the store
+/// will not open, the embedder will not load, the backend is dimensionless,
+/// or the engine rejects a statement.
+pub async fn run(cfg: &Config, args: ReindexArgs) -> anyhow::Result<()> {
+    let cfg = match args.model {
+        Some(model) => Config {
+            model,
+            ..cfg.clone()
+        },
+        None => cfg.clone(),
+    };
+
+    // The socket answers before the lock does: a daemon that is up holds the
+    // lock, and the lock's own refusal only says "another process". This one
+    // says which, and what to do about it.
+    #[cfg(unix)]
+    if let Some(socket) = live_daemon(&cfg).await {
+        let owner = crate::lock::owner(&cfg.data_dir).unwrap_or_else(|| "unknown".to_owned());
+        anyhow::bail!(
+            "a daemon is serving {socket} (pid {owner}); reindex needs the store to itself. \
+             End the agmem sessions — the daemon exits after AGMEM_IDLE_TIMEOUT — or stop pid \
+             {owner}; the next session restarts it and finishes any rows this pass leaves"
+        );
+    }
+
     // Same rule as serving: an embedded engine is single-writer, a remote one
     // is the DB server's problem.
     let lock = if cfg.db_is_remote() {
@@ -61,12 +106,16 @@ pub async fn run(cfg: &Config) -> anyhow::Result<()> {
 
     // Loading the model is where a first run downloads it; do it before
     // anything is cleared, so a missing model costs nothing.
-    let embedder = crate::embedder::build(cfg)?;
+    let embedder = crate::embedder::build(&cfg)?;
     eprintln!(
-        "  ok    embedder             {} ({}d, {})",
+        "  ok    embedder             {} ({}d, {}{})",
         embedder.model_id(),
         embedder.dim(),
-        embedder.accelerator()
+        embedder.accelerator(),
+        embedder
+            .revision()
+            .map(|rev| format!(", rev {}", agmem_store::error::short_revision(rev)))
+            .unwrap_or_default()
     );
 
     let report = execute(&db, embedder).await?;
@@ -86,7 +135,15 @@ pub async fn run(cfg: &Config) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// The pass itself, against an open store and a loaded backend.
+/// The socket of a daemon that answers, if there is one.
+#[cfg(unix)]
+async fn live_daemon(cfg: &Config) -> Option<String> {
+    let path = crate::daemon::socket_path(&cfg.data_dir).ok()?;
+    tokio::net::UnixStream::connect(&path).await.ok()?;
+    Some(path.display().to_string())
+}
+
+/// The offline pass itself, against an open store and a loaded backend.
 ///
 /// Separate from [`run`] because this is the part worth testing: a stub
 /// embedder of another width makes the whole migration runnable without a
@@ -94,9 +151,9 @@ pub async fn run(cfg: &Config) -> anyhow::Result<()> {
 ///
 /// Three phases, in this order for reasons the store's `queries::reindex`
 /// documents: clear every vector and redefine both HNSW indexes at the new
-/// width, record the new pair in `meta`, then embed until nothing is pending.
-/// The pair is written *before* the loop on purpose — the rows without
-/// vectors are the only record that the loop is unfinished, so a run
+/// width, record the new space in `meta`, then embed until nothing is
+/// pending. The space is written *before* the loop on purpose — the rows
+/// without vectors are the only record that the loop is unfinished, so a run
 /// interrupted halfway must come back to a store that already knows which
 /// model it is being moved to, and resume rather than start over.
 ///
@@ -111,35 +168,26 @@ pub async fn execute(db: &Db, embedder: Arc<dyn Embedder>) -> anyhow::Result<Rep
          BM25-only mode already opens any store, whatever embedded it"
     );
     let model = embedder.model_id().to_owned();
+    let revision = embedder.revision();
 
     let stored = migrate::stored_embedder(db).await?;
-    let moved = stored.as_ref() != Some(&(model.clone(), i64::try_from(dim).unwrap_or(i64::MAX)));
+    let moved = !stored.is_some_and(|stored| stored.matches(&model, dim, revision));
     if moved {
         repo::reindex::reset_vectors(db, dim).await?;
-        migrate::set_embedder(db, &model, dim).await?;
+        migrate::set_embedder(db, &model, dim, revision).await?;
     }
 
     let total = repo::reindex::pending_count(db).await?;
     let mut remaining = total;
     let mut embedded = 0usize;
     while remaining > 0 {
-        let batch = repo::reindex::pending(db, BATCH).await?;
-        anyhow::ensure!(
-            !batch.is_empty(),
-            "{remaining} row(s) report as unembedded but none came back"
-        );
-        let sent = batch.len();
-        let texts: Vec<String> = batch.iter().map(|row| row.text().to_owned()).collect();
-        let vectors = agmem_embed::embed_passages(Arc::clone(&embedder), texts).await?;
-        repo::reindex::write_vectors(db, batch, vectors).await?;
-
+        let left = embed_batch(db, &embedder, BATCH).await?;
         // The pending count is the progress *and* the check: an `UPDATE` over
         // a row that has gone is a silent no-op, so a batch that changed
         // nothing would otherwise come back forever.
-        let left = repo::reindex::pending_count(db).await?;
         anyhow::ensure!(
             left < remaining,
-            "a batch of {sent} row(s) left {left} still pending; refusing to loop"
+            "a batch left {left} of {remaining} row(s) still pending; refusing to loop"
         );
         embedded += remaining - left;
         remaining = left;
@@ -152,4 +200,76 @@ pub async fn execute(db: &Db, embedder: Arc<dyn Embedder>) -> anyhow::Result<Rep
         embedded,
         moved,
     })
+}
+
+/// Give the next `limit` pending rows their vectors; returns how many rows
+/// are still pending afterwards.
+///
+/// # Errors
+/// When no row comes back for a nonzero count, when the backend answers
+/// with the wrong number of vectors, or when the engine rejects a statement.
+async fn embed_batch(db: &Db, embedder: &Arc<dyn Embedder>, limit: usize) -> anyhow::Result<usize> {
+    let batch = repo::reindex::pending(db, limit).await?;
+    if batch.is_empty() {
+        return Ok(0);
+    }
+    let texts: Vec<String> = batch.iter().map(|row| row.text().to_owned()).collect();
+    let vectors = agmem_embed::embed_passages(Arc::clone(embedder), texts).await?;
+    repo::reindex::write_vectors(db, batch, vectors).await?;
+    Ok(repo::reindex::pending_count(db).await?)
+}
+
+/// Re-embed every pending row in the background, [`DRAIN_BATCH`] at a time,
+/// reporting progress through `vectors` until nothing is pending.
+///
+/// Spawned by the process that holds the store — the daemon, or the
+/// `--no-daemon` session — right after [`crate::startup::open`] found rows
+/// to do. Yields between batches so the sessions it shares a runtime with
+/// keep answering; a failed batch is retried after [`DRAIN_RETRY`], and
+/// [`DRAIN_GIVE_UP`] failures in a row stop the drain with the count left
+/// where it is, so the notice stays up and `agmem reindex` can finish it.
+///
+/// Rows written while the drain runs already carry a vector and are never
+/// touched; rows another writer removes mid-batch are a silent no-op the
+/// recount absorbs.
+pub async fn drain(db: Db, embedder: Arc<dyn Embedder>, vectors: VectorState) {
+    let mut failures = 0u32;
+    let mut previous = vectors.pending();
+    loop {
+        match embed_batch(&db, &embedder, DRAIN_BATCH).await {
+            Ok(left) if left < previous || left == 0 => {
+                failures = 0;
+                previous = left;
+                vectors.set_pending(left);
+                if left == 0 {
+                    tracing::info!(model = embedder.model_id(), "every row carries a vector");
+                    return;
+                }
+                tracing::debug!(pending = left, "re-embedding in the background");
+                tokio::task::yield_now().await;
+            }
+            Ok(left) => {
+                failures += 1;
+                tracing::warn!(
+                    pending = left,
+                    failures,
+                    "a re-embed batch changed nothing; retrying"
+                );
+                tokio::time::sleep(DRAIN_RETRY).await;
+            }
+            Err(error) => {
+                failures += 1;
+                tracing::warn!(%error, failures, "a re-embed batch failed; retrying");
+                tokio::time::sleep(DRAIN_RETRY).await;
+            }
+        }
+        if failures >= DRAIN_GIVE_UP {
+            tracing::error!(
+                pending = vectors.pending(),
+                "re-embedding gave up after {DRAIN_GIVE_UP} failed batches; run `agmem reindex` \
+                 once the cause is fixed"
+            );
+            return;
+        }
+    }
 }

--- a/crates/agmem-server/src/service.rs
+++ b/crates/agmem-server/src/service.rs
@@ -18,21 +18,25 @@ use rmcp::{
     ErrorData, Json, RoleServer, ServerHandler, ServiceExt,
     handler::server::router::prompt::PromptRouter,
     handler::server::router::tool::ToolRouter,
+    handler::server::tool::ToolCallContext,
     handler::server::wrapper::Parameters,
     model::{
-        CallToolResult, GetPromptResult, Implementation, ListResourceTemplatesResult,
-        ListResourcesResult, PaginatedRequestParams, PromptMessage, ReadResourceRequestParams,
-        ReadResourceResponse, Role, ServerCapabilities, ServerInfo,
+        CacheScope, CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
+        GetPromptResult, Implementation, ListResourceTemplatesResult, ListResourcesResult,
+        ListToolsResult, PaginatedRequestParams, PromptMessage, ProtocolVersion,
+        ReadResourceRequestParams, ReadResourceResponse, ResultType, Role, ServerCapabilities,
+        ServerInfo,
     },
     prompt, prompt_handler, prompt_router,
     service::{RequestContext, ServerInitializeError},
-    tool, tool_handler, tool_router,
+    tool, tool_router,
     transport::stdio,
 };
 
 use crate::config::{Config, ToolGroup};
 use crate::prompts::{self, Focus};
 use crate::resources;
+use crate::startup::VectorState;
 use crate::tools::GATED;
 use crate::tools::consolidate::{self, ConsolidateParams, ConsolidateResult};
 use crate::tools::context::{self, ContextParams};
@@ -84,14 +88,26 @@ pub struct AgmemService {
     /// request quite happily — so that a prompt-side override has the same
     /// seam waiting for it that `AGMEM_TOOL_DESC_<TOOL>` uses.
     prompt_router: PromptRouter<Self>,
+    /// How many rows the background re-embed still has to reach (issue
+    /// #138). Shared with the drain that lowers it; while it is above zero
+    /// every tool result ends with a line saying so, because a vector
+    /// recall silently misses those rows and nothing else would tell the
+    /// agent.
+    vectors: VectorState,
 }
 
 impl AgmemService {
     /// Assemble the service from an already-migrated store.
-    pub fn new(db: Db, embedder: Arc<dyn Embedder>, config: Arc<Config>) -> Self {
+    pub fn new(
+        db: Db,
+        embedder: Arc<dyn Embedder>,
+        config: Arc<Config>,
+        vectors: VectorState,
+    ) -> Self {
         Self {
             db,
             embedder,
+            vectors,
             pending_forget: Pending::default(),
             // Distinct per connection and sortable by start time; not a ULID
             // only because nothing in this crate mints those.
@@ -129,6 +145,19 @@ impl AgmemService {
     /// The session id this connection's writes fall back to (issue #75).
     pub(crate) fn session(&self) -> &str {
         &self.session
+    }
+
+    /// The line appended to every tool result while rows are still being
+    /// re-embedded, or nothing once they all carry a vector.
+    fn vector_notice(&self) -> Option<String> {
+        let pending = self.vectors.pending();
+        (pending > 0).then(|| {
+            format!(
+                "notice: {pending} row(s) are still being re-embedded for {}; recall's \
+                 vector arm misses them until then (BM25 still sees them)",
+                self.embedder.model_id()
+            )
+        })
     }
 }
 
@@ -486,13 +515,48 @@ claim before writing it, then remember the batch with supersedes on the correcti
 // request, which would serve the built-in descriptions and silently discard
 // every override — and for prompts it is symmetry.
 //
-// `#[tool_handler]` stays first: with `get_info` hand-written neither macro
-// generates one, but the order is what decides which capabilities an
-// auto-generated one would carry, and a future edit that deletes `get_info`
-// should degrade to "tools and prompts" rather than to "tools".
-#[tool_handler(router = self.tool_router)]
+// The tool side is written by hand rather than through `#[tool_handler]`:
+// `call_tool` has one thing to add to every answer (the re-embed notice,
+// issue #138), and the macro's `list_tools` is reproduced beside it so the
+// two stay one unit. `#[prompt_handler]` still generates the prompt side.
 #[prompt_handler(router = self.prompt_router)]
 impl ServerHandler for AgmemService {
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        let call = ToolCallContext::new(self, request, context);
+        let mut response = self.tool_router.call(call).await?;
+        if let (Some(notice), CallToolResponse::Complete(result)) =
+            (self.vector_notice(), &mut response)
+        {
+            result.content.push(ContentBlock::text(notice));
+        }
+        Ok(response)
+    }
+
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        // What `#[tool_handler]` would generate, verbatim: the cache hints
+        // exist from the 2026-07-28 protocol on, and a client that speaks it
+        // is told the list never goes stale.
+        let supports_cache_hints = context
+            .protocol_version()
+            .is_some_and(|version| version >= ProtocolVersion::V_2026_07_28);
+        Ok(ListToolsResult {
+            result_type: Some(ResultType::COMPLETE),
+            tools: self.tool_router.list_all(),
+            meta: None,
+            next_cursor: None,
+            ttl_ms: supports_cache_hints.then_some(0),
+            cache_scope: supports_cache_hints.then_some(CacheScope::Public),
+        })
+    }
+
     fn get_info(&self) -> ServerInfo {
         // Writing `get_info` by hand replaces the one the handler macros would
         // generate, so every capability has to be repeated here or the server

--- a/crates/agmem-server/src/startup.rs
+++ b/crates/agmem-server/src/startup.rs
@@ -1,10 +1,189 @@
-//! Step 8 of the startup sequence (design §5.1): the maintenance that has to
-//! happen at a start, because agmem has no scheduler to happen on.
+//! Opening the store (design §5.1 steps 3–8): the one sequence every route
+//! into it runs — the shared daemon, `--no-daemon`, and the one-shots.
 //!
-//! Both routes into the store — the shared daemon and `--no-daemon` — run it
-//! once, before anything is served.
+//! Lock, connect, migrate, load the embedder, settle the vector space, prune,
+//! register the space. The vector-space step is the policy issue #138 asks
+//! for: the configured model wins. A store recorded under another model,
+//! width or pinned revision — every store from before v0.3, which holds bge
+//! on ONNX Runtime under a retired id — is moved on open: vectors cleared,
+//! HNSW indexes redefined at the new width, `meta` rewritten. That part is
+//! sub-second. Re-embedding the rows is not, so it happens in the background
+//! ([`crate::reindex::drain`]) while the store already serves, and every
+//! tool result says how many rows are still to go until none are.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use agmem_embed::Embedder;
 use agmem_store::db::Db;
+use agmem_store::migrate::{self, StoredEmbedder};
+use agmem_store::{StoreError, repo};
+
+use crate::config::Config;
+use crate::lock::DataDirLock;
+use crate::{embedder, lock};
+
+/// How far the store's vectors are from the configured model, shared between
+/// the drain that closes the gap and the sessions that report it.
+#[derive(Debug, Clone, Default)]
+pub struct VectorState {
+    /// Rows still without a vector. Written by the drain after every batch;
+    /// read by every tool call.
+    pending: Arc<AtomicUsize>,
+    /// The space the store was recorded in before this open moved it, if it
+    /// did — what the log and `doctor` name as the "from".
+    moved_from: Option<StoredEmbedder>,
+}
+
+impl VectorState {
+    /// A state with `pending` rows to embed and nothing moved.
+    #[must_use]
+    pub fn with_pending(pending: usize) -> Self {
+        Self {
+            pending: Arc::new(AtomicUsize::new(pending)),
+            moved_from: None,
+        }
+    }
+
+    /// Rows a vector recall cannot reach yet.
+    #[must_use]
+    pub fn pending(&self) -> usize {
+        self.pending.load(Ordering::Relaxed)
+    }
+
+    /// The drain's progress report.
+    pub fn set_pending(&self, pending: usize) {
+        self.pending.store(pending, Ordering::Relaxed);
+    }
+
+    /// The space this open moved the store out of, if it moved it.
+    #[must_use]
+    pub fn moved_from(&self) -> Option<&StoredEmbedder> {
+        self.moved_from.as_ref()
+    }
+}
+
+/// An open store, ready to serve.
+pub struct Opened {
+    pub db: Db,
+    pub embedder: Arc<dyn Embedder>,
+    pub vectors: VectorState,
+    /// The schema version after migrating.
+    pub schema: u32,
+    /// Working-context memories the startup sweep closed.
+    pub pruned: usize,
+    /// The data-dir lock, for as long as the store is held; `None` behind a
+    /// remote engine, where the DB server is the boundary.
+    pub lock: Option<DataDirLock>,
+}
+
+/// Open the store the way every route does.
+///
+/// The embedder loads before the vector space is settled, on purpose: a
+/// first run downloads the model there, and a download that fails must leave
+/// an old store exactly as it was rather than cleared and waiting for a
+/// model that never came.
+///
+/// # Errors
+/// When the lock is held elsewhere, the store will not open or migrate, the
+/// embedder will not load, or the engine rejects a statement.
+pub async fn open(cfg: &Config) -> anyhow::Result<Opened> {
+    // Embedded engines require the single-writer lock for the whole process
+    // lifetime (design §5.1 step 3); remote engines skip it.
+    let lock = if cfg.db_is_remote() {
+        None
+    } else {
+        Some(lock::acquire(&cfg.data_dir)?)
+    };
+    let mut opened = open_locked(cfg).await?;
+    opened.lock = lock;
+    Ok(opened)
+}
+
+/// [`open`] for a caller that already holds the data-dir lock — the daemon,
+/// which takes it before it touches the socket. `Opened::lock` is `None`.
+///
+/// # Errors
+/// As [`open`], minus the lock.
+pub async fn open_locked(cfg: &Config) -> anyhow::Result<Opened> {
+    let db = agmem_store::db::connect_with(&cfg.db_url, cfg.db_credentials()).await?;
+    let schema = migrate::ensure(&db).await?;
+    let embedder = embedder::build(cfg)?;
+    let vectors = resolve(&db, embedder.as_ref()).await?;
+    let pruned = prune(&db).await;
+    repo::ensure_space(&db, &cfg.space).await?;
+    Ok(Opened {
+        db,
+        embedder,
+        vectors,
+        schema,
+        pruned,
+        lock: None,
+    })
+}
+
+/// Settle the store's vector space against `embedder`: the configured model
+/// wins (issue #138).
+///
+/// - No space recorded: record this one (a first run, or a store only ever
+///   opened in BM25-only mode).
+/// - The same model, width and revision: nothing to do, beyond backfilling
+///   a revision the store predates.
+/// - Anything else: move the store — clear every vector, redefine both HNSW
+///   indexes at this width, record this space — and leave every row pending
+///   for [`crate::reindex::drain`]. New writes embed with the new model at
+///   once; old rows join the vector arm as the drain reaches them.
+///
+/// A dimensionless backend claims no space and moves nothing; whatever the
+/// store recorded stays, and rows it writes simply carry no vector.
+///
+/// Interrupted moves need no bookkeeping: `meta` already names the new
+/// model, so the next open matches and finds the pending rows by their
+/// missing vectors — the invariant `agmem reindex` has always relied on.
+///
+/// # Errors
+/// [`StoreError`] for anything the engine rejects. A mismatch is not an
+/// error here; it is the case this function exists to resolve.
+pub async fn resolve(db: &Db, embedder: &dyn Embedder) -> Result<VectorState, StoreError> {
+    let dim = embedder.dim();
+    if dim == 0 {
+        return Ok(VectorState::default());
+    }
+    let model = embedder.model_id();
+    let revision = embedder.revision();
+
+    let moved_from = match migrate::stored_embedder(db).await? {
+        Some(stored) if !stored.matches(model, dim, revision) => {
+            repo::reindex::reset_vectors(db, dim).await?;
+            migrate::set_embedder(db, model, dim, revision).await?;
+            Some(stored)
+        }
+        _ => {
+            migrate::ensure_embedder(db, model, dim, revision).await?;
+            None
+        }
+    };
+    let pending = repo::reindex::pending_count(db).await?;
+    if let Some(from) = &moved_from {
+        tracing::warn!(
+            from = %from.model,
+            from_dim = from.dim,
+            to = model,
+            to_dim = dim,
+            pending,
+            "moved the store to the configured model; its rows re-embed in the background"
+        );
+    } else if pending > 0 {
+        tracing::info!(
+            pending,
+            "rows without a vector; re-embedding in the background"
+        );
+    }
+    Ok(VectorState {
+        pending: Arc::new(AtomicUsize::new(pending)),
+        moved_from,
+    })
+}
 
 /// Close working-context memories that decayed while nobody was running, and
 /// report how many.
@@ -16,7 +195,7 @@ use agmem_store::db::Db;
 /// growth. It is the rule `recall`'s reinforcement already follows (design
 /// §5.3 step 6) — the sweep is not what the session came for.
 pub async fn prune(db: &Db) -> usize {
-    match agmem_store::repo::prune_expired(db).await {
+    match repo::prune_expired(db).await {
         Ok(closed) => closed.len(),
         Err(error) => {
             tracing::warn!(%error, "the startup prune failed; serving anyway");

--- a/crates/agmem-server/tests/daemon.rs
+++ b/crates/agmem-server/tests/daemon.rs
@@ -135,6 +135,39 @@ async fn call(
         .expect("a tool answers with structured content")
 }
 
+/// `agmem reindex` needs the store to itself (#138): while a daemon serves
+/// it, the verb refuses before it touches the lock, naming the socket and
+/// the pid so the operator knows what to stop.
+#[tokio::test]
+async fn reindex_refuses_while_a_daemon_serves_the_store() {
+    let shared = Shared::start().await;
+    // A blocking child on a worker thread: the daemon serving it is a task
+    // on this runtime, which must keep turning while the child probes it.
+    let data = shared.data.path().to_path_buf();
+    let out = tokio::task::spawn_blocking(move || {
+        std::process::Command::new(env!("CARGO_BIN_EXE_agmem"))
+            .args(["--embedder", "none", "--data"])
+            .arg(data)
+            .arg("reindex")
+            .output()
+    })
+    .await
+    .expect("join")
+    .expect("run agmem reindex");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "a live daemon owns the store: {stderr}"
+    );
+    assert!(out.stdout.is_empty(), "stdout stays the MCP wire: {stderr}");
+    assert!(
+        stderr.contains("a daemon is serving")
+            && stderr.contains(&format!("pid {}", std::process::id())),
+        "the refusal names the daemon and its pid: {stderr}"
+    );
+}
+
 #[tokio::test]
 async fn two_sessions_share_one_store() {
     let shared = Shared::start().await;

--- a/crates/agmem-server/tests/harness/mod.rs
+++ b/crates/agmem-server/tests/harness/mod.rs
@@ -17,6 +17,7 @@ use agmem_core::{MemoryRecord, SpaceName};
 use agmem_embed::{EmbedError, Embedder};
 use agmem_server::config::{Cli, ToolDescriptions, ToolGroup};
 use agmem_server::service::AgmemService;
+use agmem_server::startup;
 use agmem_store::db::Db;
 use agmem_store::migrate;
 use agmem_store::repo::{self, Liveness, Lookup, SpaceStats};
@@ -34,6 +35,9 @@ pub struct Harness {
     pub client: RunningService<RoleClient, ()>,
     pub server: tokio::task::JoinHandle<anyhow::Result<()>>,
     pub db: Db,
+    /// The re-embed counter the service reads (#138), for a test that runs
+    /// the drain by hand.
+    pub vectors: startup::VectorState,
     /// `mem://` never touches the data dir, but resolving one is part of
     /// startup, so it points somewhere disposable rather than at the
     /// developer's real platform directory. Dropped last.
@@ -76,6 +80,25 @@ impl Harness {
         tool_desc: ToolDescriptions,
         tools: ToolGroup,
     ) -> Self {
+        let db = agmem_store::db::connect("mem://")
+            .await
+            .expect("connect mem://");
+        Self::configure_on(db, embedder, tool_desc, tools).await
+    }
+
+    /// The whole surface on a store the test already holds — one another
+    /// backend wrote, for the cases where opening is the thing under test.
+    pub async fn start_on(db: Db, embedder: Arc<dyn Embedder>) -> Self {
+        Self::configure_on(db, embedder, ToolDescriptions::default(), ToolGroup::All).await
+    }
+
+    /// A client on `db`, serving `tools` with `tool_desc` applied.
+    pub async fn configure_on(
+        db: Db,
+        embedder: Arc<dyn Embedder>,
+        tool_desc: ToolDescriptions,
+        tools: ToolGroup,
+    ) -> Self {
         let data = tempfile::tempdir().expect("tempdir");
         let mut config = Cli::try_parse_from([
             "agmem",
@@ -97,14 +120,12 @@ impl Harness {
         .expect("resolve");
         config.tool_desc = tool_desc;
         config.tools = tools;
-        let db = agmem_store::db::connect(&config.db_url)
-            .await
-            .expect("connect mem://");
         migrate::ensure(&db).await.expect("migrate");
-        // Startup records the embedder pair right after migrating (main.rs),
-        // and a first backend whose width differs from the schema's baked
-        // 384 adopts the indexes there, so the harness mirrors it.
-        migrate::ensure_embedder(&db, embedder.model_id(), embedder.dim())
+        // Startup settles the vector space right after migrating
+        // (`startup::resolve`): a first backend records itself, and one
+        // whose width differs from the schema's baked 384 adopts the indexes
+        // there, so the harness mirrors it.
+        let vectors = startup::resolve(&db, embedder.as_ref())
             .await
             .expect("record the embedder");
         // Startup registers the configured space before it serves anything
@@ -114,7 +135,7 @@ impl Harness {
         repo::ensure_space(&db, &space())
             .await
             .expect("register the space");
-        let service = AgmemService::new(db.clone(), embedder, Arc::new(config));
+        let service = AgmemService::new(db.clone(), embedder, Arc::new(config), vectors.clone());
 
         let (server_end, client_end) = tokio::io::duplex(4096);
         let server = tokio::spawn(async move {
@@ -126,6 +147,7 @@ impl Harness {
             client,
             server,
             db,
+            vectors,
             _data: data,
         }
     }
@@ -272,6 +294,18 @@ impl Harness {
 }
 
 /// The space the harness's server was started with.
+/// Every text block of a result, in order.
+pub fn texts(result: &CallToolResult) -> Vec<String> {
+    result
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text(text) => Some(text.text.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
 pub fn space() -> SpaceName {
     "default".parse().expect("valid slug")
 }

--- a/crates/agmem-server/tests/reindex.rs
+++ b/crates/agmem-server/tests/reindex.rs
@@ -8,11 +8,13 @@
 //! one of the width the index was rebuilt at, so the stub proves the same
 //! thing the model would.
 
+mod harness;
+
 use std::sync::Arc;
 
 use agmem_core::{Kind, SpaceName, Writer};
 use agmem_embed::{EmbedError, Embedder, NoopEmbedder};
-use agmem_server::reindex;
+use agmem_server::{reindex, startup};
 use agmem_store::db::Db;
 use agmem_store::repo::{self, Batch, NewChunk, NewEpisode, NewMemory, Search};
 use agmem_store::{db, migrate};
@@ -21,6 +23,7 @@ use agmem_store::{db, migrate};
 struct Stub {
     model: &'static str,
     dim: usize,
+    revision: Option<&'static str>,
 }
 
 impl Stub {
@@ -41,6 +44,10 @@ impl Embedder for Stub {
         self.model
     }
 
+    fn revision(&self) -> Option<&str> {
+        self.revision
+    }
+
     fn thresholds(&self) -> agmem_core::dedup::Thresholds {
         agmem_core::dedup::Thresholds::BGE_SMALL
     }
@@ -55,7 +62,37 @@ impl Embedder for Stub {
 }
 
 fn stub(model: &'static str, dim: usize) -> Arc<dyn Embedder> {
-    Arc::new(Stub { model, dim })
+    Arc::new(Stub {
+        model,
+        dim,
+        revision: None,
+    })
+}
+
+/// The same backend, claiming a pinned revision.
+fn pinned(model: &'static str, dim: usize, revision: &'static str) -> Arc<dyn Embedder> {
+    Arc::new(Stub {
+        model,
+        dim,
+        revision: Some(revision),
+    })
+}
+
+/// A store as v0.2 left it: bge on ONNX Runtime under the id no release
+/// since can run, every row vectored at 384. Built with a stub of that id
+/// and width, which is indistinguishable from the real thing to everything
+/// under test — the move never reads a vector, only clears them.
+async fn pre_v03_store() -> Db {
+    let db = bm25_only_store().await;
+    reindex::execute(&db, stub("bge-small-en-v1.5-q", 384))
+        .await
+        .expect("embed as v0.2 did");
+    assert_eq!(
+        repo::reindex::pending_count(&db).await.expect("count"),
+        0,
+        "the old store is whole under its own model"
+    );
+    db
 }
 
 fn space() -> SpaceName {
@@ -124,7 +161,7 @@ async fn a_store_written_without_vectors_gets_them() {
         vector_recall(&db, embedder.as_ref(), "the user prefers Rust over Python").await > 0,
         "and now recall reaches them"
     );
-    migrate::ensure_embedder(&db, "stub-8", 8)
+    migrate::ensure_embedder(&db, "stub-8", 8, None)
         .await
         .expect("the startup guard passes afterwards");
 }
@@ -150,7 +187,7 @@ async fn another_model_moves_the_store_and_the_guard_follows_it() {
         .expect("first run");
 
     let narrower = stub("stub-4", 4);
-    migrate::ensure_embedder(&db, "stub-4", 4)
+    migrate::ensure_embedder(&db, "stub-4", 4, None)
         .await
         .expect_err("before the reindex the guard refuses the new model");
 
@@ -163,10 +200,10 @@ async fn another_model_moves_the_store_and_the_guard_follows_it() {
         "every row is re-embedded, not just new ones"
     );
 
-    migrate::ensure_embedder(&db, "stub-4", 4)
+    migrate::ensure_embedder(&db, "stub-4", 4, None)
         .await
         .expect("the guard now passes for the new model");
-    migrate::ensure_embedder(&db, "stub-8", 8)
+    migrate::ensure_embedder(&db, "stub-8", 8, None)
         .await
         .expect_err("and refuses the old one");
     assert!(vector_recall(&db, narrower.as_ref(), "answer in English").await > 0);
@@ -183,7 +220,7 @@ async fn an_interrupted_run_resumes_where_it_stopped() {
 
     // The first two phases of `execute`, and then nothing — the crash.
     repo::reindex::reset_vectors(&db, 8).await.expect("reset");
-    migrate::set_embedder(&db, "stub-8", 8)
+    migrate::set_embedder(&db, "stub-8", 8, None)
         .await
         .expect("record the target");
     let first = repo::reindex::pending(&db, 1).await.expect("one row");
@@ -207,6 +244,201 @@ async fn an_interrupted_run_resumes_where_it_stopped() {
     );
 }
 
+/// The upgrade path (issue #138): a v0.2 store opened by a binary whose
+/// configured model is another one. The configured model wins — the store is
+/// moved on open, sub-second, and every row is left pending for the drain.
+#[tokio::test]
+async fn opening_a_pre_v03_store_moves_it_and_leaves_every_row_pending() {
+    let db = pre_v03_store().await;
+    let gemma = stub("stub-768", 768);
+
+    let state = startup::resolve(&db, gemma.as_ref())
+        .await
+        .expect("the configured model wins; a mismatch is not an error");
+    assert_eq!(
+        state.moved_from().map(|from| from.model.as_str()),
+        Some("bge-small-en-v1.5-q"),
+        "the move names what it moved from"
+    );
+    assert_eq!(state.pending(), 3, "every row is waiting for a new vector");
+    migrate::ensure_embedder(&db, "stub-768", 768, None)
+        .await
+        .expect("meta already names the new model, before a single row is embedded");
+
+    let again = startup::resolve(&db, gemma.as_ref())
+        .await
+        .expect("a second open");
+    assert!(
+        again.moved_from().is_none(),
+        "an interrupted move resumes: nothing is cleared twice"
+    );
+    assert_eq!(again.pending(), 3);
+}
+
+/// A store recorded under the same id and width but another pinned revision
+/// is another space (the weights changed): moved like a retired id. A store
+/// that recorded no revision is not — it predates the field, and takes it.
+#[tokio::test]
+async fn a_moved_pin_moves_the_store_but_a_missing_one_is_backfilled() {
+    let db = bm25_only_store().await;
+    startup::resolve(&db, stub("stub-8", 8).as_ref())
+        .await
+        .expect("a backend without a revision records none");
+
+    let state = startup::resolve(&db, pinned("stub-8", 8, "aaaa").as_ref())
+        .await
+        .expect("the first pinned run");
+    assert!(
+        state.moved_from().is_none(),
+        "no revision on record is not a mismatch"
+    );
+    assert_eq!(
+        migrate::stored_embedder(&db)
+            .await
+            .expect("read")
+            .expect("recorded")
+            .revision
+            .as_deref(),
+        Some("aaaa"),
+        "and it is backfilled"
+    );
+
+    let state = startup::resolve(&db, pinned("stub-8", 8, "bbbb").as_ref())
+        .await
+        .expect("another pin");
+    assert_eq!(
+        state
+            .moved_from()
+            .and_then(|from| from.revision.clone())
+            .as_deref(),
+        Some("aaaa"),
+        "a different pin of the same id moves the store"
+    );
+}
+
+/// The drain finishes what the move left, in the background of a store that
+/// keeps taking writes, and the counter it reports reaches zero exactly when
+/// the store is whole.
+#[tokio::test]
+async fn the_drain_finishes_the_move_while_writes_keep_landing() {
+    let db = pre_v03_store().await;
+    // Enough rows that the drain takes several batches.
+    let extra = (0..40)
+        .map(|n| NewMemory::new(Kind::Fact, format!("fact number {n} about the user")))
+        .collect();
+    repo::insert_batch(
+        &db,
+        Batch {
+            space: space(),
+            episode: None,
+            memories: extra,
+            writer: Writer::default(),
+        },
+    )
+    .await
+    .expect("seed more");
+    let embedder = stub("stub-8", 8);
+    let state = startup::resolve(&db, embedder.as_ref())
+        .await
+        .expect("move");
+    assert_eq!(state.pending(), 43);
+
+    // A `remember` mid-drain writes its vector under the new model at once;
+    // the drain must never touch it, and must still end at zero.
+    let concurrent = {
+        let db = db.clone();
+        let embedder = Arc::clone(&embedder);
+        async move {
+            tokio::task::yield_now().await;
+            let mut memory = NewMemory::new(Kind::Fact, "written while the drain ran");
+            memory.embedding = Some(
+                embedder
+                    .embed_passages(&[memory.content.clone()])
+                    .expect("embed")[0]
+                    .clone(),
+            );
+            repo::insert_batch(
+                &db,
+                Batch {
+                    space: space(),
+                    episode: None,
+                    memories: vec![memory],
+                    writer: Writer::default(),
+                },
+            )
+            .await
+            .expect("a write lands mid-drain");
+        }
+    };
+    tokio::join!(
+        reindex::drain(db.clone(), Arc::clone(&embedder), state.clone()),
+        concurrent
+    );
+
+    assert_eq!(
+        state.pending(),
+        0,
+        "the counter the notice reads ends at zero"
+    );
+    assert_eq!(
+        repo::reindex::pending_count(&db).await.expect("count"),
+        0,
+        "and the store agrees"
+    );
+    assert!(vector_recall(&db, embedder.as_ref(), "answer in English").await > 0);
+    assert!(
+        vector_recall(&db, embedder.as_ref(), "written while the drain ran").await > 0,
+        "the concurrent write is reachable too"
+    );
+}
+
+/// Acceptance item 1 of issue #138, on the wire: a store another backend
+/// wrote, opened by this one, answers every tool with a line saying how many
+/// rows a vector recall cannot reach yet — and stops saying it once the
+/// drain is through. Nothing else tells the agent, which is why it is on
+/// every result rather than in a log.
+#[tokio::test]
+async fn every_tool_result_says_how_many_rows_are_still_to_embed() {
+    let db = pre_v03_store().await;
+    let embedder = stub("stub-8", 8);
+    let harness = harness::Harness::start_on(db.clone(), Arc::clone(&embedder)).await;
+
+    for (tool, arguments) in [
+        ("recall", serde_json::json!({ "query": "Rust" })),
+        ("context", serde_json::json!({})),
+        (
+            "remember",
+            serde_json::json!({ "memories": [{ "content": "the user likes clear notices" }] }),
+        ),
+    ] {
+        let result = harness
+            .call(tool, arguments)
+            .await
+            .expect("the tool answers");
+        let last = harness::texts(&result)
+            .pop()
+            .expect("at least one text block");
+        assert!(
+            last.starts_with("notice: 3 row(s) are still being re-embedded for stub-8"),
+            "{tool} ends with the notice: {last}"
+        );
+    }
+
+    // The drain runs on the daemon's runtime in the binary; here it is run to
+    // completion by hand, on the same `VectorState` the service reads.
+    reindex::drain(db, embedder, harness.vectors.clone()).await;
+    let result = harness
+        .call("recall", serde_json::json!({ "query": "Rust" }))
+        .await
+        .expect("recall");
+    assert!(
+        harness::texts(&result)
+            .iter()
+            .all(|text| !text.starts_with("notice:")),
+        "once every row carries a vector the notice is gone"
+    );
+}
+
 #[tokio::test]
 async fn a_dimensionless_backend_has_nowhere_to_reindex_into() {
     let db = bm25_only_store().await;
@@ -219,35 +451,36 @@ async fn a_dimensionless_backend_has_nowhere_to_reindex_into() {
     );
 }
 
-/// The flag itself: it must reach `reindex::run` rather than start a server,
-/// and its report — including the refusal — goes to stderr, because stdout is
-/// the MCP wire even in a maintenance pass.
+/// The verb itself: `agmem reindex` must reach `reindex::run` rather than
+/// start a server, and its report — including the refusal — goes to stderr,
+/// because stdout is the MCP wire even in a maintenance pass. The hidden
+/// `--reindex` flag from before v0.3.1 still lands on the same path.
 #[test]
-fn the_flag_runs_the_pass_instead_of_serving() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let out = std::process::Command::new(env!("CARGO_BIN_EXE_agmem"))
-        .args([
-            "--reindex",
-            "--db",
-            "mem://",
-            "--embedder",
-            "none",
-            "--data",
-        ])
-        .arg(dir.path())
-        .output()
-        .expect("run agmem --reindex");
+fn the_verb_runs_the_pass_instead_of_serving() {
+    for spelling in [
+        &["reindex"][..],
+        &["reindex", "--model", "bge-small-en-v1.5"][..],
+        &["--reindex"][..],
+    ] {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let out = std::process::Command::new(env!("CARGO_BIN_EXE_agmem"))
+            .args(["--db", "mem://", "--embedder", "none", "--data"])
+            .arg(dir.path())
+            .args(spelling)
+            .output()
+            .expect("run agmem reindex");
 
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        !out.status.success(),
-        "a dimensionless backend has no space to reindex into: {stderr}"
-    );
-    assert!(out.stdout.is_empty(), "stdout stays the MCP wire: {stderr}");
-    assert!(
-        stderr.contains("agmem reindex") && stderr.contains("--embedder none"),
-        "the report and the reason both go to stderr: {stderr}"
-    );
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            !out.status.success(),
+            "a dimensionless backend has no space to reindex into ({spelling:?}): {stderr}"
+        );
+        assert!(out.stdout.is_empty(), "stdout stays the MCP wire: {stderr}");
+        assert!(
+            stderr.contains("agmem reindex") && stderr.contains("--embedder none"),
+            "the report and the reason both go to stderr ({spelling:?}): {stderr}"
+        );
+    }
 }
 
 /// The same path with the real model behind it: ignored, because it needs the
@@ -256,13 +489,14 @@ fn the_flag_runs_the_pass_instead_of_serving() {
 /// `cargo test -p agmem-server --test reindex -- --ignored`
 #[test]
 #[ignore = "loads the real embedding model"]
-fn the_flag_reindexes_a_real_store() {
+fn the_verb_reindexes_a_real_store() {
     let dir = tempfile::tempdir().expect("tempdir");
     let out = std::process::Command::new(env!("CARGO_BIN_EXE_agmem"))
-        .args(["--reindex", "--data"])
+        .arg("--data")
         .arg(dir.path())
+        .arg("reindex")
         .output()
-        .expect("run agmem --reindex");
+        .expect("run agmem reindex");
 
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(out.status.success(), "stderr: {stderr}");

--- a/crates/agmem-store/src/error.rs
+++ b/crates/agmem-store/src/error.rs
@@ -50,14 +50,35 @@ pub enum StoreError {
 
     /// The store's vectors were built by a different embedder.
     #[error(
-        "store was embedded with {stored_model} ({stored_dim}d) but this run is configured for \
-         {configured_model} ({configured_dim}d); vectors from two models are not comparable — \
-         switch back, or re-embed the store with `agmem --reindex`"
+        "store was embedded with {stored_model} ({stored_dim}d{}) but this run is configured for \
+         {configured_model} ({configured_dim}d{}); vectors from two models are not comparable — \
+         switch back, or re-embed the store with `agmem reindex`",
+        revision_suffix(stored_revision.as_deref()),
+        revision_suffix(configured_revision.as_deref())
     )]
     EmbedderMismatch {
         stored_model: String,
         stored_dim: i64,
+        stored_revision: Option<String>,
         configured_model: String,
         configured_dim: i64,
+        configured_revision: Option<String>,
     },
+}
+
+/// `, rev <short>` when there is a revision to name, nothing otherwise.
+fn revision_suffix(revision: Option<&str>) -> String {
+    revision
+        .map(|revision| format!(", rev {}", short_revision(revision)))
+        .unwrap_or_default()
+}
+
+/// The first seven characters of a commit hash — enough to name it in a
+/// message, the way `git` does.
+#[must_use]
+pub fn short_revision(revision: &str) -> &str {
+    revision
+        .char_indices()
+        .nth(7)
+        .map_or(revision, |(end, _)| &revision[..end])
 }

--- a/crates/agmem-store/src/migrate.rs
+++ b/crates/agmem-store/src/migrate.rs
@@ -14,6 +14,7 @@ const BOOTSTRAP: &str = "DEFINE TABLE IF NOT EXISTS meta SCHEMAFULL;
      DEFINE FIELD IF NOT EXISTS schema_version ON meta TYPE int;
      DEFINE FIELD IF NOT EXISTS embedder_model ON meta TYPE option<string>;
      DEFINE FIELD IF NOT EXISTS embedder_dim ON meta TYPE option<int>;
+     DEFINE FIELD IF NOT EXISTS embedder_revision ON meta TYPE option<string>;
      DEFINE FIELD IF NOT EXISTS created_at ON meta TYPE datetime DEFAULT time::now();";
 
 /// Ordered migration batches; index + 1 is the schema version they produce.
@@ -35,12 +36,51 @@ pub const SCHEMA_VERSION: u32 = MIGRATIONS.len() as u32;
 /// Embedding width the v1 schema defines its HNSW indexes with (design §2.2).
 ///
 /// What a store starts at, not what it is stuck at: the dimension is baked
-/// into the index definitions, so changing embedder families means rebuilding
-/// them and re-embedding every row, which is what `agmem --reindex` does and
-/// the only way it is allowed to happen. Startup compares the configured
-/// backend against `meta:main.embedder_dim` — the pair the store recorded —
-/// rather than against this constant.
+/// into the index definitions, so changing models means rebuilding them and
+/// re-embedding every row — which the server does on open when the store's
+/// recorded space differs from the configured model (issue #138), and
+/// `agmem reindex` does on demand. Startup compares the configured backend
+/// against what `meta:main` recorded, never against this constant.
 pub const EMBEDDING_DIM: usize = 384;
+
+/// The vector space a store's rows were built in, as `meta:main` records it.
+///
+/// `revision` is `None` for a store written before agmem recorded one
+/// (pre-v0.3) or by a backend whose weights have no such identity (test
+/// doubles); [`Self::matches`] says how that reads.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredEmbedder {
+    /// `meta.embedder_model`.
+    pub model: String,
+    /// `meta.embedder_dim`.
+    pub dim: i64,
+    /// `meta.embedder_revision`.
+    pub revision: Option<String>,
+}
+
+impl StoredEmbedder {
+    /// Whether a backend reporting `model_id`/`dim`/`revision` embeds into
+    /// this space.
+    ///
+    /// The id and the width must agree. The revision is compared only when
+    /// both sides carry one: a store that never recorded a revision is not a
+    /// mismatch — it predates the field, and the first run that knows the
+    /// revision backfills it — and a backend without one claims nothing.
+    #[must_use]
+    pub fn matches(&self, model_id: &str, dim: usize, revision: Option<&str>) -> bool {
+        self.model == model_id
+            && self.dim == width(dim)
+            && match (self.revision.as_deref(), revision) {
+                (Some(stored), Some(configured)) => stored == configured,
+                _ => true,
+            }
+    }
+}
+
+/// A width as `meta` stores it.
+fn width(dim: usize) -> i64 {
+    i64::try_from(dim).unwrap_or(i64::MAX)
+}
 
 /// Read the applied schema version (0 = fresh store).
 ///
@@ -58,7 +98,9 @@ pub async fn current_version(db: &Db) -> Result<u32, StoreError> {
 ///
 /// The HNSW indexes carry one dimension and the vectors one geometry, so two
 /// models in one store means silently wrong neighbours. First run writes the
-/// pair into `meta`; later runs must match it.
+/// space into `meta`; later runs must match it ([`StoredEmbedder::matches`]).
+/// This is the guard; moving a store that does not match is the server's
+/// decision, made in its startup with [`set_embedder`] (issue #138).
 ///
 /// A dimensionless backend (`--embedder none`) claims no vector space: it is
 /// neither recorded nor checked, so BM25-only mode opens any store and only
@@ -69,6 +111,10 @@ pub async fn current_version(db: &Db) -> Result<u32, StoreError> {
 /// no pair has never held a vector (every run that could write one records
 /// its pair here first), so the indexes are empty and the switch is free.
 ///
+/// A store that matches on id and width but never recorded a revision gets
+/// this run's revision written in: it predates the field, and the vectors it
+/// holds are the ones this pin produces until a later pin says otherwise.
+///
 /// Two first runs on one shared store — `ws://`, where no advisory lock
 /// serialises processes — can both find the pair absent (issue #72). The
 /// write is conditional on it still being absent, so the engine lets exactly
@@ -77,71 +123,72 @@ pub async fn current_version(db: &Db) -> Result<u32, StoreError> {
 ///
 /// # Errors
 /// [`StoreError::EmbedderMismatch`] when the store was embedded with another
-/// model or width, or when a concurrent first run recorded its pair first.
-pub async fn ensure_embedder(db: &Db, model_id: &str, dim: usize) -> Result<(), StoreError> {
+/// model, width or revision, or when a concurrent first run recorded its
+/// pair first.
+pub async fn ensure_embedder(
+    db: &Db,
+    model_id: &str,
+    dim: usize,
+    revision: Option<&str>,
+) -> Result<(), StoreError> {
     if dim == 0 {
         return Ok(());
     }
-    let width = i64::try_from(dim).unwrap_or(i64::MAX);
+    let mismatch = |stored: StoredEmbedder| StoreError::EmbedderMismatch {
+        stored_model: stored.model,
+        stored_dim: stored.dim,
+        stored_revision: stored.revision,
+        configured_model: model_id.to_owned(),
+        configured_dim: width(dim),
+        configured_revision: revision.map(str::to_owned),
+    };
 
-    let mut resp = db
-        .query(
-            "SELECT VALUE embedder_model FROM meta:main;
-             SELECT VALUE embedder_dim FROM meta:main;",
-        )
-        .await?
-        .check()?;
-    let stored_model: Option<String> = resp
-        .take::<Vec<Option<String>>>(0)?
-        .into_iter()
-        .flatten()
-        .next();
-    let stored_dim: Option<i64> = resp
-        .take::<Vec<Option<i64>>>(1)?
-        .into_iter()
-        .flatten()
-        .next();
-
-    match (stored_model, stored_dim) {
-        (Some(model), Some(stored)) if model != model_id || stored != width => {
-            Err(StoreError::EmbedderMismatch {
-                stored_model: model,
-                stored_dim: stored,
-                configured_model: model_id.to_owned(),
-                configured_dim: width,
-            })
+    match stored_embedder(db).await? {
+        Some(stored) if !stored.matches(model_id, dim, revision) => Err(mismatch(stored)),
+        Some(stored) => {
+            if let (None, Some(revision)) = (&stored.revision, revision) {
+                tracing::info!(
+                    model = model_id,
+                    revision,
+                    "recording store embedder revision"
+                );
+                db.query(
+                    "UPDATE meta:main SET embedder_revision = $revision
+                     WHERE embedder_revision IS NONE",
+                )
+                .bind(("revision", revision.to_owned()))
+                .await?
+                .check()?;
+            }
+            Ok(())
         }
-        (Some(_), Some(_)) => Ok(()),
-        _ => {
+        None => {
             // No pair recorded means no run could have written a vector yet,
             // so the HNSW indexes still stand empty at the width the schema
             // baked in — adopt this backend's width now, while it costs
-            // nothing. From here on, only `--reindex` may move it.
+            // nothing.
             if dim != EMBEDDING_DIM {
                 crate::repo::reindex::reset_vectors(db, dim).await?;
             }
-            tracing::info!(model = model_id, dim, "recording store embedder");
+            tracing::info!(model = model_id, dim, revision, "recording store embedder");
             // Conditional on the pair still being absent: a check in Rust and
             // an unconditional write is two statements, and another first run
             // fits between them (issue #72). One guarded statement is the
             // only write the engine applies atomically, so exactly one pair
             // lands — the re-read below is what tells a loser it lost.
             db.query(
-                "UPDATE meta:main SET embedder_model = $model, embedder_dim = $dim
+                "UPDATE meta:main SET embedder_model = $model, embedder_dim = $dim,
+                     embedder_revision = $revision
                  WHERE embedder_model IS NONE AND embedder_dim IS NONE",
             )
             .bind(("model", model_id.to_owned()))
-            .bind(("dim", width))
+            .bind(("dim", width(dim)))
+            .bind(("revision", revision.map(str::to_owned)))
             .await?
             .check()?;
             match stored_embedder(db).await? {
-                Some((model, stored)) if model == model_id && stored == width => Ok(()),
-                Some((stored_model, stored_dim)) => Err(StoreError::EmbedderMismatch {
-                    stored_model,
-                    stored_dim,
-                    configured_model: model_id.to_owned(),
-                    configured_dim: width,
-                }),
+                Some(stored) if stored.matches(model_id, dim, revision) => Ok(()),
+                Some(stored) => Err(mismatch(stored)),
                 // `ensure` ran before this, so `meta:main` exists and one of
                 // the writers above matched it; an absent pair here is the
                 // engine misbehaving, not a caller error.
@@ -153,19 +200,20 @@ pub async fn ensure_embedder(db: &Db, model_id: &str, dim: usize) -> Result<(), 
     }
 }
 
-/// The model and width this store's vectors were built with, if a run has
-/// ever recorded one.
+/// The vector space this store's rows were built in, if a run has ever
+/// recorded one.
 ///
 /// `None` for a store only ever opened in BM25-only mode: a dimensionless
 /// backend claims no vector space, so it writes nothing here.
 ///
 /// # Errors
 /// [`StoreError::Db`] for anything the engine rejects.
-pub async fn stored_embedder(db: &Db) -> Result<Option<(String, i64)>, StoreError> {
+pub async fn stored_embedder(db: &Db) -> Result<Option<StoredEmbedder>, StoreError> {
     let mut resp = db
         .query(
             "SELECT VALUE embedder_model FROM meta:main;
-             SELECT VALUE embedder_dim FROM meta:main;",
+             SELECT VALUE embedder_dim FROM meta:main;
+             SELECT VALUE embedder_revision FROM meta:main;",
         )
         .await?
         .check()?;
@@ -179,27 +227,46 @@ pub async fn stored_embedder(db: &Db) -> Result<Option<(String, i64)>, StoreErro
         .into_iter()
         .flatten()
         .next();
-    Ok(model.zip(dim))
+    let revision: Option<String> = resp
+        .take::<Vec<Option<String>>>(2)?
+        .into_iter()
+        .flatten()
+        .next();
+    Ok(model.zip(dim).map(|(model, dim)| StoredEmbedder {
+        model,
+        dim,
+        revision,
+    }))
 }
 
-/// Record `model_id`/`dim` as the store's vector space, replacing whatever
-/// was there.
+/// Record `model_id`/`dim`/`revision` as the store's vector space, replacing
+/// whatever was there.
 ///
-/// [`ensure_embedder`] only ever writes the pair when it is absent — it is a
-/// guard, and a guard that overwrites what it guards is not one. `--reindex`
-/// is the sanctioned way to change the pair, and this is where it says so.
-/// Writing it *before* the re-embedding loop is deliberate: the rows without
-/// vectors are the resume marker, so a run interrupted halfway must not come
-/// back to a store that thinks it still belongs to the old model.
+/// [`ensure_embedder`] only ever writes the space when it is absent — it is a
+/// guard, and a guard that overwrites what it guards is not one. Moving a
+/// store is a re-embed (the server's startup on a mismatch, or
+/// `agmem reindex`), and this is where it says so. Writing it *before* the
+/// re-embedding loop is deliberate: the rows without vectors are the resume
+/// marker, so a run interrupted halfway must not come back to a store that
+/// thinks it still belongs to the old model.
 ///
 /// # Errors
 /// [`StoreError::Db`] for anything the engine rejects.
-pub async fn set_embedder(db: &Db, model_id: &str, dim: usize) -> Result<(), StoreError> {
-    db.query("UPSERT meta:main SET embedder_model = $model, embedder_dim = $dim")
-        .bind(("model", model_id.to_owned()))
-        .bind(("dim", i64::try_from(dim).unwrap_or(i64::MAX)))
-        .await?
-        .check()?;
+pub async fn set_embedder(
+    db: &Db,
+    model_id: &str,
+    dim: usize,
+    revision: Option<&str>,
+) -> Result<(), StoreError> {
+    db.query(
+        "UPSERT meta:main SET embedder_model = $model, embedder_dim = $dim,
+             embedder_revision = $revision",
+    )
+    .bind(("model", model_id.to_owned()))
+    .bind(("dim", width(dim)))
+    .bind(("revision", revision.map(str::to_owned)))
+    .await?
+    .check()?;
     Ok(())
 }
 

--- a/crates/agmem-store/tests/migrate.rs
+++ b/crates/agmem-store/tests/migrate.rs
@@ -21,26 +21,80 @@ async fn the_embedder_is_recorded_once_and_then_enforced() {
     let conn = db::connect("mem://").await.expect("connect mem://");
     migrate::ensure(&conn).await.expect("ensure");
 
-    migrate::ensure_embedder(&conn, "bge-small-en-v1.5-q", 384)
+    migrate::ensure_embedder(&conn, "bge-small-en-v1.5-q", 384, None)
         .await
         .expect("first run records the embedder");
-    migrate::ensure_embedder(&conn, "bge-small-en-v1.5-q", 384)
+    migrate::ensure_embedder(&conn, "bge-small-en-v1.5-q", 384, None)
         .await
         .expect("the same embedder is fine");
 
-    let err = migrate::ensure_embedder(&conn, "potion-base-8m", 256)
+    let err = migrate::ensure_embedder(&conn, "potion-base-8m", 256, None)
         .await
         .expect_err("another model must be refused");
     let message = err.to_string();
     assert!(message.contains("bge-small-en-v1.5-q"), "{message}");
     assert!(
-        message.contains("--reindex"),
+        message.contains("agmem reindex"),
         "must name the remedy: {message}"
     );
 
-    migrate::ensure_embedder(&conn, "none", 0)
+    migrate::ensure_embedder(&conn, "none", 0, None)
         .await
         .expect("BM25-only mode claims no vector space and opens any store");
+}
+
+/// The revision is the third part of the key (issue #138): a store that
+/// never recorded one accepts any and takes it; once recorded, a different
+/// pin is a different space.
+#[tokio::test]
+async fn the_revision_is_backfilled_once_and_then_enforced() {
+    let conn = db::connect("mem://").await.expect("connect mem://");
+    migrate::ensure(&conn).await.expect("ensure");
+
+    migrate::ensure_embedder(&conn, "stub", 8, None)
+        .await
+        .expect("a backend without a revision records none");
+    let stored = migrate::stored_embedder(&conn)
+        .await
+        .expect("read")
+        .expect("recorded");
+    assert_eq!(stored.revision, None);
+    assert!(
+        stored.matches("stub", 8, Some("aaaa")),
+        "no revision on record matches any"
+    );
+
+    migrate::ensure_embedder(&conn, "stub", 8, Some("aaaa"))
+        .await
+        .expect("the first run that knows the revision is accepted");
+    let stored = migrate::stored_embedder(&conn)
+        .await
+        .expect("read")
+        .expect("recorded");
+    assert_eq!(stored.revision.as_deref(), Some("aaaa"), "and backfills it");
+
+    migrate::ensure_embedder(&conn, "stub", 8, None)
+        .await
+        .expect("a backend that claims no revision still matches");
+    let err = migrate::ensure_embedder(&conn, "stub", 8, Some("bbbb"))
+        .await
+        .expect_err("another pin of the same id is another space");
+    assert!(
+        matches!(
+            &err,
+            StoreError::EmbedderMismatch { stored_revision: Some(stored), configured_revision: Some(configured), .. }
+                if stored == "aaaa" && configured == "bbbb"
+        ),
+        "{err}"
+    );
+    assert!(err.to_string().contains("rev aaaa"), "{err}");
+
+    migrate::set_embedder(&conn, "stub", 8, Some("bbbb"))
+        .await
+        .expect("a re-embed moves the pin");
+    migrate::ensure_embedder(&conn, "stub", 8, Some("bbbb"))
+        .await
+        .expect("and the guard follows it");
 }
 
 /// Issue #72: concurrent first runs on one shared store race the
@@ -57,7 +111,7 @@ async fn concurrent_first_runs_record_exactly_one_embedder() {
         .map(|n| {
             let db = conn.clone();
             tokio::spawn(async move {
-                migrate::ensure_embedder(&db, &format!("contender-{n}"), 384).await
+                migrate::ensure_embedder(&db, &format!("contender-{n}"), 384, None).await
             })
         })
         .collect();
@@ -77,12 +131,15 @@ async fn concurrent_first_runs_record_exactly_one_embedder() {
     }
     assert_eq!(winners.len(), 1, "exactly one first run records its pair");
 
-    let (model, dim) = migrate::stored_embedder(&conn)
+    let stored = migrate::stored_embedder(&conn)
         .await
         .expect("read the pair")
         .expect("a pair was recorded");
-    assert_eq!(model, winners[0], "the store holds the winner's model");
-    assert_eq!(dim, 384);
+    assert_eq!(
+        stored.model, winners[0],
+        "the store holds the winner's model"
+    );
+    assert_eq!(stored.dim, 384);
 }
 
 /// A row written before v2 carries no `derived_from` column at all — a
@@ -376,7 +433,7 @@ async fn a_fresh_store_adopts_the_first_embedders_width() {
     let conn = db::connect("mem://").await.expect("connect mem://");
     migrate::ensure(&conn).await.expect("ensure");
 
-    migrate::ensure_embedder(&conn, "potion-base-8M", 256)
+    migrate::ensure_embedder(&conn, "potion-base-8M", 256, None)
         .await
         .expect("first run records the pair and adopts its width");
 
@@ -393,10 +450,10 @@ async fn a_fresh_store_adopts_the_first_embedders_width() {
     .check()
     .expect("a 256-wide vector lands in the redefined index");
 
-    migrate::ensure_embedder(&conn, "potion-base-8M", 256)
+    migrate::ensure_embedder(&conn, "potion-base-8M", 256, None)
         .await
         .expect("the same pair is still fine");
-    let err = migrate::ensure_embedder(&conn, "bge-small-en-v1.5-q", 384)
+    let err = migrate::ensure_embedder(&conn, "bge-small-en-v1.5-q", 384, None)
         .await
         .expect_err("the baked width is now the wrong one");
     assert!(err.to_string().contains("potion-base-8M"), "{err}");

--- a/docs/design.md
+++ b/docs/design.md
@@ -86,7 +86,7 @@ Key properties:
 | Background workers: elaboration, consolidation, decay sweeps | **No background jobs.** Decay is computed at read time; pruning runs lazily at startup; consolidation is agent-invoked (phase 3) |
 | decision/retrieval/response trace graph | Provenance (`source`) on every record + supersession chains; `inspect` walks them. Full trace tables deferred |
 | Grants, principals, key attenuation, delegation | Local trust model: space isolation + destructive-op flags. No auth in v1 |
-| REST + Management API + SDKs + CLI/TUI | **None.** MCP tools only; the CLI is `--doctor`, `--reindex`, and the one-shots that mirror a tool (`agmem context`, `agmem doc …`, `agmem hook …`) |
+| REST + Management API + SDKs + CLI/TUI | **None.** MCP tools only; the CLI is `--doctor`, `agmem reindex`, and the one-shots that mirror a tool (`agmem context`, `agmem doc …`, `agmem hook …`) |
 
 ---
 
@@ -257,9 +257,11 @@ Notes:
   it needs the query-side embedding anyway.
 - Dimension 384 is what v1 baked in; a first run with a wider model (the
   default is now 768) redefines the indexes before recording its pair. The
-  dimension is recorded in `meta`; switching models requires an explicit
-  `agmem --reindex`
-  maintenance pass — startup refuses a model/dim mismatch with a clear
+  dimension is recorded in `meta` with the model id and its pinned
+  revision (#138); startup moves a store whose recorded space differs from
+  the configured model and re-embeds it in the background, and
+  `agmem reindex` does the same in one sitting — see §5.5. The store crate's
+  guard still refuses a mismatch with a clear
   error rather than silently mixing spaces.
 - `writer` (v6) is the attribution `source` never was: `source` says where
   the content came from, `writer` says which client and session put it in the
@@ -707,7 +709,7 @@ agmem/
 │       │   ├── startup.rs        # steps 4–9 of §5.1, shared by every route
 │       │   ├── lock.rs           # the single-writer advisory lock
 │       │   ├── doctor.rs         # --doctor self-check
-│       │   ├── reindex.rs        # --reindex re-embedding pass
+│       │   ├── reindex.rs        # the re-embedding pass: background drain + `agmem reindex`
 │       │   ├── oneshot.rs        # `agmem context`: one briefing, no server;
 │       │   │                     #   the daemon/direct routes `doc` shares
 │       │   ├── doc.rs            # `agmem doc put/get/list/forget` (#135)
@@ -830,7 +832,8 @@ main()
  6. migrate::ensure()     — idempotent DEFINEs, meta.schema_version gate
  7. embedder init (async — model may download on very first run)
       meta.embedder_model/dim  vs  configured backend
-      └─ mismatch → hard error naming the `reindex` remedy (no silent mixing)
+      └─ mismatch → the configured model wins (#138): move the store, drain in
+         the background, a notice on every tool result until done
  8. repo::prune_expired() — lazy TTL close of decayed `fast` records, every
       space at once, and never fatal: the schema and the embedder are up, so a
       failed sweep is logged and the session is served anyway
@@ -1119,7 +1122,7 @@ points, keeping the process count at one:
 | Decay sweep (importance × rate daily) | Computed in the scoring formula at read time — nothing to run |
 | TTL expiry of context-category | `repo::prune_expired` closes decayed `fast` records at every start |
 | Consolidation / elaboration | `consolidate` returns *candidates* — near-dup clusters, contradiction pairs, stale contexts; the **agent** decides merges via `remember(supersedes)` or `forget`. The LLM stays client-side (issue #25) |
-| Reindex / re-embed | Explicit maintenance op (`agmem --reindex`), required for embedder change: clears every vector, redefines both HNSW indexes at the new width, then re-embeds — the rows still without a vector are what an interrupted pass resumes from |
+| Reindex / re-embed | Automatic on a model change (#138): startup clears every vector, redefines both HNSW indexes at the new width, records the new space, then a background task in the process holding the store re-embeds while it serves, with a notice on every tool result until done; `agmem reindex [--model]` is the same pass in one sitting. The rows still without a vector are what an interrupted pass resumes from |
 | fsck duplicate audit | Folded into `inspect stats` + `consolidate` candidates |
 
 The prune is one `UPDATE`, and the decay curve is not repeated in it. The
@@ -1198,7 +1201,7 @@ rather than details:
 | `--db-user`, `--db-pass` / `AGMEM_DB_USER`, `AGMEM_DB_PASS` | none | Root signin for a remote `--db`, as a pair; embedded engines have no signin |
 | `--space` / `AGMEM_SPACE` | derived: git project name, else cwd name, else `default` | Current space for this server instance; an explicit value pins it (#44). Derivation uses the git *common* dir's parent, so every worktree of a repo shares one space, and never lands on the reserved `user` |
 | `--embedder` / `AGMEM_EMBEDDER` | `llama` | The local llama.cpp runtime, the only supported backend (`none` is a hidden test-only value). An API-backed backend (#120) would be a second variant |
-| `--model` / `AGMEM_MODEL` | `embeddinggemma-300m` | `embeddinggemma-300m` (768d, Q8_0, the measured winner — `docs/eval/embed-models.md`, `docs/eval/llama-runtime.md`) or `bge-small-en-v1.5` (384d, Q8_0, light). The model carries its own thresholds (`dedup::Thresholds`); checked across the daemon handshake; changing it on a store with vectors is `--reindex` (#138) |
+| `--model` / `AGMEM_MODEL` | `embeddinggemma-300m` | `embeddinggemma-300m` (768d, Q8_0, the measured winner — `docs/eval/embed-models.md`, `docs/eval/llama-runtime.md`) or `bge-small-en-v1.5` (384d, Q8_0, light). The model carries its own thresholds (`dedup::Thresholds`); checked across the daemon handshake; changing it on a store with vectors moves the store on the next start and re-embeds in the background, or `agmem reindex --model` now (#138) |
 | `--accelerator` / `AGMEM_ACCELERATOR` | `auto` | `metal` on an Apple-silicon build (compiled in by target, not by feature), `cpu` everywhere else and as the opt-out. CoreML on ONNX Runtime was measured and dropped (#139, `docs/eval/coreml-ep.md`) before ONNX Runtime itself was replaced |
 | `--pool`, `--max-k` / `AGMEM_POOL`, `AGMEM_MAX_K` | 64 / 50 | Retrieval pool and k ceiling |
 | `--tools` / `AGMEM_TOOLS` | `core` | Which tools a session serves: `core` removes `consolidate` and `forget` from the router (neither listed nor callable), `all` serves every tool. Travels the daemon handshake per session; one-shots ask for `all` on their own (#150) |
@@ -1208,7 +1211,7 @@ rather than details:
 | `--idle-timeout` / `AGMEM_IDLE_TIMEOUT` | 600 | Seconds the daemon outlives its last session; 0 keeps it until reboot |
 | `--daemon-serve` | — | Be the daemon. Started automatically; hidden from `--help` |
 | `--doctor` | — | One-shot self check: lock, DB open, migrate, embedder, sample roundtrip, vector coverage; prints report, exits |
-| `--reindex` | — | Re-embed every row under the configured backend and record its model/dim pair — the one sanctioned way to change embedders; exits |
+| `reindex` subcommand | — | Re-embed every row now, under the configured model or `--model`; refuses while a daemon serves the store; exits. `--reindex` is the hidden pre-v0.3.1 spelling |
 | `context` subcommand | — | Print one session-start briefing to stdout and exit (`--query`, `--space`, `--budget-chars`) — the shell-hook surface, no MCP served |
 | `hook <event>` subcommand | — | The Claude Code plugin's hooks, reading the hook JSON on stdin: `session-start` (aimed briefing, one-sentence footer, branch tag with its document count, post-compaction recall list), `post-tool-use` (recall/write log, once-per-session seam nudges), `stop` (recalled-but-wrote-nothing nudge); no MCP served |
 


### PR DESCRIPTION
Closes #138.

## What

The upgrade path for every existing store. A store recorded under another model, width or pinned revision — which is every store from before v0.3, holding bge on ONNX Runtime under the retired id `bge-small-en-v1.5-q` — used to refuse to open until `--reindex`. Now the configured model wins:

- **On open** (`startup::resolve`): vectors cleared, both HNSW indexes redefined at the new width, `meta` rewritten. Sub-second, and `meta` is written before the first vector so an interrupted move resumes rather than restarts.
- **In the background** (`reindex::drain`): the process holding the store — the daemon, or a `--no-daemon` session — re-embeds pending rows 16 at a time while serving. New writes embed immediately; old rows join the vector arm as the drain reaches them. Five failed batches in a row stop the drain and leave the rest to `agmem reindex`.
- **On every tool result** while rows are pending: `notice: N row(s) are still being re-embedded for <model>; recall's vector arm misses them until then (BM25 still sees them)`. Done through a hand-written `call_tool` (the `#[tool_handler]` macro's `list_tools` is reproduced beside it).
- **`agmem reindex [--model <spelling>]`**: the same pass in one sitting, no session attached. Refuses while a daemon answers on the socket, naming the pid. `--reindex` stays as a hidden alias for one release.
- **Revision as part of the key**: `Source::Gguf` pins the hub commit (`hf_hub::Repo::with_revision`), `Embedder::revision()` reports it, `meta.embedder_revision` records it. Compared only when both sides carry one; a pre-v0.3 store is backfilled. A release that moves a pin is then a vector-space change the store can see.
- **doctor**: prints the revision, a scheduled-move line instead of FAIL for a mismatch, and pending rows as ok with the remedy.

Decisions (user, 2026-09-06): the configured model always wins (no store-wins exception for runnable ids; the cross-worktree ping-pong risk is accepted for the simpler rule), blocking on open was rejected against the 120 s daemon ready deadline.

## Tests

- `tests/reindex.rs`: a pre-v0.3 fixture (3 rows vectored at 384 under the retired id) opened by another model is moved with every row pending and resumes on a second open; a moved pin moves the store while a missing one is backfilled; the drain finishes 43 rows while a concurrent write lands; the notice is on `recall`/`context`/`remember` over the wire and gone after the drain; the verb, its `--model`, and the hidden flag all reach the pass.
- `tests/daemon.rs`: `agmem reindex` refuses while a daemon serves, naming the pid.
- `agmem-store/tests/migrate.rs`: revision recorded, backfilled, enforced.

Full workspace suite, clippy `-D warnings` and fmt clean under `AGMEM_MODEL_DIR=/nonexistent`.

## Not in this PR

- Re-recording the eval fixtures with Gemma (still bge vectors), and the Gemma cluster bar.
- Doctor cannot read the live pending count while a daemon holds the store (needs a daemon status request).
- Gemma CPU latency on Linux, which sets how long the drain takes there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaM7oSutMKHS8BKh8ngCte