### PR TITLE
chore: release v0.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
   "owner": { "name": "Mate Alfoldi" },
   "metadata": {
     "description": "agmem — persistent memory for coding agents over MCP",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "jiff",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-embed"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "agmem-core",
  "hf-hub",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "agmem-core",
  "agmem-embed",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agmem-store"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "agmem-core",
  "jiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -21,9 +21,9 @@ homepage = "https://github.com/AlfoldiMate/agmem"
 # dependency with no version requirement. Local builds resolve by path either
 # way, and a caret requirement stays satisfied across the bumps release-plz
 # makes.
-agmem-core = { path = "crates/agmem-core", version = "0.3.0" }
-agmem-store = { path = "crates/agmem-store", version = "0.3.0" }
-agmem-embed = { path = "crates/agmem-embed", version = "0.3.0" }
+agmem-core = { path = "crates/agmem-core", version = "0.4.0" }
+agmem-store = { path = "crates/agmem-store", version = "0.4.0" }
+agmem-embed = { path = "crates/agmem-embed", version = "0.4.0" }
 
 # MCP + storage + embeddings (pinned per docs/design.md §4.1)
 rmcp = { version = "3.1", features = ["server", "macros", "transport-io"] }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "agmem",
   "displayName": "agmem memory",
   "description": "Persistent cross-session memory for Claude Code: the agmem MCP server, a briefing injected at every session start, checkpoint and tidy commands, and hooks that log what memory was used so the store can learn what helped.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": { "name": "Mate Alfoldi" },
   "homepage": "https://github.com/AlfoldiMate/agmem",
   "repository": "https://github.com/AlfoldiMate/agmem",


### PR DESCRIPTION



## 🤖 New release

* `agmem-core`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `agmem-store`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `agmem-embed`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `agmem-server`: 0.3.0 -> 0.4.0 (✓ API compatible changes)

### ⚠ `agmem-core` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/function_missing.ron

Failed in:
  function agmem_core::dedup::is_cluster_candidate, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-core-0.3.0/src/dedup.rs:101
  function agmem_core::dedup::is_correction_candidate, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-core-0.3.0/src/dedup.rs:79
  function agmem_core::dedup::is_contradiction_candidate, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-core-0.3.0/src/dedup.rs:124
  function agmem_core::dedup::is_near_duplicate, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-core-0.3.0/src/dedup.rs:69

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  CORRECTION_FLOOR in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-core-0.3.0/src/dedup.rs:65
  CLUSTER_THRESHOLD in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-core-0.3.0/src/dedup.rs:98
  NEAR_DUP_THRESHOLD in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-core-0.3.0/src/dedup.rs:14
```

### ⚠ `agmem-embed` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_missing.ron

Failed in:
  enum agmem_embed::candidates::Candidate, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/candidates.rs:62

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_added.ron

Failed in:
  variant Accelerator:Metal in /tmp/.tmpJTP69C/agmem/crates/agmem-embed/src/accelerator.rs:27
  variant Accelerator:Metal in /tmp/.tmpJTP69C/agmem/crates/agmem-embed/src/accelerator.rs:27
  variant Active:Metal in /tmp/.tmpJTP69C/agmem/crates/agmem-embed/src/accelerator.rs:79
  variant Active:Metal in /tmp/.tmpJTP69C/agmem/crates/agmem-embed/src/accelerator.rs:79

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Accelerator::CoreMl, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/accelerator.rs:27
  variant Accelerator::CoreMl, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/accelerator.rs:27
  variant Active::CoreMl, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/accelerator.rs:87
  variant Active::CoreMl, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/accelerator.rs:87

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/feature_missing.ron

Failed in:
  feature rerank in the package's Cargo.toml
  feature coreml in the package's Cargo.toml
  feature candidates in the package's Cargo.toml

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/function_missing.ron

Failed in:
  function agmem_embed::candidates::cache_dir, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/candidates.rs:201

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/inherent_method_missing.ron

Failed in:
  Active::execution_providers, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/accelerator.rs:111
  Active::execution_providers, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/accelerator.rs:111

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/module_missing.ron

Failed in:
  mod agmem_embed::candidates, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/candidates.rs:1
  mod agmem_embed::fastembed, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/fastembed.rs:1
  mod agmem_embed::rerank, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/rerank.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  DIM in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/fastembed.rs:20
  CANDIDATE_ENV in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/candidates.rs:42
  MODEL_ID in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/rerank.rs:17
  MODEL_ID in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/fastembed.rs:17

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/struct_missing.ron

Failed in:
  struct agmem_embed::fastembed::FastembedBackend, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/fastembed.rs:31
  struct agmem_embed::rerank::FastembedReranker, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/rerank.rs:24
  struct agmem_embed::candidates::CandidateBackend, previously in file /tmp/release-plz-agmem-core-K4gyWK/worktree/target/package/agmem-embed-0.3.0/src/candidates.rs:226

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/trait_method_added.ron

Failed in:
  trait method agmem_embed::Embedder::thresholds in file /tmp/.tmpJTP69C/agmem/crates/agmem-embed/src/lib.rs:62
```

<details><summary><i><b>Changelog</b></i></summary><p>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).