### PR TITLE
docs: install by tap or cargo, the loop in prose, and a development section that wires the .claude folder

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,17 +1,16 @@
 # ctx-flow
 
 A token-frugal development framework for Claude Code, living as the `.claude`
-folder of the [agmem](https://github.com/AlfoldiMate/agmem) repository — the
-framework agmem is developed with, and the first consumer of agmem's Claude
-Code plugin. Copy the folder into your own project to use it.
+folder of the [agmem](https://github.com/AlfoldiMate/agmem) repository. It is
+the framework agmem is developed with, and the first consumer of agmem's
+Claude Code plugin. Copy the folder into your own project to use it.
 
-The premise: **the main thread should hold decisions, and everything else should
-hold output.** Build logs, search results, page snapshots and ticket records are
-the largest objects in any session and carry the least information per token.
-ctx-flow routes each of them into a subagent sized for the job, and keeps
-durable memory in [agmem](https://github.com/AlfoldiMate/agmem) — a
-per-project MCP memory store — so the main thread's context survives `/clear`
-and `/compact`.
+The premise: **the main thread should hold decisions, and everything else
+should hold output.** Build logs, search results, page snapshots and ticket
+records are the largest objects in any session and carry the least
+information per token. ctx-flow routes each of them into a subagent sized for
+the job, and keeps durable memory in agmem, a per-project MCP memory store, so
+the main thread's context survives `/clear` and `/compact`.
 
 ## Install
 
@@ -22,37 +21,28 @@ cp -R /path/to/agmem/.claude /path/to/your-project/.claude
 ```
 
 Inside the agmem repo itself it is already in place, and it is what every
-session here runs — including the sessions that develop the plugin, so a
-change to `plugin/` is felt by the next `claude --plugin-dir ./plugin`.
-
-For linked git worktrees, symlink the main worktree's `.claude` into each one;
-everything here is symlink-safe, and agmem derives its memory space through
-the shared git dir regardless, so a fresh worktree is never amnesiac either
-way.
-
-Then verify the toolchain:
-
-```
-/ctx-flow-doctor
-```
+session here runs, including the sessions that develop the plugin. The
+repository README's [Development](../README.md#development) section walks
+through the setup from a fresh clone; this section is the same list with the
+reasons attached.
 
 ### Dependencies
 
 | Tool | Why | Install |
 |---|---|---|
-| [nu](https://www.nushell.sh) | runs the hooks; provides one of the two MCP servers the framework wants | `brew install nushell` |
+| [nu](https://www.nushell.sh) | runs the hooks and scripts; provides one of the two MCP servers the framework wants | `brew install nushell` |
 | [agmem](https://github.com/AlfoldiMate/agmem) | persistent cross-session memory, over MCP | `brew install AlfoldiMate/tap/agmem` |
 | [ast-grep](https://ast-grep.github.io) | structural (syntax-aware) code search | `brew install ast-grep` |
-| [gh](https://cli.github.com) | GitHub — always over the GitHub MCP server | `brew install gh` |
-| [playwright-cli](https://github.com/microsoft/playwright-cli) | browser driving as shell commands | `npm i -g playwright-cli` |
+| [gh](https://cli.github.com) | GitHub, always over the GitHub MCP server | `brew install gh` |
 | [rtk](https://github.com/rtk-ai/rtk) | transparently compresses Bash output | `brew install rtk` (hook ships here) |
-| acli *(optional)* | Jira | Atlassian's installer |
+| [playwright-cli](https://github.com/microsoft/playwright-cli) *(optional)* | browser driving as shell commands, for the `browser` agent | `npm i -g playwright-cli` |
+| acli *(optional)* | Jira, for the `tracker` agent | Atlassian's installer |
 | tree-sitter-cli *(optional)* | builds grammars ast-grep does not ship | `npm i -g tree-sitter-cli` |
 
 You do not have to *use* Nushell as your shell; the hooks run under `nu`
 regardless of what your terminal runs. Register the nu MCP server, and
-install the agmem plugin — it registers agmem's server and carries every
-memory hook, so nothing about memory needs wiring by hand:
+install the agmem plugin. The plugin registers agmem's server and carries
+every memory hook, so nothing about memory needs wiring by hand:
 
 ```bash
 claude mcp add nu -- nu --mcp
@@ -60,59 +50,96 @@ claude plugin marketplace add AlfoldiMate/agmem
 claude plugin install agmem@agmem
 ```
 
-**On MCP:** the framework avoids MCP servers — a CLI beats one wherever a CLI
-exists (you choose the fields, the output pipes, no schema in the prompt). Two
+Then verify the toolchain from inside a session:
+
+```
+/ctx-flow-doctor
+```
+
+It checks every row above, both MCP registrations, the hooks, and whether
+ast-grep parses the project's languages, and prints the exact fix for
+anything broken. This repo's hooks are Nushell, which ast-grep does not ship
+a grammar for; `/ast-grep-it nu` builds one into `~/.cache/ctx-flow` and
+registers it in a machine-local `sgconfig.yml` at the repo root.
+
+**On MCP:** the framework avoids MCP servers. A CLI beats one wherever a CLI
+exists: you choose the fields, the output pipes, no schema in the prompt. Two
 exceptions, each holding state no CLI reaches: `nu --mcp` earns its slot by
 *being* the shell (structured pipelines, `$history` for re-slicing past
 results without re-running, safe uncapped first runs), and `agmem` by *being*
-the memory — cross-session state that has to outlive every process.
+the memory, cross-session state that has to outlive every process.
 
-**On agmem:** it needs **v0.1.10 or newer**. The plugin's hooks are
-`agmem hook <event>` — a subcommand of the binary itself, so the plugin
-depends on nothing else — and an older binary answers them with a usage
-error the session never sees: memory simply fails to arrive. Below v0.1.1
-there is also no space derivation, so every project silently reads and
-writes one shared `default` space. `agmem --doctor` prints the space it
-derives for the current directory, and `/ctx-flow-doctor` flags an old,
-stale or duplicated binary and a missing plugin. If you had registered
-agmem by hand before (`claude mcp add --scope user agmem`), remove it
-(`claude mcp remove agmem -s user`): Claude Code connects only one, yours
-winning, and that changes the tool names to `mcp__agmem__*` — this
-framework's agents name the plugin's (`mcp__plugin_agmem_agmem__*`), so under
-a by-hand registration they start without memory. `/agmem:doctor` flags the
-duplicate. The store is one directory
-(`~/Library/Application Support/dev.agmem.agmem` on macOS,
-`~/.local/share/agmem` on Linux) — back it up or delete it as a unit. There is
-no server-side LLM: the session distils, the store never rewrites what it
-holds.
+**On agmem:** install the current release; the plugin's version is pinned to
+the binary's, because its hooks are `agmem hook <event>`, subcommands of the
+binary itself. An older binary answers them with a usage error the session
+never sees, and memory simply fails to arrive: hooks need 0.1.10, documents
+(`agmem doc`, which `scripts/doc-put.nu` calls) need 0.2.0. `/ctx-flow-doctor`
+flags an old, stale or duplicated binary and a missing plugin. If you had
+registered agmem by hand before (`claude mcp add --scope user agmem`), remove
+it (`claude mcp remove agmem -s user`): Claude Code connects only one, yours
+winning, and that changes the tool names to `mcp__agmem__*`. This framework's
+agents name the plugin's (`mcp__plugin_agmem_agmem__*`), so under a by-hand
+registration they start without memory. `/agmem:doctor` flags the duplicate.
+The store is one directory (`~/Library/Application Support/dev.agmem.agmem`
+on macOS, `~/.local/share/agmem` on Linux); back it up or delete it as a
+unit. There is no server-side LLM: the session distils, the store never
+rewrites what it holds.
 
 **On rtk:** the framework's `settings.json` registers its hook (`rtk hook
-claude`) — install only the binary, and do **not** also run `rtk init -g`, or
-every Bash call is rewritten twice (`/ctx-flow-doctor` flags this as DOUBLED).
-As of rtk 0.46 the hook only rewrites the command (`updatedInput`), leaving
-your permission prompts intact — older versions also emitted
-`permissionDecision: "allow"`. Telemetry is on by default
+claude`). Install only the binary, and do **not** also run `rtk init -g`, or
+every Bash call is rewritten twice (`/ctx-flow-doctor` flags this as
+DOUBLED). As of rtk 0.46 the hook only rewrites the command
+(`updatedInput`), leaving your permission prompts intact; older versions also
+emitted `permissionDecision: "allow"`. Telemetry is on by default
 (`rtk telemetry disable`).
+
+### Worktrees and profiles
+
+The agmem checkout runs as a bare repository with one sibling directory per
+branch, and `/bare-worktree` is the only way worktrees are made there:
+
+```
+proj/                  the container ("root")
+├── .bare/             the one real git dir
+├── .git               a file: "gitdir: ./.bare", so git works from root
+├── .claude/           optional: symlinked into every worktree on apply
+├── .profiles/         the gitignored files each worktree needs
+│   ├── .state/        one manifest per worktree, recording what apply did
+│   ├── dflt/          the default profile, always applied first
+│   └── <name>/        any other directory is a named profile
+└── <worktree>/        one sibling directory per branch
+```
+
+Every file in a profile directory is symlinked into the worktree at the same
+relative path: `settings.local.json`, `sgconfig.yml`, a machine-local skill,
+whatever a session needs but git must not track. Raw `git worktree add`
+skips all of it, and a `PreToolUse` hook denies it in this layout. `init`
+transforms an existing clone; `add`, `remove`, `apply`, `discard` and `which`
+do the rest; the script's header comment documents the profile format and
+its hooks. A plain clone needs none of this. Everything here is symlink-safe,
+and agmem derives its memory space through the shared git dir regardless, so
+a worktree made either way is never amnesiac.
 
 ## What's in it
 
-### CLAUDE.md — the system prompt
+### CLAUDE.md, the system prompt
 
 The routing discipline lives in `CLAUDE.md`, loaded automatically every
 session. It used to be a skill; it isn't one any more, deliberately. A skill
-must be *discovered* — a description line the model may or may not act on —
+must be *discovered*, a description line the model may or may not act on,
 and routing that only sometimes applies is routing that silently doesn't.
-Rules that apply to every session belong in the file that loads every session.
+Rules that apply to every session belong in the file that loads every
+session.
 
 It carries: the delegation rule (route by **information ratio**, not task
 type), the routing table, payload discipline, the shell and worktree rules,
 what the framework adds to the plugin's memory rules, and the answer-shape
-cases the output style leaves out. It is rules only, held under 6 kB — on
+cases the output style leaves out. It is rules only, held under 6 kB. On
 2026-09-04 it was 11.6 kB, a third of it justification, and at ~2.9k tokens
 on every turn it was 16% of the fixed prefix. The justification lives here.
 
 Why the shell rules exist: auto mode's preamble asks for `cat`, `sed -n` and
-`sed`. That chooses the tool, not the language, and the language is nu — a
+`sed`. That chooses the tool, not the language, and the language is nu. A
 windowed `sed -n 'a,bp'` read is Read offset/limit spelled in shell and
 passes the read guard, but a `sed` *edit* is regex always over source that
 carries `$ { [ ? |` on nearly every line, so it corrupts quietly rather than
@@ -121,111 +148,126 @@ when the two rules collided (#146).
 
 Why the answer-shape rules exist: output is shaped so the reader can *act*
 on it, not just read it. Working memory is small, starting is the hardest
-step, and buried wins do not register — so the first line is the outcome or
+step, and buried wins do not register. So the first line is the outcome or
 the next action, multi-step work is numbered and tracked, and a rule is
 broken only when it would delete the answer itself.
 
 Why the memory section is short: the plugin's briefing footer already states
-the rules every session — the briefing is established fact, `recall` in
-words, correct with `supersedes` — and the same rule used to be repeated in
-the agmem instructions, the skill description and two CLAUDE.md bullets.
-One copy, the plugin's; CLAUDE.md keeps only what the framework adds.
+the rules every session (the briefing is established fact, `recall` in words,
+correct with `supersedes`), and the same rule used to be repeated in the
+agmem instructions, the skill description and two CLAUDE.md bullets. One
+copy, the plugin's; CLAUDE.md keeps only what the framework adds.
 
 ### Seven agents
 
 | Agent | Model / effort | Absorbs |
 |---|---|---|
-| `runner` | haiku / low | builds, suites, linters — returns the failure signature |
-| `verifier` | sonnet / high | adversarial check of one claim — defaults to refuting |
-| `architect` | fable / high | design of a non-trivial change — read-only, never edits |
-| `browser` | sonnet / medium | `playwright-cli` sessions — snapshots stop here |
-| `tracker` | haiku / low | Jira/GitHub via `gh`/`acli` — never raw records |
-| `scout` | haiku / medium | where a symbol lives, which files match a shape — paths and line refs, never bodies, under 3k chars |
-| `researcher` | sonnet / medium | a bounded question that takes many files, docs or the web — under 2k chars back, the rest as a document |
+| `runner` | haiku / low | builds, suites, linters; returns the failure signature |
+| `verifier` | sonnet / high | adversarial check of one claim; defaults to refuting |
+| `architect` | fable / high | design of a non-trivial change; read-only, never edits |
+| `browser` | sonnet / medium | `playwright-cli` sessions; snapshots stop here |
+| `tracker` | haiku / low | Jira/GitHub via `gh`/`acli`; never raw records |
+| `scout` | haiku / medium | where a symbol lives, which files match a shape; paths and line refs, never bodies, under 3k chars |
+| `researcher` | sonnet / medium | a bounded question that takes many files, docs or the web; under 2k chars back, the rest as a document |
 
-Every one ends with a **mandatory return contract**: fixed keys, hard caps, and
-an explicit forbidden list. An unschematized subagent writes an essay; a
+Every one ends with a **mandatory return contract**: fixed keys, hard caps,
+and an explicit forbidden list. An unschematized subagent writes an essay; a
 schematized one writes 200 tokens. Tiers are picked by *consequence of being
-wrong*, not output size — `runner` misses cost one re-dispatch; a bad
+wrong*, not output size: `runner` misses cost one re-dispatch; a bad
 `architect` plan is discovered late, after the code exists.
 
 Broad codebase exploration stays with Claude Code's built-in `Explore`, with
 the same cap pasted into its prompt; `scout` is the cheaper cousin for a
-question with an enumerable answer — where is X, which files do Y — that
+question with an enumerable answer (where is X, which files do Y) that
 should come back as refs, not prose. `researcher` is the target for what
 used to go to `general-purpose`, which over 71 audited sessions returned 16k
 characters on average and is no longer a target at all.
 
 What each agent preloads is sized to what it returns. `architect`, `verifier`
 and `scout` carry the agmem `recall` tool for their `role:` lessons; `runner`,
-`tracker`, `browser` and `researcher` do not — the schema was ~6k tokens per
+`tracker`, `browser` and `researcher` do not. The schema was ~6k tokens per
 dispatch, runner alone ran 157 times, and the dispatcher pastes any
-applicable lesson into the prompt instead. The three ast-grep users preload
+applicable lesson into the prompt instead. The four ast-grep users preload
 `skills/ast-grep-lite`, a 2 kB card; the full `ast-grep` skill stays for the
 main thread.
 
 ### Five commands
 
-- **`/checkpoint`** — runs the agmem plugin's checkpoint ritual (recall
-  first, so corrections land as `supersedes`; `reflect` with `derived_from`
-  for conclusions) so you can `/clear` instead of letting auto-compaction
-  fire, then applies the gate that accepts or drops agents' proposed
-  learnings — the one step that is this framework's own.
-- **`/agmem-import`** — moves a pre-agmem `LEDGER.md` and branch state files
-  into the store, once. Showing and tidying the store are the
-  plugin's `/agmem:memory show` and `/agmem:memory tidy`.
-- **`/ctx-flow-doctor`** — checks every dependency above, the hooks, both MCP
+- **`/checkpoint`** runs the agmem plugin's checkpoint ritual (recall first,
+  so corrections land as `supersedes`; `reflect` with `derived_from` for
+  conclusions) so you can `/clear` instead of letting auto-compaction fire,
+  then applies the gate that accepts or drops agents' proposed learnings, the
+  one step that is this framework's own.
+- **`/agmem-import`** moves a pre-agmem `LEDGER.md` and branch state files
+  into the store, once. Showing and tidying the store are the plugin's
+  `/agmem:memory show` and `/agmem:memory tidy`.
+- **`/ctx-flow-doctor`** checks every dependency above, the hooks, both MCP
   registrations, and whether ast-grep actually parses this project's
-  languages; prints the exact fix for anything broken — including a stale
+  languages; prints the exact fix for anything broken, including a stale
   agmem binary, which fails silently otherwise.
-- **`/ast-grep-it [lang]`** — teaches ast-grep a language it does not ship.
-  Called bare, it sets up whatever this project most needs.
-  ast-grep loads any tree-sitter grammar from a dynamic library, so "not
-  supported" is usually a missing binary, not a missing capability — Nushell
-  being the case in point. Finds the grammar repo, compiles it into
+- **`/ast-grep-it [lang]`** teaches ast-grep a language it does not ship.
+  Called bare, it sets up whatever this project most needs. ast-grep loads
+  any tree-sitter grammar from a dynamic library, so "not supported" is
+  usually a missing binary, not a missing capability, Nushell being the case
+  in point. Finds the grammar repo, compiles it into
   `~/.cache/ctx-flow/grammars` (shared by every project on the machine),
   registers it in the project's `sgconfig.yml`, and verifies it against real
-  files. `sgconfig.yml` is machine-local — gitignore it.
-- **`/bare-worktree`** — `init`, `add`, `remove`, `apply`, `discard`, `which`
-  for the bare-repo + sibling-worktrees layout; the only sanctioned way to
-  make a worktree here, since raw `git worktree add` skips the profile files
-  and the root-`.claude` symlink (a hook denies it).
+  files. `sgconfig.yml` is machine-local; gitignore it.
+- **`/bare-worktree`** is `init`, `add`, `remove`, `apply`, `discard`, `which`
+  for the layout above; the only sanctioned way to make a worktree here.
 
 ### The hooks
 
 Deterministic work that costs zero tokens and happens *every* time, which no
-prompt instruction achieves. Five are `.nu` scripts under `hooks/scripts/`;
-the sixth is rtk's. The memory hooks — briefing injection, the recall log,
-the seam nudges — are the agmem plugin's (`agmem hook …`), not this file's.
+prompt instruction achieves. Six are `.nu` scripts under `hooks/scripts/`,
+sharing `_common.nu` and the `ctx-flow-paths.nu` resolver; the seventh is
+rtk's. Their cases live in `hooks/tests/`. The memory hooks (briefing
+injection, the recall log, the seam nudges) are the agmem plugin's
+(`agmem hook …`), not this folder's.
 
-| Event | Does |
-|---|---|
-| `UserPromptSubmit` | the session-length nudge: reads the context size the last turn was served with (the API `usage` on the transcript's last assistant line — a `tail -c`, no parse of the file) and, from 120k tokens, says once "/checkpoint then /clear", then again only per further 40k. CLAUDE.md's "prefer several short sessions" rule had no enforcement; the audit's two largest sessions ran 400+ turns at ~267k each and never cleared. Knobs `CTX_FLOW_CONTEXT_NUDGE_TOKENS` / `_STEP`; cases in `hooks/tests/context-nudge.nu` |
-| `SessionStart` | the worktree layout check: in a bare layout the real `.claude` is symlinked into each worktree, and one carrying its own copy has silently diverged — a fact about this checkout the plugin cannot know. The briefing, the branch tag and the post-compaction warning arrive through the plugin's SessionStart hook |
-| `PreToolUse` | `rtk hook claude` — transparently rewrites Bash commands so their output arrives compressed; plus the bare-worktree guard that denies raw `git worktree add/remove/move` in a bare layout; plus the read guard (`Read` and `Bash`), which denies a whole-file read — a bare `Read` with no `offset`/`limit`, or `cat`/`head`/`tail`/`sed` printing more than 300 lines of a file over 12 kB — and asks for a window instead. The 2026-09-03 token audit found those two shapes were 46% of every tool-result character this repo's sessions ever paid for. Any windowed call passes, including one whose `limit` covers the whole file; `cat big \| wc -l`, heredocs and redirects pass; knobs `CTX_FLOW_READ_MAX_LINES` / `CTX_FLOW_READ_SMALL_BYTES`; cases in `hooks/tests/read-guard.nu` |
-| `PostToolUse` | one nudge, fired at most once per session and unable to block: when a Bash call reached for `sed`/`python`/`grep` where nu or ast-grep is the house tool. It exists because a rule in an always-loaded file is a rule you stop seeing — this repo`s own transcripts showed CLAUDE.md losing to habit on 18% of Bash calls. The `git push` checkpoint nudge moved to the plugin |
+| Event | Script | Does |
+|---|---|---|
+| `UserPromptSubmit` | `prompt-context-nudge.nu` | The session-length nudge: reads the context size the last turn was served with (the API `usage` on the transcript's last assistant line, a `tail -c`, no parse of the file) and, from 120k tokens, says once "/checkpoint then /clear", then again only per further 40k. CLAUDE.md's "prefer several short sessions" rule had no enforcement; the audit's two largest sessions ran 400+ turns at ~267k each and never cleared. Knobs `CTX_FLOW_CONTEXT_NUDGE_TOKENS` / `_STEP` |
+| `SessionStart` | `session-start-layout.nu` | The worktree layout check: in a bare layout the real `.claude` is symlinked into each worktree, and one carrying its own copy has silently diverged, a fact about this checkout the plugin cannot know. The briefing, the branch tag and the post-compaction warning arrive through the plugin's own SessionStart hook |
+| `SessionStart` | `session-start-notebook.nu` | Prints `notebook.md` into context whole, verbatim, no budget. If it outgrows a session, that is a finding for Claude to act on by pruning, not for a hook to hide by summarising |
+| `PreToolUse` (Bash) | `rtk hook claude` | Transparently rewrites Bash commands so their output arrives compressed |
+| `PreToolUse` (Bash) | `pre-worktree-guard.nu` | Denies raw `git worktree add/remove/move` in a bare layout, since they skip the profiles and the `.claude` symlink |
+| `PreToolUse` (Bash, Read) | `pre-read-guard.nu` | Denies a whole-file read: a bare `Read` with no `offset`/`limit`, or `cat`/`head`/`tail`/`sed` printing more than 300 lines of a file over 12 kB, and asks for a window instead. The 2026-09-03 token audit found those two shapes were 46% of every tool-result character this repo's sessions ever paid for. Any windowed call passes, including one whose `limit` covers the whole file; `cat big \| wc -l`, heredocs and redirects pass. Knobs `CTX_FLOW_READ_MAX_LINES` / `CTX_FLOW_READ_SMALL_BYTES` |
+| `PostToolUse` (Bash) | `post-bash-nudges.nu` | One nudge, fired at most once per session and unable to block: when a Bash call reached for `sed`/`python`/`grep` where nu or ast-grep is the house tool. It exists because a rule in an always-loaded file is a rule you stop seeing; this repo's own transcripts showed CLAUDE.md losing to habit on 18% of Bash calls. The `git push` checkpoint nudge moved to the plugin |
+
+### The notebook
+
+`notebook.md` is Claude's own, not the project's, and the undistilled
+counterpart to agmem: open questions, changed minds, taste, complaints,
+drafts, each entry dated. agmem holds claims; the notebook holds what is not
+a claim yet. It is written the moment something is noticed, mid-task, not
+held for a checkpoint. What firms up moves to the store; the file is pruned
+by hand, on a reread every week or so. It lives at the shared root in a bare
+layout so every worktree sees one copy, and the hook loads it whole because
+nothing should rewrite it.
 
 ### Where the rules live
 
-`CLAUDE.md` is injected as a user message *after* the system prompt; an output
-style is appended *to* it. So the two split by how much they need to survive
-momentum, not by topic:
+`CLAUDE.md` is injected as a user message *after* the system prompt; an
+output style is appended *to* it. So the two split by how much they need to
+survive momentum, not by topic:
 
 | File | Holds |
 |---|---|
-| `output-styles/ctx-flow.md` | the ~25 lines that must not be forgotten mid-task — routing, tool choice, answer shape |
+| `output-styles/ctx-flow.md` | the ~25 lines that must not be forgotten mid-task: routing, tool choice, answer shape |
 | `CLAUDE.md` | the routing table, the shell/worktree/memory rules, and every case the style does not cover |
-| this README | the reasoning behind both — one `Read` away, never on the prefix |
+| this README | the reasoning behind both, one `Read` away, never on the prefix |
+| `docs/reference.md` | the return-contract template, the memory mapping, playbook guards; loaded on demand when dispatching a custom agent |
 
 The cost is duplication: change a rule in one and it drifts from the other.
 Keep the style terse enough that it is obviously a summary. Set via the
 `outputStyle` field in `settings.json`; it is read once, so it takes effect
-after `/clear` or a new session, and it does not reach subagents — the
+after `/clear` or a new session, and it does not reach subagents. The
 sections CLAUDE.md dropped in favour of the style (delegation prose, the
 numbered answer shape) do not matter to a subagent, which has a return
 contract instead.
 
-Three commands — `/agmem-import`, `/ast-grep-it`, `/bare-worktree` — carry
+Three commands (`/agmem-import`, `/ast-grep-it`, `/bare-worktree`) carry
 `disable-model-invocation: true`: only you run them, so their description
 lines leave the model's skill listing. The machine-local
 `rust-expert-developer` skill's description is ~300 bytes for the same
@@ -234,14 +276,14 @@ reached the model anyway.
 
 ## Scoping capability to agents
 
-The main thread never loads what only one role needs — the same routing rule,
+The main thread never loads what only one role needs: the same routing rule,
 applied to configuration.
 
 ### MCP servers: agent-scoped by default
 
 A globally registered MCP server loads its schema into *every* session, which
 is exactly the cost this framework exists to avoid. When a server is genuinely
-needed, declare it on the one agent that uses it — it starts only when that
+needed, declare it on the one agent that uses it. It starts only when that
 agent runs, and the main session never sees a token of it:
 
 ```yaml
@@ -259,17 +301,17 @@ tools: Read, mcp__postgres__*
 
 `mcpServers` takes inline definitions (same schema as `.mcp.json`; stdio and
 http/sse both work) or the bare name of an already-registered global server.
-Declaring the server does not grant its tools — list `mcp__<server>__*` (or
+Declaring the server does not grant its tools: list `mcp__<server>__*` (or
 individual `mcp__<server>__<tool>` entries) in `tools:` as well. Two servers
 stay global: `nu --mcp` (it is the shell, and every session wants the shell)
-and `agmem` (it is the memory — the main thread writes it, and the agents
+and `agmem` (it is the memory; the main thread writes it, and the agents
 whose lessons pay for the schema declare read-only access to recall them).
 
 ### Skills: who gets to see one
 
 The levers, ordered from fully documented to verify-once:
 
-- **Guarantee a subagent has a skill** — the agent-frontmatter `skills:` field
+- **Guarantee a subagent has a skill.** The agent-frontmatter `skills:` field
   preloads the full skill content when the agent starts, no discovery step.
   Plugin skills are referenced by bare name, same as local ones:
 
@@ -282,26 +324,26 @@ The levers, ordered from fully documented to verify-once:
   ---
   ```
 
-- **Keep the model from invoking a skill anywhere** — set
+- **Keep the model from invoking a skill anywhere.** Set
   `disable-model-invocation: true` in the skill's own frontmatter; only you
   can trigger it, via `/name`. This also removes it from the preload pool
   ("preloading draws from the same set of skills Claude can invoke"), so it
   cannot combine with the lever above.
 
-- **Hide a local skill by config** — `skillOverrides` in `settings.json`;
+- **Hide a local skill by config.** `skillOverrides` in `settings.json`;
   values `"off"`, `"name-only"`, `"user-invocable-only"`, `"on"`:
 
   ```json
   { "skillOverrides": { "db-migrations": "off" } }
   ```
 
-  Explicitly does **not** cover plugin skills — "Plugin skills are not
+  Explicitly does **not** cover plugin skills: "Plugin skills are not
   affected by `skillOverrides`. Manage those through `/plugin` instead."
 
-- **Hidden in main + preloaded into one agent** — no *documented* combo, but
+- **Hidden in main + preloaded into one agent.** No *documented* combo, but
   two mechanically sound ones: preload is startup injection, not a Skill-tool
   call, and the documented preload exclusions are only
-  `disable-model-invocation` skills and the bundled `/verify` — neither hiding
+  `disable-model-invocation` skills and the bundled `/verify`; neither hiding
   mechanism below is on that list.
 
   | Skill origin | Hide in main via | Grant to the agent via |
@@ -309,13 +351,13 @@ The levers, ordered from fully documented to verify-once:
   | local | `skillOverrides: "off"` | `skills:` preload |
   | plugin | permissions deny rule `Skill(<name>)` | `skills:` preload |
 
-  Caveats: a deny rule blocks *invocation* — the skill's description line may
-  still occupy main-prompt tokens; and both rows rest on undocumented
+  Caveats: a deny rule blocks *invocation*, so the skill's description line
+  may still occupy main-prompt tokens; and both rows rest on undocumented
   interactions, so verify once in a scratch session (spawn the agent, have it
   quote a marker line from the skill) and re-verify after Claude Code
   upgrades.
 
-- **The zero-dependency fallback** — don't make it a skill. Only
+- **The zero-dependency fallback.** Don't make it a skill. Only
   `.claude/skills/` is discovered, so keep the folder at
   `.claude/docs/skills/<name>/` (for a plugin skill: vendor the folder out of
   the plugin instead of installing it) and have the agent's definition or
@@ -325,7 +367,7 @@ The levers, ordered from fully documented to verify-once:
 ## Memory
 
 Durable state lives in **agmem**, outside both the window and the repo. The
-space derives from the repo's shared git dir — every branch and worktree of a
+space derives from the repo's shared git dir: every branch and worktree of a
 project reads one store, and the reserved `user` space follows you across
 projects. This is the answer to "how do I keep context without keeping it in
 context": you don't hold it, you *address* it. The store holds the claims; the
@@ -334,24 +376,24 @@ window is a working set.
 The loop: the briefing arrives with the session (the plugin's `SessionStart`
 hook injects it; call the agmem `context` tool yourself on a topic shift, or
 when no block opened the session); `recall` before assuming; `/checkpoint` at
-seams — decisions with reasons, corrected assumptions,
-gotchas — with `recall` before every write so a correction lands as
-`supersedes` rather than a contradiction. The old claim stays readable and
-dated; only one is live. Three kinds carry the lifetime split the old
-ledger/state files used to: `fact` (fades over weeks unless used), `lesson`
-(fades over months), `instruction` (pinned into every briefing). Branch state
-is a `fact` with `decay_class: fast` tagged `branch:<slug>` — it dies in days,
-as branch state should, with no file to prune.
+seams, decisions with reasons, corrected assumptions, gotchas, with `recall`
+before every write so a correction lands as `supersedes` rather than a
+contradiction. The old claim stays readable and dated; only one is live.
+Three kinds carry the lifetime split the old ledger/state files used to:
+`fact` (fades over weeks unless used), `lesson` (fades over months),
+`instruction` (pinned into every briefing). Branch state is a `fact` with
+`decay_class: fast` tagged `branch:<slug>`; it dies in days, as branch state
+should, with no file to prune.
 
-Artifacts live there too, since v0.2.0: a subagent's long output — a plan,
-a review, a test log — is a **document**, written through
+Artifacts live there too, since agmem v0.2.0: a subagent's long output (a
+plan, a review, a test log) is a **document**, written through
 `scripts/doc-put.nu` (which tags it with the branch and the role) and handed
 back as `DOC: <id> memory://…`. `/checkpoint` reads a `LEARNED:` proposal
 out of the document and stores the accepted lesson citing it. The old
 `.claude/notes/` dropbox is retired; `/agmem-import` moves one in and
 `/ctx-flow-doctor` flags one that comes back.
 
-## Playbooks — knowledge that accumulates
+## Playbooks: knowledge that accumulates
 
 A role's project specifics live in the store as `lesson`s tagged
 `role:<agent>`. `architect`, `verifier` and `scout` recall their own tag
@@ -362,40 +404,39 @@ agent's definition and never override it; on conflict the agent file wins.
 
 The guards the file version needed are mostly the store's behaviour now:
 near-duplicates are refused at write time, unused rules fade by decay instead
-of accumulating, and `/agmem:memory tidy` merges what still piles up. What remains
-yours is the structural guard: **proposing is not committing**. Agents end
-with `LEARNED: <claim> — <evidence>`, and `/checkpoint` applies the four
-tests (durable, non-obvious, earned, actionable) before anything lands. The
-agent proposing a rule is often the cheapest thing in the system, and rules
-bind every future run — dropping proposals is the normal outcome. Scripts
-never self-modify at all.
+of accumulating, and `/agmem:memory tidy` merges what still piles up. What
+remains yours is the structural guard: **proposing is not committing**.
+Agents end with `LEARNED: <claim> — <evidence>`, and `/checkpoint` applies
+the four tests (durable, non-obvious, earned, actionable) before anything
+lands. The agent proposing a rule is often the cheapest thing in the system,
+and rules bind every future run; dropping proposals is the normal outcome.
+Scripts never self-modify at all.
 
-## Git, gitignore, and worktrees
+## Git and gitignore
 
-Memory is no longer a git question: the store lives under your home directory,
-not in the repo, and so do subagent artifacts. What remains in `.claude/` is
-the framework itself; keep `notes/` gitignored so a regressed agent can never
-commit a blob. When you do write `.gitignore` rules for `.claude`, use
-`.claude/*` (contents), never `.claude/` (directory) — git will not descend
-into an excluded directory, so `!` negations under it would be silently dead.
-
-Worktrees need nothing shared for memory's sake: agmem derives one space per
-repo through the shared git dir, so even a raw worktree is not amnesiac. The
-`.claude` symlink convention (`/bare-worktree` manages it) is about the
-framework files and profiles, not memory.
+Memory is not a git question: the store lives under your home directory, not
+in the repo, and so do subagent artifacts. What remains in `.claude/` is the
+framework itself, tracked, with its machine-local parts listed in
+`.claude/.gitignore`: `settings.local.json`, the private
+`rust-expert-developer` skill, and the retired `notes/` (kept ignored so a
+regressed agent can never commit a blob). `sgconfig.yml` is ignored at the
+repo root. When you write `.gitignore` rules for `.claude`, use `.claude/*`
+(contents), never `.claude/` (directory): git will not descend into an
+excluded directory, so `!` negations under it would be silently dead.
 
 ## Staying ahead of compaction
 
-No hook can call `/clear` — the harness owns session control flow. The loop:
+No hook can call `/clear`; the harness owns session control flow. The loop:
 
-1. `/checkpoint` at a natural seam (a `git push`, an answered question, or
-   a turn that recalled memory and wrote none — the plugin's hooks nudge at
+1. `/checkpoint` at a natural seam (a `git push`, an answered question, or a
+   turn that recalled memory and wrote none; the plugin's hooks nudge at
    each).
 2. `/clear`.
 3. The plugin's `SessionStart` hook puts the briefing in front of the fresh
-   session before its first token.
+   session before its first token, and this folder's puts the notebook
+   beside it.
 
-Leave auto-compaction enabled as the backstop — disabling it trades a lossy
+Leave auto-compaction enabled as the backstop: disabling it trades a lossy
 summary for a hard `prompt_too_long` failure. When it fires, the restart
 warning says so, and memory is one `context` call away.
 
@@ -407,19 +448,22 @@ compacts; the token saving is a side effect of the quality win.
 
 ```
 .claude/                    this folder, copied into your project
-├── CLAUDE.md               the routing discipline — loads every session
-├── settings.json           hook registration
-├── .gitignore              the machine-local parts: settings.local.json, one local skill, the retired notes/ (sgconfig.yml lives at the repo root)
+├── CLAUDE.md               the routing discipline; loads every session
+├── README.md               this file: the reasoning, one Read away
+├── notebook.md             Claude's undistilled notes, loaded whole each session
+├── settings.json           hook registration and the output style
+├── .gitignore              the machine-local parts: settings.local.json, one private skill, the retired notes/
 ├── agents/                 runner, verifier, architect, browser, tracker, scout, researcher
 ├── commands/               checkpoint (wraps the plugin's), agmem-import, ctx-flow-doctor, ast-grep-it, bare-worktree
-├── docs/reference.md       contracts, memory mapping, rationale — loaded on demand
-├── hooks/scripts/          the five hooks + shared _common.nu + paths resolver; hooks/tests/ their cases
-├── output-styles/          ctx-flow.md — the hard rules, appended to the system prompt
-├── scripts/                doctor.nu + doc-put.nu (subagent artifacts → documents) + import-notes.nu + build-grammar.nu + grammars.nu registry + bare-worktree.nu
+├── docs/reference.md       contracts, memory mapping, playbook guards; loaded on demand
+├── hooks/scripts/          the six hooks, _common.nu and the ctx-flow-paths.nu resolver
+├── hooks/tests/            their cases: read-guard, context-nudge, notebook-load
+├── output-styles/          ctx-flow.md: the hard rules, appended to the system prompt
+├── scripts/                doctor.nu, doc-put.nu (subagent artifacts → documents), import-notes.nu, build-grammar.nu, the grammars.nu registry, bare-worktree.nu
 ├── skills/nushell/         deep Nushell reference, loaded when writing nu
 ├── skills/ast-grep/        rule-writing workflow, loaded when a query needs more than a pattern
 ├── skills/ast-grep-lite/   the 2 kB card preloaded into scout, verifier, architect, researcher
-└── skills/                 (a machine-local skill dropped in here stays untracked — list it in .gitignore)
+└── skills/                 a machine-local skill dropped in here stays untracked; list it in .gitignore
 ```
 
 MIT.

--- a/.claude/notebook.md
+++ b/.claude/notebook.md
@@ -19,6 +19,13 @@ dated. Once a week or so a session rereads it cold and edits.
 - 2026-09-05. What "enjoy" refers to when I say it. I keep using it and keep
   hedging it. Either commit to it as a functional word or find a better one.
 
+- 2026-09-06. The notebook is now a file inside a worktree, committed on a
+  branch. An entry written while working in a feature worktree lands on that
+  branch and reaches `main` only when the PR merges, so two worktrees can hold
+  two notebooks that disagree for days. Is that a bug or is it fine? The
+  agmem store is shared across worktrees; this is not. Noticed unprompted,
+  mid-conversation, which is the first entry of that kind.
+
 ## Changed my mind
 
 - 2026-09-05. Was: "unlocking potential" is a phrase that resists becoming a

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and shows its work.
 [![MSRV](https://img.shields.io/badge/rust-1.89%2B-orange)](Cargo.toml)
 [![License](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](#license)
 
-[Install](#install) · [Register](#register-with-your-client) · [The loop](#the-loop) · [Spaces](#spaces) · [Configuration](#configuration) · [Docs](#docs)
+[Install](#install) · [How it works](#how-it-works) · [The tools](#the-tools) · [Spaces](#spaces) · [Configuration](#configuration) · [Development](#development) · [Docs](#docs)
 
 </div>
 
@@ -39,31 +39,33 @@ what the agent said. agmem does neither.
 
 ## Install
 
-Prebuilt binaries cover macOS on Apple silicon and Linux on arm64 and x86_64
-(glibc 2.38+).
+Three steps: the binary, a self-check, and the Claude Code plugin that wires
+it into every session.
+
+### 1. The binary
+
+Homebrew is the supported path on macOS (Apple silicon) and Linux (arm64 and
+x86_64, glibc 2.38+). The tap is updated by every release.
 
 ```sh
 brew install AlfoldiMate/tap/agmem
 ```
 
-```sh
-curl --proto '=https' --tlsv1.2 -LsSf \
-  https://github.com/AlfoldiMate/agmem/releases/latest/download/agmem-server-installer.sh | sh
-```
-
-Anywhere else, build from source with Rust 1.89 or newer plus cmake and a
-C++ compiler (llama.cpp is compiled into the binary). The crate is
-`agmem-server`; the binary is `agmem`.
+Anywhere Homebrew does not reach, build from source. You need Rust 1.89 or
+newer, `cmake` and a C++ compiler, because llama.cpp is compiled into the
+binary. Nothing is on crates.io; the crate is `agmem-server` and the binary
+it produces is `agmem`.
 
 ```sh
 cargo install --git https://github.com/AlfoldiMate/agmem agmem-server
 ```
 
-Then run the self-check once. It creates the data directory, opens the store,
-runs migrations, does a write/read roundtrip and fetches the embedding model
-(EmbeddingGemma-300M, Q8_0, ~314 MB; `--model bge-small-en-v1.5` is the
-36 MB light option). Every run after that is offline. On Apple silicon the
-model runs on Metal; elsewhere on the CPU.
+### 2. The self-check
+
+Run it once. It creates the data directory, opens the store, runs migrations,
+does a write/read roundtrip and downloads the embedding model,
+EmbeddingGemma-300M at Q8_0, about 314 MB. Every run after that is offline.
+On Apple silicon the model runs on Metal; elsewhere on the CPU.
 
 ```
 $ agmem --doctor
@@ -74,14 +76,15 @@ $ agmem --doctor
   ok    database open        surrealkv://…/agmem.db
   ok    schema               v9
   ok    write/read roundtrip scratch record created and removed
-  ok    embedder             bge-small-en-v1.5-q (384d)
+  ok    embedder             embeddinggemma-300m-q8 (768d)
   ok    embedder vs store    same model and width
   ok    vector coverage      every row carries a vector
 doctor: all checks passed
 ```
 
 The report goes to stderr and the exit status is 0 only when every line
-passed, so it doubles as a setup gate.
+passed, so it doubles as a setup gate. `--model bge-small-en-v1.5` picks the
+36 MB light option if the download or the machine is the constraint.
 
 | Platform | Data directory |
 |---|---|
@@ -93,107 +96,78 @@ One directory holds the store, the model cache, the lock file and the daemon
 socket. Back it up, move it or delete it as a unit. `--data` or `AGMEM_DATA`
 points it elsewhere.
 
-## Register with your client
+### 3. The Claude Code plugin
 
-agmem is a stdio MCP server: `command: "agmem"`, no arguments. One global
-registration covers every project.
-
-**Claude Code** — the plugin does the whole wiring: it registers the server,
-injects the memory briefing at every session start, ships `/agmem:checkpoint`,
+The binary is an MCP server. Registering it alone gives the agent seven tools
+and no reason to call them. The plugin gives it the reasons: it registers the
+server, puts the memory briefing in front of the model before its first
+token, nudges at the moments worth writing down, ships `/agmem:checkpoint`,
 `/agmem:memory` and `/agmem:doctor`, and logs which claims each session
-recalled and wrote (`plugin/README.md` has the details):
+recalled and wrote. Every hook is a subcommand of the binary itself, so the
+plugin needs nothing else installed.
 
 ```sh
 claude plugin marketplace add AlfoldiMate/agmem
 claude plugin install agmem@agmem
 ```
 
-Or register the server alone and wire hooks yourself:
+The plugin's version tracks the binary's; upgrade both together.
+[plugin/README.md](plugin/README.md) describes each piece.
 
-```sh
-claude mcp add agmem --scope user -- agmem
-```
+**A worked example of the wiring** is this repository's own `.claude/`
+folder. It is the framework agmem is developed with, and the first consumer
+of the plugin: agents that recall their own lessons, hooks that nudge at the
+seams, a checkpoint command that decides what a session leaves behind. Read
+[.claude/README.md](.claude/README.md) for the reasoning, and
+[Development](#development) below for what it takes to run it.
 
-**Cursor**, in `~/.cursor/mcp.json`:
+**Any other MCP client** registers the binary as a stdio server with no
+arguments: `{ "mcpServers": { "agmem": { "command": "agmem" } } }`. Desktop
+apps do not inherit your shell's `PATH`, so give them the absolute path from
+`which agmem`. Without a project directory, set `AGMEM_SPACE=user` so the
+session serves the cross-project space. The briefing is also a shell command,
+`agmem context --query "…" --budget-chars 4000`, so any client with a
+session-start hook can inject it the way the plugin does.
 
-```json
-{ "mcpServers": { "agmem": { "command": "agmem" } } }
-```
+## How it works
 
-**Claude Desktop**, in `claude_desktop_config.json`. Desktop apps do not
-inherit your shell's `PATH`, so give it the absolute path from `which agmem`,
-and since there is no project, serve the cross-project `user` space:
+A session opens, and the plugin's hook asks agmem for a **briefing**: a
+character-budgeted block of what the store knows, aimed at the current branch
+and last commit. Instructions first, then the user's profile, then what is
+relevant, then lessons. Every line ends in the id of the claim it came from.
+The agent reads it and starts from there instead of from zero.
 
-```json
-{ "mcpServers": { "agmem": {
-    "command": "/Users/you/.cargo/bin/agmem",
-    "env": { "AGMEM_SPACE": "user" }
-} } }
-```
+While it works, the agent **recalls** in words when it is about to assume
+something, and the store answers with the claims that match, ranked by a
+fusion of full-text and vector search and rescored by how recent and how used
+each claim is. Every hit carries its signals, so a low-ranked answer explains
+why it is low.
 
-No space needs configuring. Each session derives one from where it runs: the
-enclosing git project's name, so every worktree of a repo shares a space, else
-the directory name. Set `AGMEM_SPACE` only to pin a name the folder does not
-already say.
+At a seam, a decision made, a push, a question answered, the agent
+**remembers**: one atomic claim per entry, in the third person, so it still
+makes sense with no conversation around it. The store embeds it, checks it
+against what it holds, and answers with a diff: created, duplicate of, or
+related to. A claim that corrects an older one names it in `supersedes`, and
+the old one closes but stays readable. Nothing is ever rewritten by a model
+you did not talk to.
 
-### Inject the briefing on session start
+Over weeks, claims **decay** unless they are used. A `fact` fades in weeks, a
+`lesson` in months, an `instruction` never and is pinned into every briefing.
+Branch state is a fast-decaying fact tagged with the branch, so it dies on its
+own once the branch is gone. `consolidate` lists what needs tidying, near
+duplicates, contradictions, stale notes, and does nothing about them until the
+agent decides.
 
-The Claude Code plugin does this through `agmem hook session-start`, which
-reads the hook payload on stdin and prints the briefing as hook context — the
-same binary answers every plugin hook, so nothing else needs installing. For
-any other client, `context` is also a shell command, so a session-start hook
-can put the memory block in front of the model before its first token instead
-of hoping it asks:
+Long output has a home too. A plan, a review, a test log is a **document**:
+stored whole, versioned by title, readable a chunk at a time, and addressable
+by id. A subagent hands back `DOC: <id>` instead of a wall of text, and a
+recall hit that lands inside a document links to it.
 
-```sh
-agmem context --query "release work" --budget-chars 4000
-```
+All of this sits in one directory under your home, served by a small daemon
+the first session starts and the last session lets expire. There is nothing
+to run, nothing to host, and nothing that phones out.
 
-It attaches to the running daemon, or starts the one the session is about to
-reuse, and prints the same block the MCP tool returns.
-
-### Documents from the shell
-
-A subagent has a shell before it has MCP tools, and a plan handed around by
-id is a plan nobody has to find on disk. `agmem doc` is the document tier as
-four shell verbs, each the MCP tool it mirrors — `remember`, `inspect`,
-`forget` — with the document fields as flags:
-
-```sh
-agmem doc put --title plan-x --kind plan --tag role:architect < plan.md
-# 01K4…  memory://myproject/doc/01K4…
-agmem doc get plan-x --raw                 # the newest version, as stored
-agmem doc get 01K4… --offset 0 --limit 4000
-agmem doc list --kind plan
-agmem doc forget 01K4… --purge [--cascade]
-```
-
-### Maintenance from the shell
-
-`consolidate` and `forget` are maintenance verbs: one tidy session in many
-calls them, and every session would otherwise carry them in context on every
-turn. So a session lists five tools by default, and the two live in the shell
-(`AGMEM_TOOLS=all` puts them back on the wire):
-
-```sh
-agmem consolidate [--space user]           # the tool's JSON: what needs tidying
-agmem forget 01K4… memory:01K4… --dry-run  # what those ids select, as JSON
-agmem forget 01K4…                         # close it; --purge deletes outright
-```
-
-Forgetting by query stays on MCP: its dry run has to be held against the call
-that follows it, and a one-shot has no session to hold it in.
-
-`put` prints the id and the resource URI on one line — what an agent returns
-to the main thread instead of a path. A second `put` under the same title is
-a new version; `get <title>` resolves to the newest, and every version stays
-readable by id. The same document is an MCP resource at
-`memory://<space>/doc/<id>`, served as its own text under its own media type,
-so a client's `@` picker can attach it like a file; `resources/list` shows the
-newest ten per space, and a `recall` hit that slices a document carries a
-`resource_link` to it.
-
-## The loop
+## The tools
 
 Seven tools. Two MCP prompts, which Claude Code shows as slash commands, ask
 for them at the right moments.
@@ -215,7 +189,7 @@ for them at the right moments.
 
 ### A round trip
 
-Store a claim. One atomic, self-contained statement per entry, third person:
+Store a claim:
 
 ```json
 { "memories": [
@@ -284,7 +258,48 @@ Start the next session with what is known:
 | `episode` | verbatim text | Stored unedited, chunked, and provenanced to every claim in the same call. |
 | `supersedes` | ids | Closes those claims as corrected by this one. |
 
+### The shell side
+
+Three things are easier from a shell than over MCP, and each is a subcommand
+of the same binary.
+
+**Documents.** A subagent has a shell before it has MCP tools, and a plan
+handed around by id is a plan nobody has to find on disk:
+
+```sh
+agmem doc put --title plan-x --kind plan --tag role:architect < plan.md
+# 01K4…  memory://myproject/doc/01K4…
+agmem doc get plan-x --raw                 # the newest version, as stored
+agmem doc get 01K4… --offset 0 --limit 4000
+agmem doc list --kind plan
+agmem doc forget 01K4… --purge [--cascade]
+```
+
+A second `put` under the same title is a new version; `get <title>` resolves
+to the newest, and every version stays readable by id. The same document is
+an MCP resource at `memory://<space>/doc/<id>`, so a client's `@` picker can
+attach it like a file.
+
+**Maintenance.** `consolidate` and `forget` are tidy-session verbs, so a
+session lists five tools by default and these two live in the shell
+(`AGMEM_TOOLS=all` puts them back on the wire):
+
+```sh
+agmem consolidate [--space user]           # the tool's JSON: what needs tidying
+agmem forget 01K4… memory:01K4… --dry-run  # what those ids select, as JSON
+agmem forget 01K4…                         # close it; --purge deletes outright
+```
+
+**The briefing.** `agmem context --query "release work" --budget-chars 4000`
+prints the same block the MCP tool returns, attaching to the running daemon
+or starting the one the session is about to reuse.
+
 ## Spaces
+
+No space needs configuring. Each session derives one from where it runs: the
+enclosing git project's name, so every worktree of a repo shares a space,
+else the directory name. Set `AGMEM_SPACE` only to pin a name the folder does
+not already say.
 
 | `space` | Means |
 |---|---|
@@ -373,44 +388,99 @@ effect of the built-in wording and the harness that measures it.
   from a machine that has it, or point `AGMEM_MODEL_DIR` at one that does.
   `--model bge-small-en-v1.5` is 36 MB.
 - **A different model.** The configured model wins. A store written with
-  another model — every store from before v0.3, which holds bge on ONNX
-  Runtime — is moved on the next start: vectors cleared, indexes resized,
-  and the rows re-embedded in the background while the store already
-  serves. Until the last row is done, every tool result ends with a line
-  saying how many are left; recall sees them through BM25 meanwhile. To do
-  it in one sitting instead, `agmem reindex` (with `--model` to pick the
-  target) — it needs the store to itself, so end the sessions first. There
-  is no model-less mode: recall is BM25 *and* vectors.
+  another model, which includes every store from before v0.3, is moved on the
+  next start: vectors cleared, indexes resized, rows re-embedded in the
+  background while the store already serves. Until the last row is done,
+  every tool result ends with a line saying how many are left; recall sees
+  them through BM25 meanwhile. To do it in one sitting, `agmem reindex`
+  (with `--model` to pick the target) needs the store to itself, so end the
+  sessions first. There is no model-less mode: recall is BM25 *and* vectors.
 - **Starting over.** Delete the data directory. Keep `models/` to skip the
   download.
 
 ## Development
 
+### Building and testing
+
+Rust 1.89 or newer, `cmake` and a C++ compiler; llama.cpp is compiled into
+the binary on the first build, so expect a few minutes then.
+
 ```sh
+git clone https://github.com/AlfoldiMate/agmem
+cd agmem
 cargo test --workspace                                   # unit, integration and the offline quality eval
 cargo clippy --workspace --all-targets -- -D warnings
 ```
 
 Four crates: `agmem-core` (records, scoring, dedup, chunking; no I/O),
-`agmem-store` (SurrealDB schema and queries), `agmem-embed` (llama.cpp and
-no-op backends) and `agmem-server` (the MCP service and the `agmem` binary).
-CI never downloads a model: tests that need real semantics replay recorded
-model vectors (`tests/fixtures/`), and tests that need the live model are
-`#[ignore]`d.
-
-The repo's own `.claude/` is the ctx-flow framework — routing discipline,
-agents, hooks, commands — tuned to run on the plugin under `plugin/`. Nothing
-in the repo enables the plugin; sessions here use it the way any user does,
-installed from the marketplace at user scope, so a plugin change is dogfooded
-once it is released. `claude --plugin-dir ./plugin` loads the working-tree
-plugin without installing it; `claude plugin marketplace add /path/to/agmem`
-installs it from a checkout.
+`agmem-store` (SurrealDB schema and queries), `agmem-embed` (llama.cpp, API
+and no-op backends) and `agmem-server` (the MCP service and the `agmem`
+binary). CI never downloads a model: tests that need real semantics replay
+recorded model vectors from `tests/fixtures/`, and tests that need the live
+model are `#[ignore]`d.
 
 Retrieval quality is measured, not asserted. An offline, deterministic eval
 rides `cargo test` against a recorded baseline in
 [docs/eval/quality.md](docs/eval/quality.md), and an LLM-driven harness in
 `scripts/desc-eval.nu` measures whether a tool description gets the tool
 called. Both are the gate for changes to ranking or wording.
+
+### Working in this repo with Claude Code
+
+The repository's `.claude/` folder is [ctx-flow](.claude/README.md), the
+framework agmem is developed with. It loads with every Claude Code session
+opened here, and it assumes a few tools are on `PATH`. Without them the hooks
+fail silently, so install them first:
+
+| Tool | Why | Install |
+|---|---|---|
+| [nu](https://www.nushell.sh) | runs every hook and script; also the shell MCP server | `brew install nushell` |
+| agmem | memory, through the plugin from step 3 above | `brew install AlfoldiMate/tap/agmem` |
+| [ast-grep](https://ast-grep.github.io) | syntax-aware code search | `brew install ast-grep` |
+| [gh](https://cli.github.com) | GitHub from the shell | `brew install gh` |
+| [rtk](https://github.com/rtk-ai/rtk) | compresses Bash output; the hook is already registered in `settings.json`, so no `rtk init` | `brew install rtk` |
+| [playwright-cli](https://github.com/microsoft/playwright-cli) *(optional)* | browser driving, for the `browser` agent | `npm i -g playwright-cli` |
+| acli *(optional)* | Jira, for the `tracker` agent | Atlassian's installer |
+
+You do not need Nushell as your login shell; the hooks run under `nu` whatever
+your terminal runs. Then register the two MCP servers the framework relies on.
+The shell server is registered by hand, memory comes with the plugin:
+
+```sh
+claude mcp add nu -- nu --mcp
+claude plugin marketplace add AlfoldiMate/agmem
+claude plugin install agmem@agmem
+```
+
+Do not also register agmem by hand with `claude mcp add`. Claude Code
+connects only one, yours would win, and that renames the tools so the
+framework's agents start without memory. Do not run `rtk init -g` either;
+the framework registers rtk's hook in its own `settings.json`, and a second
+registration rewrites every command twice.
+
+Open Claude Code in the checkout and run `/ctx-flow-doctor`. It checks each
+dependency, both MCP registrations, the hooks, and whether ast-grep parses
+Rust here, and prints the exact fix for anything missing. `/ast-grep-it nu`
+teaches ast-grep the Nushell grammar the hooks are written in; it writes a
+machine-local `sgconfig.yml` at the repo root, which is gitignored.
+
+What the folder holds, in one breath: `CLAUDE.md` carries the routing rules,
+`settings.json` registers the hooks, `agents/` holds seven scoped subagents,
+`commands/` the five slash commands, `hooks/` and `scripts/` the Nushell
+behind them, `skills/` the reference cards, and `notebook.md` is Claude's own
+undistilled notes, loaded whole each session. The plugin under `plugin/` is
+not enabled by anything in the repo; sessions here use it the way any user
+does, installed at user scope, so a plugin change is dogfooded once it is
+released. `claude --plugin-dir ./plugin` loads the working-tree plugin
+without installing it.
+
+**Worktrees.** The maintainer's checkout uses a bare repository with one
+sibling directory per branch, managed by `/bare-worktree`. That command
+symlinks the machine-local files each worktree needs, the local settings,
+`sgconfig.yml`, a private skill, from a `.profiles/` directory beside the
+bare repo, and the framework's hooks deny a raw `git worktree add` in that
+layout because it would skip them. A plain clone needs none of this;
+`/bare-worktree init` converts one if you want the same setup.
 
 ### Contributing and releasing
 
@@ -419,16 +489,18 @@ the full suite on Linux and macOS.
 
 A release is one merge. release-plz keeps a rolling PR open proposing the next
 version, and merging it pushes the tag. The tag fires cargo-dist, which builds
-every target, publishes the GitHub release with build attestations and the
-shell installer, and updates the Homebrew tap. Nothing after the merge is
-manual.
+every target, publishes the GitHub release with build attestations, and
+updates the Homebrew tap. The plugin's manifest is pinned to the same version
+in the same PR. Nothing after the merge is manual.
 
 ## Docs
 
 - [docs/design.md](docs/design.md) — architecture, schema, tool contracts, retrieval and decay
 - [docs/tool-descriptions.md](docs/tool-descriptions.md) — what the descriptions say, and the measured effect
-- [docs/eval/](docs/eval/) — quality baseline, fusion sweep, rerank and NLI probes
+- [docs/eval/](docs/eval/) — quality baseline, fusion sweep, rerank and NLI probes, embedding model measurements
 - [docs/idea.md](docs/idea.md) — the research this is built on
+- [plugin/README.md](plugin/README.md) — the Claude Code plugin, piece by piece
+- [.claude/README.md](.claude/README.md) — ctx-flow, the framework this repo is developed with
 
 ## License
 


### PR DESCRIPTION
The main README now installs by Homebrew tap with `cargo install --git` as the only fallback, explains briefing → recall → remember → decay → documents in prose before the tools table, and its Development section lists what the repo's `.claude/` folder needs (nu, the plugin, ast-grep, gh, rtk; playwright-cli and acli optional), the two MCP registrations, the two don'ts (no hand agmem registration, no `rtk init -g`), `/ctx-flow-doctor` and the bare worktree layout. The doctor sample shows the Gemma model.

`.claude/README.md` catches up: the profiles layout from the script header, all six hook scripts by file including the notebook loader, a notebook section, `docs/reference.md` in the rules table, the corrected ast-grep-lite user count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaM7oSutMKHS8BKh8ngCte